### PR TITLE
Fix Pagination State Management When Applying Filters from Non-First Pages

### DIFF
--- a/pages/watchlist/index.vue
+++ b/pages/watchlist/index.vue
@@ -88,7 +88,7 @@
             <p>Switch tabs to see your {{ filter === 'movies' ? 'TV shows' : 'movies' }}!</p>
           </div>
           
-          <div v-else-if="filteredItems.length === 0 && (selectedGenre || selectedTmdbRating || selectedUserRating || customYearStart || customYearEnd)" class="no-results-state">
+          <div v-else-if="(filteredItems.length === 0 || itemsToShow.length === 0) && hasActiveFilters" class="no-results-state">
             <img src="~/static/cinema-popcorn.svg" alt="No results" class="no-results-icon">
             <h3>No Results Found</h3>
             <p>We couldn't find any content matching your current filters.</p>
@@ -597,6 +597,46 @@ export default {
     this.$root.$off('rated-items-updated', this.checkData);
   },
   
+  watch: {
+    selectedGenre() {
+      this.currentPage = 1;
+    },
+    selectedTmdbRating() {
+      this.currentPage = 1;
+    },
+    selectedUserRating() {
+      this.currentPage = 1;
+    },
+    customYearStart() {
+      this.currentPage = 1;
+    },
+    customYearEnd() {
+      this.currentPage = 1;
+    },
+    orderMode() {
+      this.currentPage = 1;
+    },
+    totalPages(newTotal) {
+      if (newTotal === 0) {
+        this.currentPage = 1;
+      } else if (this.currentPage > newTotal) {
+        this.currentPage = newTotal;
+      }
+    },
+    currentPage(newPage) {
+      if (this.totalPages === 0) {
+        this.currentPage = 1;
+      } else if (newPage > this.totalPages) {
+        this.$nextTick(() => {
+          this.currentPage = this.totalPages;
+        });
+      } else if (newPage < 1) {
+        this.$nextTick(() => {
+          this.currentPage = 1;
+        });
+      }
+    }
+  },
   
   methods: {
     removeFilter(filterValue) {


### PR DESCRIPTION
## Fix Pagination State Management When Applying Filters from Non-First Pages

This Pull Request resolves three critical pagination bugs that occurred when users applied filters while positioned on pages beyond page 1, or manually entered invalid page numbers. The fix ensures consistent pagination behavior and proper empty state displays regardless of the user's current page position or input method.

## Summary of Changes

This PR implements reactive watchers and validation logic to maintain valid pagination state by:

* Adding watchers for `selectedGenre`, `selectedTmdbRating`, `selectedUserRating`, `customYearStart`, `customYearEnd`, and `orderMode` to reset `currentPage` to 1 on any filter change
* Implementing a `totalPages` watcher that validates `currentPage` against the computed total and auto-corrects invalid states
* Adding a `currentPage` watcher to prevent and correct manual input of invalid page numbers in the pagination input field
* Enhancing the "No Results Found" conditional logic to detect both completely empty results and pagination mismatches
* Replacing manual filter property checks with the existing `hasActiveFilters` computed property for cleaner, more maintainable code
* Using `$nextTick` for safe reactive property modifications to prevent infinite reactivity loops
* Ensuring users always start viewing filtered results from page 1, providing predictable and intuitive behavior

## Motivation

The watchlist pagination system previously maintained `currentPage` state across filter changes without validation and lacked input validation for manual page number entry. This caused three distinct failure scenarios:

**Bug A - Blank Grid Without Empty State:**
Users with large collections (300-400+ items spanning 12-13 pages) who navigated to high page numbers and then applied restrictive filters yielding zero results would see a completely blank grid. The "No Results Found" message failed to display because the template only checked `filteredItems.length === 0`, missing cases where `itemsToShow.length === 0` due to pagination mismatch.

**Bug B - Invalid Pagination Display:**
Users who navigated to high page numbers and then applied filters that reduced the total page count below their current position would see mathematically impossible states like "Page 12 of 9". The pagination controls became non-functional, and users couldn't access the filtered results without manually navigating back to valid pages.

**Bug C - Manual Invalid Page Input:**
Users who manually typed page numbers exceeding `totalPages` (e.g., typing "14" when only 13 pages exist) would see broken pagination states like "Page 14 of 13" with an empty grid. The system accepted any numeric input without validation, allowing impossible pagination states through direct user input.

All three issues stemmed from:
- No reactive logic to reset or validate `currentPage` when filters changed
- No validation that `currentPage` remained within valid bounds when `totalPages` decreased
- No input validation for manual page number entry
- Incomplete empty state detection logic that didn't account for pagination edge cases

This fix ensures smooth, predictable filtering and pagination behavior for users with large watchlists while maintaining all existing functionality.

## Implementation Details

### Core Changes

**1. Filter Change Watchers**

Added six watchers in the Vue component's `watch` object:

```javascript
watch: {
  selectedGenre() {
    this.currentPage = 1;
  },
  selectedTmdbRating() {
    this.currentPage = 1;
  },
  selectedUserRating() {
    this.currentPage = 1;
  },
  customYearStart() {
    this.currentPage = 1;
  },
  customYearEnd() {
    this.currentPage = 1;
  },
  orderMode() {
    this.currentPage = 1;
  },
  // ...
}
```

These watchers trigger whenever any filter value changes, immediately resetting `currentPage` to 1. This ensures users always start viewing filtered results from the beginning, providing consistent and predictable behavior.

**2. Total Pages Validation Watcher**

Added a `totalPages` watcher that validates pagination state:

```javascript
totalPages(newTotal) {
  if (newTotal === 0) {
    this.currentPage = 1;
  } else if (this.currentPage > newTotal) {
    this.currentPage = newTotal;
  }
}
```

This watcher runs whenever `totalPages` recalculates (which happens automatically when `filteredItems` changes). It prevents invalid pagination states by:
- Resetting to page 1 when no results exist
- Adjusting to the last valid page when `currentPage` exceeds available pages

**3. Manual Page Input Validation**

Added a `currentPage` watcher that validates user input in the page number field:

```javascript
currentPage(newPage) {
  if (this.totalPages === 0) {
    this.currentPage = 1;
  } else if (newPage > this.totalPages) {
    this.$nextTick(() => {
      this.currentPage = this.totalPages;
    });
  } else if (newPage < 1) {
    this.$nextTick(() => {
      this.currentPage = 1;
    });
  }
}
```

This watcher prevents users from manually entering invalid page numbers by:
- Restricting minimum value to 1 (prevents 0, negative numbers)
- Restricting maximum value to `totalPages` (prevents exceeding available pages)
- Using `$nextTick` to safely modify the reactive property without causing infinite loops
- Providing immediate visual feedback when users attempt invalid input

**4. Enhanced Empty State Detection**

Updated the "No Results Found" template condition:

**Before:**
```html
<div v-else-if="filteredItems.length === 0 && (selectedGenre || selectedTmdbRating || ...)" class="no-results-state">
```

**After:**
```html
<div v-else-if="(filteredItems.length === 0 || itemsToShow.length === 0) && hasActiveFilters" class="no-results-state">
```

This enhancement:
- Detects both truly empty results (`filteredItems.length === 0`) and pagination mismatches (`itemsToShow.length === 0`)
- Uses the existing `hasActiveFilters` computed property for cleaner, more maintainable code
- Ensures the "No Results Found" message displays in all edge cases

### User Experience Flow

**Bug A Resolution - Empty Filter Results:**

1. User has 300 movies (13 pages) and navigates to page 12
2. User applies "My Rating: 9" filter yielding 0 results
3. `selectedUserRating` watcher triggers → `currentPage` resets to 1
4. `filteredItems` recalculates to empty array
5. `totalPages` watcher triggers with `newTotal = 0` → ensures `currentPage = 1`
6. Template condition `(filteredItems.length === 0 || itemsToShow.length === 0) && hasActiveFilters` evaluates to `true`
7. "No Results Found" empty state displays correctly

**Bug B Resolution - Page Count Reduction:**

1. User has 400 movies (13 pages) and navigates to page 12
2. User applies "Genre: Horror" filter yielding 175 results (9 pages)
3. `selectedGenre` watcher triggers → `currentPage` resets to 1
4. `filteredItems` recalculates to 175 items
5. `totalPages` recalculates to 9
6. User immediately sees page 1 of filtered Horror movies
7. Pagination displays "Page 1 of 9" correctly
8. User can navigate through all 9 pages normally

**Bug C Resolution - Manual Invalid Input:**

1. User has 300 movies displayed across 13 pages
2. User clicks page number input field and types "14"
3. `currentPage` watcher detects `newPage (14) > totalPages (13)`
4. Watcher executes `this.$nextTick(() => { this.currentPage = this.totalPages; })`
5. Input field automatically corrects to "13"
6. Grid displays content from page 13 (last valid page)
7. Similar corrections occur for values < 1 (corrects to 1)

**Additional Scenarios Covered:**

- **Multiple Filter Changes:** Each filter change resets to page 1, preventing accumulated pagination drift
- **Filter Clearing:** When users click "Clear All Filters", all watchers trigger and reset to page 1
- **Tab Switching:** Existing `toggleFilterType` logic already resets to page 1, now complemented by filter watchers
- **Sort Changes:** Changing sort order now resets to page 1 for consistency
- **Year Range Adjustments:** Both start and end year changes independently reset to page 1
- **Negative Input:** User typing "-5" in page field auto-corrects to "1"
- **Zero Input:** User typing "0" in page field auto-corrects to "1"
- **Excessive Input:** User typing "999" in 13-page collection auto-corrects to "13"

### Key Features

**Automatic Page Reset on Filter Changes**
* Every filter modification immediately resets pagination to page 1
* Users never experience confusion about where filtered results begin
* Predictable, intuitive behavior aligned with user expectations

**Invalid State Prevention**
* `totalPages` watcher continuously validates pagination bounds
* Automatically corrects `currentPage` when it exceeds available pages
* Eliminates "Page X of Y" where X > Y scenarios entirely

**Manual Input Validation**
* Real-time validation of user-entered page numbers
* Automatic correction to valid range (1 to totalPages)
* Prevents impossible states like "Page 14 of 13"
* Safe reactive updates using `$nextTick` to avoid infinite loops

**Comprehensive Empty State Detection**
* Catches both zero-result filters and pagination mismatches
* Displays appropriate "No Results Found" message in all edge cases
* Uses existing `hasActiveFilters` computed property for maintainability

**Preserved Existing Behavior**
* Tab switching still resets to page 1 as designed
* All empty state messages remain unchanged
* Filter combinations work identically
* No breaking changes to component API or data flow

**Performance Considerations**
* Watchers are lightweight, single-line assignments
* No additional API calls or heavy computations introduced
* Reactive updates happen instantly without perceptible lag
* Validation occurs only when relevant computed properties change
* `$nextTick` usage is minimal and only when necessary for safety

## Breaking Changes

None. This is a pure bug fix that enhances existing functionality without modifying any component APIs, props, events, or data structures. All existing features continue working identically.

## Testing Recommendations

**Bug A Testing (Empty Results):**

1. Add 300+ movies to watchlist to generate 12+ pages
2. Navigate to page 10 or higher
3. Apply "My Rating: 9" filter (assuming no items rated 9)
4. Verify pagination immediately shows "Page 1 of 0" (or hides)
5. Verify "No Results Found" empty state displays correctly
6. Verify "Clear All Filters" button appears and works
7. Click "Clear All Filters"
8. Verify return to page 1 with all items visible

**Bug B Testing (Page Count Reduction):**

1. Add 400+ movies to watchlist to generate 13+ pages
2. Navigate to page 12
3. Note current content visible on page 12
4. Apply "Genre: Horror" filter yielding ~150 results (7-8 pages)
5. Verify pagination immediately shows "Page 1 of 7" (or similar)
6. Verify Horror genre movies display in grid
7. Navigate to page 7 and confirm content displays
8. Remove filter and verify return to page 1 of full collection

**Bug C Testing (Manual Invalid Input):**

1. Navigate to a collection with 13 pages
2. Click the page number input field
3. Type "14" and press Enter → verify auto-corrects to "13"
4. Verify grid displays content from page 13
5. Type "0" and press Enter → verify auto-corrects to "1"
6. Type "-5" and press Enter → verify auto-corrects to "1"
7. Type "999" and press Enter → verify auto-corrects to "13"
8. Apply filter reducing pages to 5
9. Manually type "10" → verify auto-corrects to "5"
10. Clear filters returning to 13 pages
11. Verify page input accepts valid numbers (1-13) without correction
12. Type "7" → verify accepts input and navigates to page 7

**Filter Reset Behavior:**

1. Navigate to page 8 of large collection
2. Apply Genre filter → verify reset to page 1
3. Navigate to page 5 of filtered results
4. Change TMDB Rating filter → verify reset to page 1
5. Navigate to page 3 of filtered results
6. Adjust Year range → verify reset to page 1
7. Navigate to page 2 of filtered results
8. Change Sort order → verify reset to page 1

**Multiple Filter Combinations:**

1. Start on page 10 of 300-item collection
2. Apply Genre: "Action" → verify page 1, ~80 results
3. While viewing Action results, add "My Rating: 8" → verify page 1, ~15 results
4. While viewing combined filters, add Year: "2020-2025" → verify page 1, ~8 results
5. Remove Genre filter → verify page 1, year + rating filters remain active
6. Clear all filters → verify page 1, all 300 items visible

**Tab Switching:**

1. Navigate to page 7 of Movies tab (200+ movies)
2. Apply Genre filter → verify page 1
3. Navigate to page 3 of filtered Movies
4. Switch to TV Shows tab → verify page 1 (existing behavior)
5. Apply different filter on TV Shows → verify page 1
6. Switch back to Movies → verify page 1 with previous filters cleared

**Edge Cases:**

1. Test with exactly 1 page of results after filtering from high page
2. Test with filters that yield exactly `itemsPerPage` results (1 full page)
3. Test rapid filter toggling (apply, remove, apply different filter quickly)
4. Test with "Not Rated" user rating filter from high page numbers
5. Test combining all filters simultaneously from page 12
6. Verify manual page input field respects new validation (can't enter page > totalPages)
7. Test typing non-numeric characters in page field (Vue's v-model.number handles this)
8. Test copy-pasting invalid page numbers into input field

**Empty State Verification:**

1. Apply filters yielding 0 results from page 1 → verify "No Results Found"
2. Apply filters yielding 0 results from page 12 → verify "No Results Found"
3. Apply filters yielding results from page 12 → verify grid displays correctly
4. Verify empty state never overlaps with pagination controls
5. Verify "Clear All Filters" button appears in all empty state scenarios

**Pagination Control Functionality:**

1. After filter reset to page 1, verify "First" and "Previous" buttons disabled
2. After filter reset to page 1, verify "Next" and "Last" buttons enabled (if multiple pages)
3. Verify page number input field displays "1" after filter changes
4. Verify page count displays correctly as "of X" after filter changes
5. Verify all pagination controls remain functional after automatic page adjustments
6. Test clicking "Last" button after manual invalid input correction
7. Test clicking "Next" repeatedly and verify stops at last valid page

**Reactivity Loop Prevention:**

1. Monitor browser console for warnings during testing
2. Verify no infinite update loops occur when typing in page field
3. Confirm `$nextTick` prevents recursion in currentPage watcher
4. Test rapid consecutive filter changes (< 1 second apart)
5. Verify performance remains smooth with no lag or freezing

## Impact

This fix significantly improves the robustness and user experience of the watchlist filtering and pagination system:

**User Experience**

* Eliminated confusing blank grid states when filtering from high page numbers
* Removed impossible "Page X of Y" pagination displays
* Prevented manual entry of invalid page numbers with automatic correction
* Consistent, predictable behavior: filters always show results starting from page 1
* Clear feedback through appropriate empty states in all scenarios
* Smooth filtering experience regardless of collection size or current position
* Immediate visual correction when invalid page numbers are entered

**Code Quality**

* Added reactive watchers following Vue.js best practices
* Centralized validation logic in dedicated watchers
* Leveraged existing `hasActiveFilters` computed property for consistency
* Clean, maintainable solution without complex conditionals or workarounds
* Self-documenting code with clear separation of concerns
* Proper use of `$nextTick` to prevent reactivity edge cases

**Reliability**

* Automatic validation prevents invalid pagination states from ever occurring
* Defensive programming ensures graceful handling of edge cases
* No reliance on user intervention to correct broken states
* Robust solution that works across all filter combinations and sequences
* Protection against both programmatic and user-input-driven invalid states

**Maintainability**

* Watchers are simple, single-purpose functions easy to understand and modify
* Follows existing component patterns and conventions
* No new dependencies or external libraries introduced
* Easy to extend if new filter types are added in the future
* Clear documentation through commit message and PR description
* Comprehensive testing recommendations for regression prevention

**Performance**

* Minimal performance overhead (simple reactive assignments)
* No additional API calls or data fetching
* Watchers trigger only when relevant properties change
* Efficient validation logic with immediate short-circuit evaluation
* No impact on initial render or data loading times
* Strategic use of `$nextTick` only where necessary

This PR delivers critical stability fixes that enhance watchlist usability for users with large collections while maintaining clean, maintainable code architecture. The three-bug resolution ensures pagination behaves predictably in all scenarios: filter changes, page count reductions, and manual user input.

Closes #132
```