### PR TITLE
Enhance Movie Release Status with Contextual Navigation

### DIFF
--- a/components/MediaNav.vue
+++ b/components/MediaNav.vue
@@ -18,6 +18,10 @@ export default {
       type: Array,
       required: true,
     },
+    activeLabel: {
+      type: String,
+      default: '',
+    },
   },
 
   data () {
@@ -30,6 +34,19 @@ export default {
     clicked (index, item) {
       this.active = index;
       this.$emit('clicked', item.replace(/\s+/g, '-').toLowerCase());
+    },
+  },
+
+  watch: {
+    activeLabel: {
+      handler(newVal) {
+        if (!newVal) return;
+        const index = this.menu.findIndex(item => item.replace(/\s+/g, '-').toLowerCase() === newVal);
+        if (index !== -1) {
+          this.active = index;
+        }
+      },
+      immediate: true,
     },
   },
 };

--- a/components/movie/MovieInfo.vue
+++ b/components/movie/MovieInfo.vue
@@ -63,7 +63,16 @@
             </li>
             <li v-if="item.status">
               <div :class="$style.label">Status</div>
-              <div :class="$style.value">{{ item.status }}</div>
+              <div :class="$style.value">
+                {{ item.status }}
+                <span 
+                  v-if="releaseStatusSuffix" 
+                  :class="$style.releaseLink"
+                  @click="$emit('open-releases')"
+                >
+                  {{ releaseStatusSuffix }}
+                </span>
+              </div>
             </li>
             <li v-if="item.original_language">
               <div :class="$style.label">Language</div>
@@ -181,6 +190,7 @@
 
 <script>
 import { apiImgUrl, getMovieProviders, getMovieReviews, getTraktReviews, getMovieRecommended, getPerson, getMoviesByProductionCompany, getIMDbRatingFromDB, enrichMovieWithIMDbRating } from '~/utils/api'; 
+import { getReleaseStatusContext } from '~/utils/helpers';
 import { SUPPORTED_PRODUCTION_COMPANIES } from '~/utils/constants'; 
 import { name, directors } from '~/mixins/Details';
 import Filters from '~/mixins/Filters';
@@ -291,6 +301,20 @@ export default {
        const hasProviders = this.providersToDisplay && this.providersToDisplay.length > 0;
        const hasImdb = this.item.external_ids && this.item.external_ids.imdb_id;
        return (hasProviders || hasImdb) && this.isReleasedOrCloseToRelease;
+    },
+    releaseStatusSuffix() {
+      const context = getReleaseStatusContext(this.item, process.env.API_COUNTRY || 'US');
+      
+      switch (context) {
+        case 'FESTIVALS_AND_THEATRICAL_ONLY':
+          return ' (Festivals and Theatrical Only)';
+        case 'THEATRICAL_ONLY':
+          return ' (Theatrical Only)';
+        case 'FESTIVALS_ONLY':
+          return ' (Festivals Only)';
+        default:
+          return '';
+      }
     }
   },
 
@@ -938,6 +962,14 @@ export default {
   color: #999;
   padding: 4rem;
   font-style: italic;
+}
+.releaseLink {
+  color: #8AE8FC !important;
+  cursor: pointer;
+  
+  &:hover {
+    text-decoration: underline;
+  }
 }
 </style>
 

--- a/pages/movie/[id].vue
+++ b/pages/movie/[id].vue
@@ -15,10 +15,10 @@
     <template v-else>
       <Hero v-if="item && item.id" :item="item" />
       
-      <MediaNav :menu="menu" @clicked="navClicked" />
+      <MediaNav :menu="menu" :active-label="activeMenu" @clicked="navClicked" />
 
       <template v-if="activeMenu === 'overview'">
-        <MovieInfo v-if="item && item.id" :item="item" :reviews-prop="reviews">
+        <MovieInfo v-if="item && item.id" :item="item" @open-releases="activeMenu = 'releases'" :reviews-prop="reviews">
           <template #before-recommendations>
             <Credits v-if="showCredits" :people="item.credits.cast" />
           </template>

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -21,3 +21,37 @@ export function handleImageError(item, event = null) {
         }
     }
 }
+
+export function getReleaseStatusContext(item, targetCountry = 'US') {
+    if (item.status !== 'Released') return null;
+    if (!item.release_dates || !item.release_dates.results) return null;
+
+    const releases = item.release_dates.results;
+
+    let relevantReleases = releases.find(r => r.iso_3166_1 === targetCountry);
+    let allDates = [];
+
+    if (relevantReleases) {
+        allDates = relevantReleases.release_dates;
+    } else {
+        allDates = releases.flatMap(r => r.release_dates);
+    }
+
+    if (!allDates || allDates.length === 0) return null;
+
+    const types = new Set(allDates.map(d => d.type));
+
+    if (types.has(4) || types.has(5) || types.has(6)) return null;
+
+    const hasTheatrical = types.has(2) || types.has(3);
+    const hasPremiere = types.has(1);
+
+    if (hasTheatrical) {
+        if (hasPremiere) return 'FESTIVALS_AND_THEATRICAL_ONLY';
+        return 'THEATRICAL_ONLY';
+    }
+
+    if (hasPremiere) return 'FESTIVALS_ONLY';
+
+    return null;
+}


### PR DESCRIPTION
## Enhance Movie Release Status with Contextual Navigation

This Pull Request introduces enhanced contextual information for a movie's "Released" status and provides a direct navigation path to view detailed release information. By analyzing a movie's specific release types (e.g., theatrical, festivals), a clarifying suffix is displayed alongside the status, which is clickable to switch to the "releases" navigation tab.

## Summary of Changes

This PR improves the user's understanding of a movie's release status and facilitates navigation by:

