### PR TITLE
Fix - Chatbot Media Reference Accuracy and AI Reasoning

### DIFF
--- a/pages/watchlist/index.vue
+++ b/pages/watchlist/index.vue
@@ -819,7 +819,8 @@ export default {
           year: item.details.yearStartForDb,
           poster_path: item.details.posterForDb,
           rating_source: item.details.rating_source,
-          tmdb_rating: item.details.starsForDb || null
+          tmdb_rating: item.details.starsForDb || null,
+          imdb_votes: item.details.imdb_votes || null
         });
       }
     },


### PR DESCRIPTION
## Enhance Chatbot Media Reference Accuracy and AI Reasoning

This Pull Request introduces significant improvements to the chatbot's ability to accurately display media references and enhances the underlying AI's reasoning capabilities. By directly leveraging TMDB IDs for known media references, the system eliminates display inaccuracies. Furthermore, the AI's recommendation logic is refined to consider `imdb_votes`, providing more balanced and informed suggestions, alongside adjustments to prompt engineering to ensure concise and relevant responses for multi-title queries.

## Summary of Changes

This PR focuses on both frontend and backend enhancements to deliver more accurate and intelligent media interactions:

*   **Frontend (`ChatbotModal.vue`)**: Implements direct fetching of media details from TMDB using `tmdb_id` when available in a reference, bypassing ambiguous search queries and ensuring display accuracy.
*   **Frontend (`watchlist/index.vue`)**: Integrates `imdb_votes` into the media item structure, making this crucial data point available within the application.
*   **Backend (`entercinema-assistant-rust/api/gemini.rs`)**: Modifies the AI's logic to utilize `imdb_votes` from an internal dataset for improved recommendation quality. Adjusts the AI prompt and Google search strategy to prevent verbosity and maintain focus when processing multiple selected titles.

## Motivation

Previously, the chatbot faced challenges with:

*   **Media Reference Hallucinations**: Displaying incorrect movie or TV show cards due to name similarities but differing release years. The reliance on text-based search for already identified items led to ambiguity.
*   **Limited AI Reasoning**: The AI's recommendation engine primarily considered `imdb_rating`, potentially overlooking titles with high vote counts but slightly lower average ratings, leading to less nuanced suggestions.
*   **AI Verbosity**: When given multiple media references, the AI sometimes diverged or became overly verbose, especially for queries involving 6-7 or more titles.

These changes aim to:

*   **Eliminate Hallucinations**: Guarantee that media references displayed by the chatbot correspond precisely to the intended movie, TV show, or person.
*   **Enhance AI Intelligence**: Equip the AI with a richer understanding of media popularity and reception by incorporating `imdb_votes`, resulting in more contextually relevant and trustworthy recommendations.
*   **Improve AI Interaction Flow**: Ensure that the AI provides concise, focused, and informative responses, even when dealing with numerous selected titles.

## Implementation Details

### Core Changes

1.  **ChatbotModal Component Update (`components/global/ChatbotModal.vue`)**
    *   **Direct TMDB ID Resolution**: A new conditional block has been introduced to prioritize fetching media details directly from TMDB using `ref.tmdb_id` if available. This significantly enhances accuracy by avoiding fuzzy text searches for already identified entities.
    *   **External IDs Integration**: TMDB API calls now include `append_to_response: 'external_ids'`, allowing the system to retrieve crucial external identifiers (like IMDb ID), which are essential for the `enrichWithIMDb` process and backend data correlation.
    *   **Robust Media Type Mapping**: Ensures that media types (e.g., `tv_show`, `series` to `tv`; `actor`, `director` to `person`) are correctly mapped for accurate TMDB API endpoint usage.
    *   **Consistent Data Structure**: Formats fetched media items to include `originalName` and `external_ids`, preparing data for consistent display and further processing.

2.  **Watchlist Page Update (`pages/watchlist/index.vue`)**
    *   **IMDb Votes Exposure**: The `watchlist` component now includes `imdb_votes` in the data structure when processing and preparing media items for display and send to `Ask-AI` Chatbot Modal, reflecting the availability and importance of this metric within the application.

3.  **Backend AI Logic Refinement (`entercinema-assistant-rust/api/gemini.rs` - as per user description)**
    *   **TMDB ID Prioritization in AI**: The backend now directly leverages `tmdb_id` as a predefined identifier for media references, feeding this precise information into the AI model to prevent ambiguity during content generation.
    *   **IMDb Votes for AI Context**: `imdb_votes`, obtained from an internal dataset, are now passed to the AI. This allows the AI to consider the volume of ratings alongside the average rating, leading to more sophisticated and realistic title suggestions.
    *   **Refined AI Prompting**: The internal prompt given to the AI has been adjusted to guide its responses more effectively. This ensures that when multiple titles are selected, the AI remains focused, avoids repetitive information, and provides relevant details for each, preventing the previous issues of verbosity and divergence.