*   **Introducing a `getReleaseStatusContext` helper utility** to determine if a movie's "Released" status is limited to specific types like festivals or theatrical runs (e.g., "Theatrical Only").
*   **Integrating this context into `MovieInfo.vue`** to display a clickable suffix (e.g., "(Theatrical Only)") next to the main status when applicable.
*   **Emitting an `open-releases` event** from `MovieInfo.vue` when the suffix is clicked, signaling a desire to navigate to the releases section.
*   **Updating `MediaNav.vue` with an `activeLabel` prop** and a watcher to allow external components to programmatically control which menu item is active.
*   **Connecting `pages/movie/[id].vue`** to both listen for the `open-releases` event and update the `MediaNav`'s active state, thereby enabling seamless navigation to the 'releases' tab.

## Motivation

The existing "Released" status for movies can sometimes be ambiguous, especially for films that have only had limited festival screenings or theatrical releases without wider distribution (e.g., digital or home video). Users might be left wondering about the accessibility of such films.

This enhancement aims to:
*   **Provide clearer context** for a movie's release status, immediately informing users if a film is currently available only through specific channels like festivals or cinemas.
*   **Improve discoverability** of detailed release information by offering a direct and intuitive clickable link from the status itself to the dedicated 'releases' tab.
*   **Enhance user experience** by making navigation more fluid and relevant to the content being viewed.

## Implementation Details

### Core Changes

**1. `utils/helpers.js` - `getReleaseStatusContext`**
A new helper function, `getReleaseStatusContext(item, targetCountry)`, is added to determine the specific context of a movie's release.
*   It checks if the movie's status is 'Released' and if `release_dates` are available.
*   It analyzes release types (e.g., Premiere (1), Theatrical (2, 3)) in the `targetCountry` (or globally if no country-specific data) to identify if the release is limited to festivals or theatrical runs.
*   Crucially, it only returns a context if no Digital (4), Physical (5), or TV (6) releases are present, ensuring accuracy for limited distribution scenarios.

**2. `components/movie/MovieInfo.vue` - Contextual Status Display and Event Emission**
*   The new `getReleaseStatusContext` helper is imported and utilized in a new computed property, `releaseStatusSuffix`.
*   `releaseStatusSuffix` dynamically generates a string like "(Theatrical Only)" based on the movie's release data.
*   The `MovieInfo` component's `status` display is updated to conditionally render this suffix.
*   The suffix is wrapped in a `span` with a new `releaseLink` class for styling and a `@click="$emit('open-releases')"` handler. This emits an event when the user clicks the contextual suffix.
*   Styling for `.releaseLink` is added to indicate its clickable nature.

**3. `components/MediaNav.vue` - External Control for Active State**
*   A new `activeLabel` prop (String) is introduced, allowing an external parent component to dictate which menu item should be visually active.
*   A `watch` handler for `activeLabel` is implemented. When `activeLabel` changes, it finds the corresponding menu item by slugifying and matching the label, then updates the component's internal `active` data property. The `immediate: true` option ensures the initial state is correctly set.

**4. `pages/movie/[id].vue` - Page-Level Navigation Orchestration**
*   The `MediaNav` component is updated to bind its `activeLabel` prop to the page's `activeMenu` data property. This ensures `MediaNav`'s visual state reflects the current active tab.
*   The `MovieInfo` component now listens for the `@open-releases` event. When this event is emitted, the page's `activeMenu` is programmatically set to `'releases'`, which in turn updates `MediaNav` and (presumably, given the template structure) switches the displayed content to the 'releases' section.

## Breaking Changes

None. All changes are additive and enhance existing functionality without altering public APIs in an incompatible way or removing existing features.

## Testing Recommendations

**1. Verify Contextual Suffix Display:**
*   **Movie with Theatrical Only release:** Find a movie released only in theaters (e.g., check TMDb for release types). Verify "(Theatrical Only)" appears next to the status.
*   **Movie with Festivals Only release:** Find a movie released only at festivals. Verify "(Festivals Only)" appears.
*   **Movie with Festivals and Theatrical Only release:** Find a movie with both types. Verify "(Festivals and Theatrical Only)" appears.
*   **Movie with standard (Digital/Physical/TV) releases:** Verify no suffix appears.
*   **Movie not yet 'Released' (e.g., 'Rumored', 'In Production'):** Verify no suffix appears.
*   **Movie 'Released' but no relevant `release_dates` data:** Verify no suffix appears.

**2. Verify Navigation:**
*   For movies displaying a contextual suffix, click on the suffix.
*   Confirm that the `MediaNav` component's active tab visually switches to 'releases'.
*   Confirm that the content area (below `MediaNav`) switches to display the 'releases' content (assuming such content is present in the `pages/movie/[id].vue` template for `activeMenu === 'releases'`).

**3. Verify `MediaNav` external control:**
*   Manually switch between different `MediaNav` tabs (e.g., 'overview', 'videos').
*   Ensure that the `activeLabel` prop from the parent (`pages/movie/[id].vue`) correctly sets the initial and subsequent active states of `MediaNav`.

## Impact

**User Experience:**
*   Users gain immediate clarity on a movie's release availability, reducing confusion.
*   Improved discoverability of detailed release information through direct, context-sensitive navigation.
*   More intuitive and integrated browsing experience.

**Code Quality & Maintainability:**
*   Introduces a reusable helper function (`getReleaseStatusContext`) for consistent logic across the application.
*   Enhances the flexibility and reusability of the `MediaNav` component by allowing external control of its active state.
*   Cleaner separation of concerns between displaying movie info and handling navigation.

This PR significantly improves the transparency and navigability of movie release information, providing a richer experience for users seeking specific details about film availability.