### PR TITLE
Add Initial Cannes Film Festival 2026 Integration

### DIFF
--- a/components/CannesCard.vue
+++ b/components/CannesCard.vue
@@ -1,0 +1,247 @@
+<template>
+  <div class="card">
+    <nuxt-link
+      class="card__link"
+      :to="getRouteLink()">
+
+      <CardActions v-if="context === 'list'" :item="item" :currentList="list" />
+
+      <div class="card__img">
+        <div v-if="isLoading" class="card-loader">
+          <Loader :size="40" />
+        </div>
+
+        <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" />
+
+        <img
+          v-if="poster"
+          ref="posterImage"
+          :src="poster"
+          loading="lazy"
+          :class="{ 'card__img--logo': media === 'production' || media === 'streaming' }"
+          :alt="name"
+          :style="{ opacity: isLoading ? 0 : 1, transition: 'opacity 0.5s ease' }"
+          @load="onImageLoaded"
+          @error="$event.target.src = '/placeholders/image_not_found_yet.webp'; onImageLoaded($event)">
+
+        <img
+          v-else
+          ref="posterImage"
+          src="/placeholders/image_not_found_yet.webp"
+          alt="Image not found"
+          class="card__img--poster"
+          style="width: 100%; height: 100%; object-fit: cover;"
+          @load="onImageLoaded"
+          @error="onImageLoaded">
+
+        <div v-if="media === 'streaming'" class="card__badge">Streaming Service</div>
+        <div v-if="media === 'production'" class="card__badge">Production Company</div>
+      </div>
+
+      <h2 class="card__name">
+        {{ name }}
+      </h2>
+
+      <div class="card__logo-container">
+        <img
+          src="/festivals/cannes/cannes_film_festival_2026_logo.png"
+          alt="Cannes Film Festival selection"
+          class="card__cannes-logo"
+        >
+      </div>
+    </nuxt-link>
+  </div>
+</template>
+
+<script>
+import { apiImgUrl } from '~/utils/api';
+import { name, stars, poster as posterMixin } from '~/mixins/Details';
+import QuickFav from '~/components/global/QuickFav';
+import CardActions from '~/components/global/CardActions.vue';
+import Loader from '~/components/Loader.vue';
+
+export default {
+  components: {
+    QuickFav,
+    CardActions,
+    Loader,
+  },
+  mixins: [
+    name,
+    stars,
+    posterMixin,
+  ],
+
+  props: {
+    item: {
+      type: Object,
+      required: true,
+    },
+    context: {
+      type: String,
+      default: 'home'
+    },
+    list: {
+      type: Object,
+      default: null
+    }
+  },
+
+  data() {
+    return {
+      isLoading: true,
+    };
+  },
+
+  mounted() {
+    this.checkImageLoaded();
+  },
+
+  watch: {
+    item: {
+      immediate: true,
+      handler() {
+        this.isLoading = true;
+        this.$nextTick(() => {
+          this.checkImageLoaded();
+        });
+      }
+    }
+  },
+
+  methods: {
+    checkImageLoaded() {
+      const img = this.$refs.posterImage;
+      if (img && img.complete && img.naturalHeight !== 0) {
+        this.onImageLoaded();
+      }
+    },
+    onImageLoaded() {
+      this.isLoading = false;
+    },
+    getRouteLink() {
+      if (this.item.media_type === 'production') {
+        return { name: 'production-slug', params: { slug: this.item.slug } };
+      }
+      if (this.item.media_type === 'streaming') {
+        return { name: 'streaming-slug', params: { slug: this.item.slug } };
+      }
+      return { name: `${this.media}-id`, params: { id: this.item.id } };
+    }
+  },
+
+  computed: {
+    poster () {
+      if (this.poster_path) return this.poster_path;
+      if (this.item.profile_path) {
+        return `${apiImgUrl}/w500${this.item.profile_path}`;
+      } else if (this.item.logo_path) {
+        return `${apiImgUrl}/w500${this.item.logo_path}`;
+      } else {
+        return false;
+      }
+    },
+
+    media () {
+      if (this.item.media_type) {
+        return this.item.media_type;
+      } else if (this.item.name) {
+        return 'tv';
+      } else {
+        return 'movie';
+      }
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.card__link {
+  display: block;
+  position: relative;
+}
+
+.card__img {
+  position: relative;
+  overflow: hidden;
+  border-top-left-radius: 15px;
+  border-top-right-radius: 15px;
+  transform: translateZ(0);
+}
+.card__img img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.card__img--logo {
+  object-fit: contain !important;
+  padding: 20px;
+  background-color: #8BE9FD;
+  width: 100%;
+  height: 100%;
+}
+
+.card-loader {
+  display: flex;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+  background-color: #0000004e;
+  z-index: 2;
+}
+
+.card__badge {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background-color: rgba(0, 0, 0, 0.75);
+  color: #8BE9FD;
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 4px 8px;
+  border-radius: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  z-index: 5;
+  backdrop-filter: blur(4px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+
+  @media (max-width: 500px) {
+    font-size: 0.6rem;
+    padding: 2px 4px;
+    top: 5px;
+    right: 5px;
+  }
+}
+
+.card__logo-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: black;
+    box-shadow: 0 8px 10px 0 rgba(31, 104, 135, 0.37);
+    border-bottom-right-radius: 10px;
+    border-bottom-left-radius: 10px;
+    bottom: 10px;
+    padding-bottom: 0.5rem;
+    position: relative;
+    top: -30px;
+    height: 60px;
+}
+
+.card__cannes-logo {
+    height: 50px;
+    width: auto;
+    filter: invert(1) brightness(1.05);
+    object-fit: contain;
+}
+</style>

--- a/components/FestivalsCarousel.vue
+++ b/components/FestivalsCarousel.vue
@@ -75,6 +75,7 @@ import SxswCard from '~/components/festival/SxswCard.vue';
 import RomfordCard from '~/components/RomfordCard.vue';
 import BifffCard from '~/components/BifffCard.vue';
 import BaficiCard from '~/components/BaficiCard.vue';
+import CannesCard from '~/components/CannesCard.vue';
 
 export default {
   components: {
@@ -85,7 +86,8 @@ export default {
     SxswCard,
     RomfordCard,
     BifffCard,
-    BaficiCard
+    BaficiCard,
+    CannesCard
   },
 
   mixins: [carousel],
@@ -130,6 +132,7 @@ export default {
         romford: 'RomfordCard',
         bifff: 'BifffCard',
         bafici: 'BaficiCard',
+        cannes: 'CannesCard',
       };
       return cardMap[item.festival_source] || 'SundanceCard';
     }

--- a/components/Hero.vue
+++ b/components/Hero.vue
@@ -432,6 +432,7 @@ import SxswBadge from '~/components/festival/SxswBadge.vue';
 import RomfordBadge from '~/components/festival/RomfordBadge.vue';
 import BifffBadge from '~/components/festival/BifffBadge.vue';
 import BaficiBadge from '~/components/festival/BaficiBadge.vue';
+import CannesBadge from '~/components/festival/CannesBadge.vue';
 import { MANUAL_FESTIVAL_BADGES } from '~/utils/constants';
 import { getHeroEnrichment, getNoirEnrichment } from '~/utils/api';
 import NoirModal from '~/components/NoirModal.vue';
@@ -447,6 +448,7 @@ export default {
     SxswBadge,
     RomfordBadge,
     BifffBadge,
+    CannesBadge,
     BaficiBadge,
     NoirModal,
   },
@@ -533,6 +535,7 @@ export default {
       sxswFilm: null,
       romfordFilm: null,
       bifffFilm: null,
+      cannesFilm: null,
       baficiFilm: null,
       isFestivalLoading: false,
 
@@ -608,6 +611,7 @@ export default {
         { name: 'sxsw', film: this.sxswFilm, component: 'SxswBadge', link: '/festival/sxsw-2026', isSimple: true },
         { name: 'romford', film: this.romfordFilm, component: 'RomfordBadge', link: '/festival/romford-2026', isSimple: true },
         { name: 'bifff', film: this.bifffFilm, component: 'BifffBadge', link: '/festival/bifff-2026', isSimple: true },
+        { name: 'cannes', film: this.cannesFilm, component: 'CannesBadge', link: '/festival/cannes-2026', isSimple: true },
         { name: 'bafici', film: this.baficiFilm, component: 'BaficiBadge', link: '/festival/bafici-2026', isSimple: true },
       ];
       return festivalConfig.filter(f => f.film);
@@ -883,6 +887,7 @@ export default {
     const wasSxsw = !!this.sxswFilm;
     const wasRomford = !!this.romfordFilm;
     const wasBifff = !!this.bifffFilm;
+    const wasCannes = !!this.cannesFilm;
     const wasBafici = !!this.baficiFilm;
 
     this.sundanceFilm = null;
@@ -892,11 +897,12 @@ export default {
     this.sxswFilm = null;
     this.romfordFilm = null;
     this.bifffFilm = null;
+    this.cannesFilm = null;
     this.baficiFilm = null;
 
     if (this.type !== 'movie' && this.type !== 'tv') return;
 
-    if (wasSundance || wasSlamdance || wasBerlinale || wasRotterdam || wasSxsw || wasRomford || wasBifff || wasBafici) {
+    if (wasSundance || wasSlamdance || wasBerlinale || wasRotterdam || wasSxsw || wasRomford || wasBifff || wasCannes || wasBafici) {
         this.isFestivalLoading = true;
     }
 
@@ -997,6 +1003,18 @@ export default {
             }
         }
 
+        const cannesResponse = await fetch(`/api/festival/cannes/films?tmdb_id=${this.id}`);
+        if (cannesResponse.ok) {
+            const data = await cannesResponse.json();
+            if (data.results && data.results.length > 0) {
+                if (!wasCannes) {
+                    this.isFestivalLoading = true;
+                    await new Promise(resolve => setTimeout(resolve, 500));
+                }
+                this.cannesFilm = data.results[0];
+            }
+        }
+
         if (MANUAL_FESTIVAL_BADGES[this.id]) {
             const manualFestivals = MANUAL_FESTIVAL_BADGES[this.id];
             if (manualFestivals.includes('sundance') && !this.sundanceFilm) this.sundanceFilm = { title: this.name };
@@ -1006,6 +1024,7 @@ export default {
             if (manualFestivals.includes('sxsw') && !this.sxswFilm) this.sxswFilm = { title: this.name };
             if (manualFestivals.includes('romford') && !this.romfordFilm) this.romfordFilm = { title: this.name };
             if (manualFestivals.includes('bifff') && !this.bifffFilm) this.bifffFilm = { title: this.name };
+            if (manualFestivals.includes('cannes') && !this.cannesFilm) this.cannesFilm = { title: this.name };
             if (manualFestivals.includes('bafici') && !this.baficiFilm) this.baficiFilm = { title: this.name };
         }
 

--- a/components/festival/CannesBadge.vue
+++ b/components/festival/CannesBadge.vue
@@ -1,0 +1,43 @@
+<template>
+  <div :class="$style.badge">
+    <img
+      src="/festivals/cannes/cannes_film_festival_2026_logo.png"
+      alt="Cannes Film Festival 2026"
+      :class="$style.logo"
+    >
+  </div>
+</template>
+
+<style lang="scss" module>
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  padding: 0;
+  transition: transform 0.2s ease;
+  user-select: none;
+  cursor: default;
+
+  &:hover {
+      transform: translateY(-2px);
+  }
+}
+
+.logo {
+  height: 78px;
+  width: auto;
+  filter: invert(1);
+  object-fit: contain;
+  display: block;
+
+  @media (max-width: 1023px) {
+    height: 45px;
+  }
+
+  &:hover {
+      filter: brightness(0) saturate(100%) invert(84%) sepia(21%) saturate(1211%) hue-rotate(179deg) brightness(101%) contrast(104%);
+      cursor: pointer;
+  }
+}
+</style>

--- a/pages/festival/cannes-2026/index.vue
+++ b/pages/festival/cannes-2026/index.vue
@@ -1,0 +1,1006 @@
+<template>
+  <main class="main">
+    <div class="container header-container">
+      <div class="festival-hero">
+        <nuxt-link to="/festival" class="back-link">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+            All Festivals
+        </nuxt-link>
+        <a href="https://www.festival-cannes.com" target="_blank" rel="noopener noreferrer" class="hero-backdrop">
+            <img 
+              src="/festivals/cannes/cannes_backdrop_2026_eng.webp" 
+              alt="Cannes Film Festival 2026"
+            />
+            <div class="hero-overlay"></div>
+        </a>
+      </div>
+
+      <div class="switcher-container">
+
+
+        <div class="segmented-control">
+            <input type="radio" id="tab-info" value="info" v-model="activeTab">
+            <label for="tab-info" @click="activeTab = 'info'">Info</label>
+
+            <input type="radio" id="tab-films" value="films" v-model="activeTab">
+            <label for="tab-films" @click="activeTab = 'films'">Catalog</label>
+
+            <input type="radio" id="tab-schedule" value="schedule" v-model="activeTab">
+            <label for="tab-schedule" @click="activeTab = 'schedule'">Schedule</label>
+
+            <div class="glider" :class="activeTab"></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="container">
+      <div v-if="loading" class="loader-container">
+        <Loader />
+      </div>
+
+      <div v-else>
+        <div v-if="activeTab === 'films'" class="films-grid">
+            <div class="disclaimer-bar"><FestivalDataDisclaimer /></div>
+            <div
+              v-for="cat in orderedCategories"
+              :key="cat"
+              class="film-category"
+            >
+                <div class="category-header" @click="toggleCategoryOpen(cat)">
+                    <h2 class="listing__title category-title">
+                        {{ categoryLabel(cat) }}
+                        <span class="category-count">({{ (filmsByCategory[cat] || []).length }})</span>
+                    </h2>
+                    <button class="expand-btn" :aria-label="isCategoryOpen(cat) ? 'Collapse' : 'Expand'">
+                        <svg v-if="isCategoryOpen(cat)" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
+                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
+                    </button>
+                </div>
+                <transition name="slide">
+                    <div v-show="isCategoryOpen(cat)" class="listing__items">
+                        <CannesCard
+                            v-for="item in (filmsByCategory[cat] || [])"
+                            :key="`${cat}-${item.id}`"
+                            :item="item"
+                        />
+                    </div>
+                </transition>
+            </div>
+        </div>
+
+        <div v-if="activeTab === 'schedule' && showSchedulePending" class="schedule-pending">
+          <div class="schedule-pending-inner">
+            <svg xmlns="http://www.w3.org/2000/svg" width="56" height="56" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="schedule-pending-icon" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/><path d="M8 14h.01"/><path d="M12 14h.01"/><path d="M16 14h.01"/><path d="M8 18h.01"/><path d="M12 18h.01"/><path d="M16 18h.01"/></svg>
+            <h2 class="schedule-pending-title">Official schedule pending</h2>
+            <p class="schedule-pending-text">
+              The festival has not yet published full screening times and venues. When the official schedule is released, showtimes will appear here automatically.
+            </p>
+          </div>
+        </div>
+
+        <div v-else-if="activeTab === 'schedule'" class="schedule-container">
+          <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" class="schedule-day">
+            <div class="day-header" @click="toggleDay(date)">
+                <h2>{{ formatDate(date) }}</h2>
+                <div class="chevron" :class="{ 'closed': !isOpen(date) }">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down"><path d="m6 9 6 6 6-6"/></svg>
+                </div>
+            </div>
+            
+            <transition name="slide">
+                <div v-show="isOpen(date)" class="screenings-list">
+                  <div v-for="screening in dayScreenings" :key="screening.id" class="screening-card">
+                     <div class="time-block">
+                        <span class="time">{{ formatTime(screening.start_time) }}</span>
+                        <span class="timezone">{{ screening.timezone }}</span>
+                     </div>
+                     
+                      <div class="film-info">
+                         <nuxt-link
+                            v-if="screening.film.tmdb_id"
+                            :to="{ name: 'movie-id', params: { id: screening.film.tmdb_id } }"
+                            class="film-title"
+                         >
+                            {{ screening.film.title }}
+                         </nuxt-link>
+                         <span v-else class="film-title">{{ screening.film.title }}</span>
+                         <div class="film-meta">
+                             <span v-if="screening.film.director">Directed by {{ screening.film.director }}</span>
+                             <span v-if="screening.film.director && screening.film.runtime"> • </span>
+                             <span v-if="screening.film.runtime">{{ screening.film.runtime }} min</span>
+                         </div>
+                         <div v-if="screening.venue" class="venue-info">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-map-pin"><path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"/><circle cx="12" cy="10" r="3"/></svg>
+                            {{ screening.venue }}
+                         </div>
+                         <div class="tags">
+                             <span v-if="screening.is_in_person" class="tag in-person">In Person</span>
+                             <span v-if="screening.is_online" class="tag online">Online</span>
+                             <span v-if="screening.is_sold_out" class="tag sold-out">Sold Out</span>
+                         </div>
+                      </div>
+                      
+                      <div class="poster-mini">
+                          <img 
+                            v-if="screening.film.poster_path" 
+                            :src="screening.film.poster_path" 
+                            alt="Poster" 
+                            loading="lazy" 
+                            @error="$event.target.src = '/placeholders/image_not_found_yet.webp'"
+                          />
+                          <img v-else src="/placeholders/image_not_found_yet.webp" alt="No Poster" />
+                      </div>
+                  </div>
+                </div>
+            </transition>
+          </div>
+        </div>
+
+        <div v-if="activeTab === 'info'" class="info-container">
+          <div class="carousel-wrapper">
+            <button class="carousel-arrow left" @click="prevSlide" aria-label="Previous">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+            </button>
+
+            <div class="carousel-track">
+              <transition :name="slideDirection" mode="out-in">
+                <div class="carousel-card" :key="infoSlide">
+                  <!-- Slide 0: General Information + YouTube -->
+                  <template v-if="infoSlide === 0">
+                    <div class="carousel-card-header">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+                      <h3>General Information</h3>
+                    </div>
+                    <div class="youtube-embed">
+                      <iframe src="https://www.youtube.com/embed/2B5Uh_8ixsE" title="Cannes Film Festival 2026" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                    </div>
+                    <p class="carousel-desc"><strong>Website:</strong> <a href="https://www.festival-cannes.com" target="_blank" rel="noopener noreferrer" class="accent-link">festival-cannes.com</a></p>
+                    <p class="carousel-desc"><strong>Dates:</strong> May 12 – May 23, 2026 (Festival) · May 12 – May 20, 2026 (Marché du Film).</p>
+                    <p class="carousel-desc">The <strong>Cannes Film Festival</strong> is one of the world’s most prestigious film events. Cinemagoria lists titles selected for the official lineup when data is available.</p>
+                  </template>
+
+                  <!-- Slide 1: Accreditation & Badge Pickup -->
+                  <template v-if="infoSlide === 1">
+                    <div class="carousel-card-header">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="5" width="20" height="14" rx="2"/><line x1="2" y1="10" x2="22" y2="10"/></svg>
+                      <h3>Accreditation &amp; Badge Pickup</h3>
+                    </div>
+                    <p class="carousel-desc">Pick up your badge at the <strong>Gare Maritime</strong> (to the right of the Casino Croisette) or at the automatic dispensers at La Pantiero. Bring your accreditation confirmation and ID.</p>
+                    <p class="carousel-desc"><strong>Badge pickup hours:</strong> May 11–12 from 8:00 AM to 8:00 PM · May 13–23 from 9:00 AM to 6:00 PM.</p>
+                    <p class="carousel-desc">From early May 2026, use the <strong>"My Cannes"</strong> section on the festival website for quick access to tickets, screening admissions, schedules, and maps.</p>
+                    <p class="carousel-desc">Cinemagoria does not sell passes; we provide discovery and scheduling context only.</p>
+                  </template>
+
+                  <!-- Slide 2: Opening Hours & Access -->
+                  <template v-if="infoSlide === 2">
+                    <div class="carousel-card-header">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+                      <h3>Opening Hours &amp; Access</h3>
+                    </div>
+                    <ul class="bullet-list">
+                      <li><strong>Main Entrance:</strong> 9:00 AM – 12:30 AM (from 8:15 AM for early Palais screenings)</li>
+                      <li><strong>Mediterranean Entrance:</strong> 8:30 AM – 12:30 AM · 8:00 AM – 8:00 PM for exhibitors</li>
+                      <li><strong>Jetée Albert-Edouard:</strong> 9:00 AM – 6:30 PM (professional badges)</li>
+                      <li><strong>International Village:</strong> 8:00 AM – 8:00 PM (exhibitors) · 9:00 AM – 6:30 PM (professionals)</li>
+                      <li><strong>Riviera Entrance (May 12–20):</strong> 9:00 AM – 7:00 PM (Festival &amp; Press) · 9:00 AM – 10:45 PM (Marché)</li>
+                    </ul>
+                  </template>
+
+                  <!-- Slide 3: Venues & Getting to Cannes -->
+                  <template v-if="infoSlide === 3">
+                    <div class="carousel-card-header">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"/><circle cx="12" cy="10" r="3"/></svg>
+                      <h3>Venues &amp; Getting There</h3>
+                    </div>
+                    <div class="venue-list">
+                      <div class="venue-item"><strong>Palais des Festivals</strong><span>Main festival hub — Cannes, France</span></div>
+                      <div class="venue-item"><strong>International Village</strong><span>Pavilions &amp; exhibitor area</span></div>
+                      <div class="venue-item"><strong>Cinéma de la Plage</strong><span>Open-air beach screenings</span></div>
+                    </div>
+                    <ul class="bullet-list">
+                      <li><strong>By train:</strong> ~5 h 30 min TGV from Paris</li>
+                      <li><strong>By plane:</strong> Via Nice Airport — Express Bus 81 to Cannes SNCF station (45 min, €19.50)</li>
+                      <li><strong>By taxi:</strong> Nice Airport → Cannes ~€88 · Taxi Cannes: +33 (0)4 93 99 27 27</li>
+                      <li><strong>Free PalmBus:</strong> Flash your QR code from "My Cannes" for free public transport</li>
+                    </ul>
+                  </template>
+
+                  <!-- Slide 4: Security & Useful Info -->
+                  <template v-if="infoSlide === 4">
+                    <div class="carousel-card-header">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+                      <h3>Security &amp; Useful Info</h3>
+                    </div>
+                    <p class="carousel-desc">Entrances are subject to <strong>Vigipirate security checks</strong>. Weapons, aluminium cans, glass bottles, and political messages are prohibited in the Festival area.</p>
+                    <ul class="bullet-list">
+                      <li><strong>WiFi:</strong> Free for Marché &amp; Press badges; €15/day or €95/12 days for others</li>
+                      <li><strong>Luggage cloakroom:</strong> Barrière Bistingo — May 10–23, 7:30 AM – 12:30 AM</li>
+                      <li><strong>Lost property:</strong> Gare Maritime — +33 (0)4 92 98 72 24</li>
+                      <li><strong>Emergency:</strong> Ambulance 15 · Fire 18 · Police 17 · Festival security: +33 (0)4 92 99 87 77</li>
+                    </ul>
+                  </template>
+                </div>
+              </transition>
+            </div>
+
+            <button class="carousel-arrow right" @click="nextSlide" aria-label="Next">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg>
+            </button>
+          </div>
+
+          <div class="carousel-dots">
+            <button v-for="i in totalSlides" :key="i" class="dot" :class="{ active: infoSlide === i - 1 }" @click="goToSlide(i - 1)" :aria-label="`Slide ${i}`"></button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, nextTick } from 'vue';
+import Loader from '~/components/Loader.vue';
+import FestivalDataDisclaimer from '~/components/FestivalDataDisclaimer.vue';
+import CannesCard from '~/components/CannesCard.vue';
+
+const CATEGORY_ORDER = [
+    'COMPETITION',
+    'OUT OF COMPETITION',
+    'UN CERTAIN REGARD',
+    'SPECIAL SCREENINGS',
+    'MIDNIGHT SCREENINGS',
+    'CANNES PREMIERE'
+];
+
+const CATEGORY_LABELS_EN = {
+    COMPETITION: 'Competition',
+    'OUT OF COMPETITION': 'Out of Competition',
+    'UN CERTAIN REGARD': 'Un Certain Regard',
+    'SPECIAL SCREENINGS': 'Special Screenings',
+    'MIDNIGHT SCREENINGS': 'Midnight Screenings',
+    'CANNES PREMIERE': 'Cannes Première',
+    OTHER: 'Other'
+};
+
+const activeTab = ref('films');
+const infoSlide = ref(0);
+const slideDirection = ref('carousel-next');
+const totalSlides = 5;
+const prevSlide = () => { slideDirection.value = 'carousel-prev'; infoSlide.value = (infoSlide.value - 1 + totalSlides) % totalSlides; };
+const nextSlide = () => { slideDirection.value = 'carousel-next'; infoSlide.value = (infoSlide.value + 1) % totalSlides; };
+const goToSlide = (i) => { slideDirection.value = i > infoSlide.value ? 'carousel-next' : 'carousel-prev'; infoSlide.value = i; };
+const loading = ref(true);
+const films = ref({ results: [] });
+const scheduleResponse = ref(null);
+const openDays = ref(new Set());
+const categoryOpen = ref({});
+
+const filmsByCategory = computed(() => {
+    const map = Object.fromEntries(CATEGORY_ORDER.map((c) => [c, []]));
+    map.OTHER = [];
+    for (const f of films.value?.results || []) {
+        const key = String(f.section || f.category || '').toUpperCase().trim();
+        if (key && map[key]) map[key].push(f);
+        else map.OTHER.push(f);
+    }
+    return map;
+});
+
+const orderedCategories = computed(() => {
+    const out = CATEGORY_ORDER.filter((c) => (filmsByCategory.value[c] || []).length > 0);
+    if ((filmsByCategory.value.OTHER || []).length > 0) out.push('OTHER');
+    return out;
+});
+
+function categoryLabel (cat) {
+    return CATEGORY_LABELS_EN[cat] || cat;
+}
+
+function isCategoryOpen (cat) {
+    return categoryOpen.value[cat] !== false;
+}
+
+function toggleCategoryOpen (cat) {
+    categoryOpen.value = { ...categoryOpen.value, [cat]: !isCategoryOpen(cat) };
+}
+
+const schedule = computed(() => scheduleResponse.value?.results || []);
+const showSchedulePending = computed(() => schedule.value.length === 0);
+
+const formatDate = (dateStr) => {
+    const options = { weekday: 'long', month: 'long', day: 'numeric' };
+    return new Date(dateStr).toLocaleDateString('en-US', options);
+};
+
+const formatTime = (timeStr) => {
+    return new Date(timeStr).toLocaleTimeString('en-US', {
+        hour: '2-digit',
+        minute: '2-digit'
+    });
+};
+
+const groupedScreenings = computed(() => {
+    if (!schedule.value?.length) return {};
+    const groups = {};
+    schedule.value.forEach(s => {
+        const dateKey = s.start_time.split('T')[0];
+        if (!groups[dateKey]) groups[dateKey] = [];
+        groups[dateKey].push(s);
+    });
+    return Object.keys(groups).sort().reduce((obj, key) => {
+        obj[key] = groups[key];
+        return obj;
+    }, {});
+});
+
+const toggleDay = (date) => {
+    if (openDays.value.has(date)) {
+        openDays.value.delete(date);
+    } else {
+        openDays.value.add(date);
+    }
+};
+
+const isOpen = (date) => openDays.value.has(date);
+
+onMounted(async () => {
+    try {
+        const [filmsData, sched] = await Promise.all([
+            $fetch('/api/festival/cannes/films?limit=500'),
+            $fetch('/api/festival/cannes/schedule')
+        ]);
+
+        films.value = filmsData;
+        scheduleResponse.value = sched;
+
+        if (schedule.value.length > 0) {
+            const dates = new Set(schedule.value.map(s => s.start_time.split('T')[0]));
+            dates.forEach(d => openDays.value.add(d));
+        }
+
+        await nextTick();
+        const open = {};
+        orderedCategories.value.forEach((c) => { open[c] = true; });
+        categoryOpen.value = open;
+    } catch (e) {
+        console.error('Error fetching festival data', e);
+    } finally {
+        loading.value = false;
+    }
+});
+</script>
+
+<style lang="scss" scoped>
+@use '~/assets/css/utilities/variables' as *;
+
+.film-category {
+    margin-bottom: 2.5rem;
+}
+
+.category-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    cursor: pointer;
+    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
+    padding-bottom: 5px;
+    margin-bottom: 15px;
+    transition: border-color 0.2s;
+    user-select: none;
+    
+    &:hover {
+        border-color: rgba(139, 233, 253, 0.6);
+    }
+}
+
+.category-title {
+    margin: 0 !important;
+}
+
+.category-count {
+    font-size: 1.1rem;
+    color: rgba(255, 255, 255, 0.6);
+    margin-left: 10px;
+    font-weight: normal;
+}
+
+.expand-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.3);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: #fff;
+    width: 36px;
+    height: 36px;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    flex-shrink: 0;
+    
+    &:hover {
+        background: rgba(139, 233, 253, 0.15);
+        color: #8BE9FD;
+        border-color: rgba(139, 233, 253, 0.3);
+    }
+
+    svg {
+        width: 20px;
+        height: 20px;
+        min-width: 20px;
+        min-height: 20px;
+        display: block;
+    }
+}
+
+.header-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-bottom: 2rem;
+}
+
+.switcher-container {
+    display: flex;
+    top: 3.5rem;
+    position: relative;
+    justify-content: center;
+    gap: 1.5rem;
+    align-items: center;
+}
+
+.segmented-control {
+    position: relative;
+    display: flex;
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 20px; 
+    padding: 4px;
+    height: 48px;
+    align-items: center;
+    min-width: 420px;
+}
+
+.segmented-control input[type="radio"] {
+    display: none;
+}
+
+.segmented-control label {
+    position: relative;
+    z-index: 2;
+    flex: 1;
+    text-align: center;
+    font-size: 1.1rem;
+    color: rgba(255, 255, 255, 0.6);
+    cursor: pointer;
+    transition: color 0.3s;
+    font-weight: 600;
+    line-height: 40px;
+    white-space: nowrap;
+    user-select: none;
+}
+
+.segmented-control input:checked + label {
+    color: #000;
+}
+
+.segmented-control .glider {
+    position: absolute;
+    top: 4px;
+    left: 4px;
+    height: calc(100% - 8px);
+    width: calc((100% - 8px) / 3);
+    background: #8BE9FD; 
+    border-radius: 16px;
+    z-index: 1;
+    transition: transform 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
+}
+
+.segmented-control .glider.info { transform: translateX(0); }
+.segmented-control .glider.films { transform: translateX(100%); }
+.segmented-control .glider.schedule { transform: translateX(200%); }
+
+
+.festival-hero {
+    width: 100%;
+    max-width: 1000px;
+    margin: 0 auto;
+    position: relative;
+    border-radius: 15px;
+    overflow: hidden;
+    background-color: transparent;
+    display: flex;
+    justify-content: center;
+    border: 1px solid #8BE9FD;
+}
+
+.back-link {
+    position: absolute;
+    top: 30px;
+    left: 30px;
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+    color: #fff;
+    text-decoration: none;
+    font-weight: 700;
+    font-size: 1.4rem;
+    background: rgba(0, 0, 0, 0.6);
+    padding: 12px 24px;
+    border-radius: 30px;
+    backdrop-filter: blur(10px);
+    transition: all 0.3s ease;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    box-shadow: 0 4px 15px rgba(0,0,0,0.3);
+
+    &:hover {
+        background: #fff;
+        color: #000;
+        transform: translateY(-2px) scale(1.05);
+        box-shadow: 0 8px 25px rgba(0,0,0,0.4);
+        border-color: #fff;
+    }
+    
+    svg {
+        width: 24px;
+        height: 24px;
+    }
+
+    @media (max-width: 768px) {
+        top: 20px;
+        left: 20px;
+        font-size: 0.9rem;
+        padding: 8px 16px;
+        
+        svg {
+            width: 18px;
+            height: 18px;
+        }
+    }
+}
+
+.buy-tickets-btn {
+    position: absolute;
+    top: 30px;
+    right: 30px;
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: #8BE9FD;
+    color: #000;
+    padding: 12px 24px;
+    border-radius: 30px;
+    text-decoration: none;
+    font-weight: 700;
+    font-size: 1.1rem;
+    transition: transform 0.2s, opacity 0.2s;
+    backdrop-filter: blur(10px);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    box-shadow: 0 4px 15px rgba(0,0,0,0.3);
+    
+    &:hover {
+        transform: translateY(-2px) scale(1.05);
+        box-shadow: 0 8px 25px rgba(0,0,0,0.4);
+        background: #fff;
+    }
+
+    &.sold-out {
+        background: rgba(100, 100, 100, 0.6);
+        color: #ddd;
+        border-color: #666;
+        cursor: not-allowed;
+        
+        &:hover {
+            transform: none;
+            background: rgba(100, 100, 100, 0.6);
+            box-shadow: 0 4px 15px rgba(0,0,0,0.3);
+        }
+    }
+    
+    @media (max-width: 768px) {
+        top: 20px;
+        right: 20px;
+        font-size: 0.9rem;
+        padding: 8px 16px;
+    }
+}
+
+.hero-backdrop {
+    width: 100%;
+    height: auto;
+    position: relative;
+    
+    img {
+        width: 100%;
+        height: auto;
+        display: block;
+        object-fit: contain;
+    }
+
+    .hero-overlay {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: linear-gradient(to bottom, rgba(0, 0, 0, 0.2), rgb(27 77 95 / 7%));
+        pointer-events: none;
+    }
+}
+
+.container {
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 20px 20px;
+}
+
+.loader-container {
+    display: flex;
+    justify-content: center;
+    padding: 3rem;
+}
+
+.schedule-pending {
+    max-width: 640px;
+    margin: 2rem auto 3rem;
+    padding: 0 1rem;
+}
+
+.schedule-pending-inner {
+    text-align: center;
+    padding: 2.5rem 2rem;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(139, 233, 253, 0.25);
+    border-radius: 16px;
+    backdrop-filter: blur(10px);
+}
+
+.schedule-pending-icon {
+    display: block;
+    margin: 0 auto 1.25rem;
+}
+
+.schedule-pending-title {
+    font-size: 1.45rem;
+    font-weight: 700;
+    color: #8BE9FD;
+    margin: 0 0 1rem;
+}
+
+.schedule-pending-text {
+    font-size: 1.05rem;
+    line-height: 1.65;
+    color: rgba(255, 255, 255, 0.78);
+    margin: 0;
+}
+
+.schedule-container, .info-container {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+}
+
+.day-header {
+    font-size: 1.8rem;
+    color: #fff;
+    border-bottom: 1px solid #333;
+    padding-bottom: 0.5rem;
+    margin-top: 3rem;
+    margin-bottom: 1.5rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    cursor: pointer;
+    user-select: none;
+    
+    h2 {
+        font-size: 1.8rem;
+        margin: 0;
+    }
+    
+    .chevron {
+        transition: transform 0.3s ease;
+        
+        &.closed {
+            transform: rotate(-90deg);
+        }
+    }
+}
+
+.slide-enter-active,
+.slide-leave-active {
+  transition: all 0.3s ease-out;
+  max-height: 2000px;
+  opacity: 1;
+  overflow: hidden;
+}
+
+.slide-enter-from,
+.slide-leave-to {
+  max-height: 0;
+  opacity: 0;
+  margin-bottom: 0;
+}
+
+.screening-card {
+    display: flex;
+    background: #0a161b;
+    border: 1px solid #8BE9FD;
+    border-radius: 8px;
+    padding: 1.5rem;
+    margin-bottom: 1rem;
+    gap: 1.5rem;
+    transition: transform 0.2s;
+}
+
+.time-block {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-width: 80px;
+    border-right: 1px solid #333;
+    padding-right: 1.5rem;
+    
+    .time {
+        font-size: 1.2rem;
+        font-weight: 700;
+        color: #fff;
+    }
+    .timezone {
+        font-size: 0.92rem;
+        color: #888;
+    }
+}
+
+.film-info {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    
+    .film-title {
+        font-size: 1.6rem;
+        font-weight: 700;
+        color: #fff;
+        text-decoration: none;
+        margin-bottom: 0.5rem;
+        
+        &:hover {
+            color: #8BE9FD;
+        }
+    }
+    
+    .film-meta {
+        font-size: 1.05rem;
+        color: #aaa;
+        margin-bottom: 0.8rem;
+    }
+    
+    .venue-info {
+        font-size: 1.25rem;
+        color: #ccc;
+        margin-bottom: 0.8rem;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        
+        svg {
+            min-width: 18px;
+        }
+    }
+}
+
+.tags {
+    display: flex;
+    gap: 0.5rem;
+    
+    .tag {
+        font-size: 0.75rem;
+        padding: 4px 8px;
+        border-radius: 4px;
+        font-weight: 600;
+        text-transform: uppercase;
+        
+        &.in-person { background: rgba(52, 152, 219, 0.2); }
+        &.online { background: rgba(46, 204, 113, 0.2); color: #2ecc71; }
+        &.sold-out { background: rgba(231, 76, 60, 0.2); color: #e74c3c; }
+    }
+}
+
+.poster-mini {
+    width: 60px;
+    height: 90px;
+    
+    img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        border-radius: 4px;
+    }
+}
+
+@media (max-width: 600px) {
+    .screening-card {
+        flex-direction: column; 
+        gap: 1rem;
+    }
+    .time-block {
+        border-right: none;
+        border-bottom: 1px solid #333;
+        padding-right: 0;
+        padding-bottom: 1rem;
+        flex-direction: row;
+        gap: 1rem;
+        width: 100%;
+    }
+    .poster-mini {
+        display: none;
+    }
+}
+
+/* ── Carousel ─────────────────────────────── */
+.carousel-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.carousel-track {
+  flex: 1;
+  min-height: 340px;
+  overflow: hidden;
+  position: relative;
+}
+
+.carousel-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(139, 233, 253, 0.18);
+  border-radius: 20px;
+  padding: 2.2rem 2.5rem;
+  backdrop-filter: blur(12px);
+  color: rgba(255, 255, 255, 0.88);
+  line-height: 1.8;
+  min-height: 300px;
+
+  strong { color: #fff; }
+}
+
+.carousel-card-header {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  margin-bottom: 1.4rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid rgba(139, 233, 253, 0.14);
+
+  h3 {
+    font-size: 1.35rem;
+    font-weight: 700;
+    color: #8BE9FD;
+    margin: 0;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+  }
+}
+
+.carousel-desc {
+  font-size: 1.08rem;
+  margin-bottom: 1rem;
+}
+
+.carousel-arrow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 1px solid rgba(139, 233, 253, 0.25);
+  background: rgba(0, 0, 0, 0.4);
+  color: #8BE9FD;
+  cursor: pointer;
+  transition: all 0.25s ease;
+  flex-shrink: 0;
+  backdrop-filter: blur(6px);
+
+  &:hover {
+    background: rgba(139, 233, 253, 0.15);
+    border-color: #8BE9FD;
+    transform: scale(1.1);
+  }
+}
+
+.carousel-dots {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 1.4rem;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(139, 233, 253, 0.2);
+  cursor: pointer;
+  transition: all 0.3s ease;
+  padding: 0;
+
+  &.active {
+    background: #8BE9FD;
+    box-shadow: 0 0 10px rgba(139, 233, 253, 0.5);
+    transform: scale(1.25);
+  }
+
+  &:hover:not(.active) {
+    background: rgba(139, 233, 253, 0.45);
+  }
+}
+
+.carousel-next-enter-active,
+.carousel-next-leave-active,
+.carousel-prev-enter-active,
+.carousel-prev-leave-active {
+  transition: all 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.carousel-next-enter-from { opacity: 0; transform: translateX(60px); }
+.carousel-next-leave-to   { opacity: 0; transform: translateX(-60px); }
+.carousel-prev-enter-from { opacity: 0; transform: translateX(-60px); }
+.carousel-prev-leave-to   { opacity: 0; transform: translateX(60px); }
+
+@media (max-width: 600px) {
+  .carousel-wrapper { gap: 0.5rem; }
+  .carousel-card { padding: 1.5rem 1.2rem; min-height: 280px; }
+  .carousel-card-header h3 { font-size: 1.15rem; }
+  .carousel-arrow { width: 36px; height: 36px; }
+  .carousel-arrow svg { width: 18px; height: 18px; }
+}
+
+/* ── Shared card content styles ───────────── */
+.price-list {
+  list-style: none; padding: 0; margin: 1rem 0;
+  li { display: flex; justify-content: space-between; align-items: center; padding: 0.65rem 0; border-bottom: 1px dashed rgba(255,255,255,0.08); &:last-child { border: none; } }
+  .price-label { color: rgba(255,255,255,0.7); font-size: 1.05rem; }
+  .price-value { color: #8BE9FD; font-weight: 700; font-size: 1.1rem; }
+}
+
+.venue-list {
+  display: flex; flex-direction: column; gap: 0.5rem; margin: 0.5rem 0;
+  .venue-item { display: flex; justify-content: space-between; align-items: center; padding: 0.5rem 0; border-bottom: 1px solid rgba(255,255,255,0.05); span { color: rgba(255,255,255,0.5); font-size: 0.95rem; } strong { color: #fff; } }
+}
+
+.bullet-list {
+  padding-left: 1.4rem; font-size: 1.02rem;
+  li { margin-bottom: 1rem; line-height: 1.7; &::marker { color: #8BE9FD; } }
+}
+
+.accent-link {
+  color: #8BE9FD; text-decoration: none; font-weight: 600; border-bottom: 1px solid transparent; transition: border-color 0.2s;
+  &:hover { border-color: #8BE9FD; }
+}
+
+.youtube-embed {
+  position: relative;
+  width: 100%;
+  padding-bottom: 56.25%;
+  margin-bottom: 1.2rem;
+  border-radius: 12px;
+  overflow: hidden;
+
+  iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: none;
+    border-radius: 12px;
+  }
+}
+</style>

--- a/pages/festival/cannes-2026/index.vue
+++ b/pages/festival/cannes-2026/index.vue
@@ -309,7 +309,7 @@ const showSchedulePending = computed(() => schedule.value.length === 0);
 
 const formatDate = (dateStr) => {
     const options = { weekday: 'long', month: 'long', day: 'numeric' };
-    return new Date(dateStr).toLocaleDateString('en-US', options);
+    return new Date(dateStr + 'T00:00:00').toLocaleDateString('en-US', options);
 };
 
 const formatTime = (timeStr) => {

--- a/pages/festival/index.vue
+++ b/pages/festival/index.vue
@@ -26,6 +26,18 @@ onMounted(() => {
       <p class="title-secondary">Explore our curated selections from the world's leading film festivals.</p>
 
       <div class="festivals-grid">
+        <nuxt-link to="/festival/cannes-2026" class="festival-card">
+          <div class="card-image-wrapper">
+             <img src="/festivals/cannes/cannes_backdrop_2026_eng.webp" alt="Cannes Film Festival 2026" />
+             <div class="overlay"></div>
+             <div class="card-content">
+               <h2>Cannes 2026</h2>
+               <span class="festival-dates">May 12–23, 2026</span>
+               <span class="explore-btn">Explore</span>
+             </div>
+          </div>
+        </nuxt-link>
+
         <nuxt-link to="/festival/bafici-2026" class="festival-card">
           <div class="card-image-wrapper">
              <img src="/festivals/bafici/bafici_backdrop_2026_eng.webp" alt="BAFICI 2026" />

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -184,7 +184,7 @@ const { data: pageData, error: pageError } = await useAsyncData('homepage', asyn
         }
     };
 
-    const [sundanceList, berlinaleList, rotterdamList, slamdanceList, sxswList, romfordList, bifffList, baficiList, trendingMovies, trendingTv, featured] = await Promise.all([
+    const [sundanceList, berlinaleList, rotterdamList, slamdanceList, sxswList, romfordList, bifffList, baficiList, cannesList, trendingMovies, trendingTv, featured] = await Promise.all([
         fetchFestivalMovies('sundance'),
         fetchFestivalMovies('berlinale'),
         fetchFestivalMovies('rotterdam'),
@@ -193,15 +193,25 @@ const { data: pageData, error: pageError } = await useAsyncData('homepage', asyn
         fetchFestivalMovies('romford'),
         fetchFestivalMovies('bifff'),
         fetchFestivalMovies('bafici'),
+        fetchFestivalMovies('cannes'),
         fetchWithRefill('movie', 20, 3),
         fetchWithRefill('tv', 20, 6),
         fetchHero()
     ]);
     
       const FEATURED_ORDER = [
-        'The Ozu Diaries',
-        'Un balcon à Limoges',
-        'Phantoms of July',
+        // cannes 2026
+        'Gentle Monster',
+        'Colony',
+        'Parallel Tales',
+        'Minotaur',
+        'Fjord',
+        'Fatherland',
+        'Visitation',
+        'Full Phil',
+        'All of a Sudden',
+        'Teenage Sex and Death at Camp Miasma',
+        'Bitter Christmas',
         // bafici 2026
         'In-I In Motion',
         'Heysel 85',
@@ -211,11 +221,8 @@ const { data: pageData, error: pageError } = await useAsyncData('homepage', asyn
         'Sorella di clausura',
         'Nova \'78',
         'Forest High',
-        'Hair, Paper, Water...',
         // bifff 2026
-        'Orfeo',
         'Mārama',
-        'Sister',
         'Corporate Retreat',
         'Tristes Tropiques',
         'Sicko',
@@ -243,8 +250,7 @@ const { data: pageData, error: pageError } = await useAsyncData('homepage', asyn
         'Wishful Thinking',
         'Sender',        
         // slamdance 2026
-        'Whisperings of the Moon', 
-        'The Bulldogs', 
+        'Whisperings of the Moon',
         'Dump of Untitled Pieces', 
         'Zumeca',
         // romford 2026
@@ -307,7 +313,7 @@ const { data: pageData, error: pageError } = await useAsyncData('homepage', asyn
 
     const norm = (s) => s ? s.toLowerCase().replace(/[^a-z0-9]/g, '') : '';
     
-    const allFestivalFilms = [...sundanceList, ...berlinaleList, ...rotterdamList, ...slamdanceList, ...sxswList, ...romfordList, ...bifffList, ...baficiList];
+    const allFestivalFilms = [...sundanceList, ...berlinaleList, ...rotterdamList, ...slamdanceList, ...sxswList, ...romfordList, ...bifffList, ...baficiList, ...cannesList];
     
     let mixedFestivalFilms = allFestivalFilms.filter(f => {
         const t = norm(f.title);

--- a/server/api/festival/cannes/films.get.ts
+++ b/server/api/festival/cannes/films.get.ts
@@ -1,0 +1,85 @@
+import { createError, defineEventHandler, getQuery } from 'h3'
+import { createClient } from '@libsql/client'
+
+export default defineEventHandler(async (event) => {
+    const config = useRuntimeConfig()
+    const query = getQuery(event)
+
+    const dbUrl = config.rssDbUrl || config.imdbDbUrl
+    const dbToken = config.rssDbToken || config.imdbDbToken
+
+    if (!dbUrl || !dbToken) {
+        throw createError({
+            statusCode: 500,
+            statusMessage: 'Database configuration missing'
+        })
+    }
+
+    const db = createClient({
+        url: dbUrl,
+        authToken: dbToken
+    })
+
+    try {
+        let sql = `SELECT * FROM festival_films WHERE festival_name = 'Cannes Film Festival' AND festival_year = 2026`
+
+        const args: any[] = []
+
+        if (query.tmdb_id) {
+            sql += ` AND tmdb_id = ?`
+            args.push(query.tmdb_id)
+        } else if (query.imdb_id) {
+            sql += ` AND imdb_id = ?`
+            args.push(query.imdb_id)
+        }
+
+        const result = await db.execute({ sql, args })
+
+        let films = result.rows.map((row: any) => {
+            let tmdbData: any = {}
+            try {
+                tmdbData = typeof row.tmdb_data === 'string' ? JSON.parse(row.tmdb_data) : (row.tmdb_data || {})
+            } catch (e) {
+                tmdbData = {}
+            }
+
+            return {
+                id: row.tmdb_id || row.id,
+                internal_id: row.id,
+                title: row.title,
+                overview: row.description || tmdbData.overview || '',
+                poster_path: (tmdbData.tmdb_poster ? tmdbData.tmdb_poster : (tmdbData.poster_path ? `https://image.tmdb.org/t/p/w500${tmdbData.poster_path}` : row.image_url)),
+                backdrop_path: tmdbData.backdrop_path ? `https://image.tmdb.org/t/p/w1280${tmdbData.backdrop_path}` : null,
+                release_date: tmdbData.release_date || tmdbData.tmdb_release_date || '',
+                vote_average: tmdbData.vote_average || 0,
+                runtime: row.runtime_minutes || tmdbData.runtime || 0,
+                genres: tmdbData.genres || [],
+                director: row.director,
+                section: row.section || row.category,
+                imdb_id: row.imdb_id,
+                tmdb_id: row.tmdb_id,
+                ...tmdbData
+            }
+        }).filter((film: any) => {
+            return film.title && film.title.trim() !== '';
+        });
+
+        if (query.limit) {
+            const limit = parseInt(query.limit as string)
+            films = films.slice(0, limit)
+        }
+
+        films.sort((a: any, b: any) => a.title.localeCompare(b.title))
+
+        return {
+            results: films
+        }
+
+    } catch (error: any) {
+        console.error('Cannes Films Fetch Error:', error)
+        throw createError({
+            statusCode: 500,
+            statusMessage: `Failed to fetch Cannes films: ${error.message || error}`,
+        })
+    }
+})

--- a/server/api/festival/cannes/schedule.get.ts
+++ b/server/api/festival/cannes/schedule.get.ts
@@ -1,0 +1,91 @@
+import { createClient } from '@libsql/client'
+import { createError, defineEventHandler } from 'h3'
+
+export default defineEventHandler(async (event) => {
+    const config = useRuntimeConfig()
+
+    const dbUrl = config.rssDbUrl || config.imdbDbUrl
+    const dbToken = config.rssDbToken || config.imdbDbToken
+
+    if (!dbUrl || !dbToken) {
+        throw createError({
+            statusCode: 500,
+            statusMessage: 'Database configuration missing'
+        })
+    }
+
+    const db = createClient({
+        url: dbUrl.trim(),
+        authToken: dbToken.trim()
+    })
+
+    try {
+        const sql = `
+            SELECT 
+                s.id as screening_id,
+                s.start_time,
+                s.time_zone as timezone,
+                s.is_in_person,
+                s.is_online,
+                s.is_sold_out,
+                s.venue,
+                f.id as film_id,
+                f.title,
+                f.image_url,
+                f.source_url,
+                f.director,
+                f.runtime_minutes,
+                f.tmdb_id as film_tmdb_id,
+                f.tmdb_data
+            FROM festival_screenings s
+            JOIN festival_films f ON s.film_id = f.id
+            WHERE f.festival_name = 'Cannes Film Festival' AND f.festival_year = 2026
+            ORDER BY s.start_time ASC
+        `
+
+        const result = await db.execute(sql)
+
+        const screenings = result.rows.map((row: any) => {
+            let tmdbData: any = {}
+            try {
+                tmdbData = typeof row.tmdb_data === 'string' ? JSON.parse(row.tmdb_data) : (row.tmdb_data || {})
+            } catch (e) {
+                tmdbData = {}
+            }
+
+            return {
+                id: row.screening_id,
+                start_time: row.start_time,
+                timezone: row.timezone,
+                is_in_person: Boolean(row.is_in_person),
+                is_online: Boolean(row.is_online),
+                is_sold_out: Boolean(row.is_sold_out),
+                venue: row.venue,
+                film: {
+                    id: row.film_id,
+                    tmdb_id: row.film_tmdb_id,
+                    title: row.title,
+                    image_url: row.image_url,
+                    source_url: row.source_url,
+                    director: row.director,
+                    runtime: row.runtime_minutes,
+                    poster_path: row.image_url || (tmdbData?.tmdb_poster ? tmdbData.tmdb_poster : (tmdbData?.poster_path ? `https://image.tmdb.org/t/p/w500${tmdbData.poster_path}` : null))
+                }
+            }
+        })
+
+        return {
+            success: true,
+            count: screenings.length,
+            results: screenings,
+            schedule_pending: screenings.length === 0
+        }
+
+    } catch (error: any) {
+        console.error('Cannes Schedule Fetch Error:', error)
+        throw createError({
+            statusCode: 500,
+            statusMessage: `Failed to fetch Cannes schedule: ${error.message}`,
+        })
+    }
+})


### PR DESCRIPTION
## Summary

This Pull Request introduces comprehensive support for the Cannes Film Festival 2026 across the Cinemagoria platform. This initial release focuses on integrating the first official announcement of 61 films, providing dedicated UI components, a new festival landing page with a film catalog and schedule, and corresponding backend API endpoints to fetch this festival data. Further announcements regarding additional films and detailed screening schedules are anticipated in early May.

## Motivation

To expand Cinemagoria's coverage of major international film festivals, providing users with a rich and detailed experience for one of the world's most prestigious events. This integration allows for discovery of Cannes selections, detailed screening information, and essential festival guidance.

## Changes

-   **New `CannesCard.vue` Component**: A dedicated card component for displaying Cannes Film Festival selections, including a unique Cannes logo badge, poster, and name, with robust image loading and routing logic.
-   **New `CannesBadge.vue` Component**: A visual badge component for displaying the Cannes Film Festival logo, primarily used in the Hero section.
-   **New `/pages/festival/cannes-2026/index.vue` Page**:
    -   A comprehensive festival page featuring "Info," "Catalog," and "Schedule" tabs.
    -   The "Info" tab includes general information, accreditation details, opening hours, venues, and security information via an interactive carousel, along with a YouTube embed.
    -   The "Catalog" tab dynamically lists all official film selections, grouped by section (e.g., Competition, Un Certain Regard), utilizing the new `CannesCard` component. Categories are collapsible.
    -   The "Schedule" tab displays a detailed daily screening schedule (if available), showing film titles, directors, runtimes, venues, and screening types (in-person, online, sold out). It gracefully handles pending schedules.
-   **`FestivalsCarousel.vue` Integration**: `CannesCard` is now integrated into the `FestivalsCarousel`, allowing Cannes films to be displayed within the dynamic festival listings.
-   **`Hero.vue` Integration**: `CannesBadge` is integrated into the `Hero` component, enabling dynamic display of the Cannes badge on relevant film pages and the homepage hero section. Backend logic was updated to fetch `cannesFilm` details.
-   **`pages/festival/index.vue` Update**: Added a prominent card for "Cannes 2026" on the main festival overview page, providing a direct link to the new festival page.
-   **`pages/index.vue` Update**: Integrated Cannes film data fetching into the homepage's `useAsyncData` to ensure Cannes selections are included in the main festival carousel and `FEATURED_ORDER` list.
-   **New API Endpoints**:
    -   `server/api/festival/cannes/films.get.ts`: Fetches the film catalog for Cannes 2026 from the database, supporting filtering by `tmdb_id` or `imdb_id`, and providing structured film data.
    -   `server/api/festival/cannes/schedule.get.ts`: Fetches the detailed screening schedule for Cannes 2026 from the database, providing screening times, venues, and associated film details.
-   **Styling**: Extensive SCSS styling has been added for all new components and pages to ensure a consistent and professional look and feel.

## Testing

The new Cannes Film Festival 2026 integration has been thoroughly tested:

-   **Frontend UI**:
    -   Navigated to `/festival/cannes-2026` and verified correct rendering of all tabs ("Info", "Catalog", "Schedule").
    -   Tested tab switching functionality, ensuring content updates correctly.
    -   Verified the carousel navigation and content display on the "Info" tab.
    -   Confirmed collapsible categories on the "Catalog" tab function as expected, displaying `CannesCard` instances.
    -   Checked the "Schedule" tab for proper display of screening data, including date/time formatting, venue details, and tags. Verified the "schedule pending" message when no data is available.
    -   Confirmed `CannesCard` instances correctly display film posters, titles, and the Cannes logo.
    -   Verified image loading states (loader and error placeholders) for `CannesCard`.
    -   Checked the presence and functionality of the "Cannes 2026" card on `/festival`.
    -   Confirmed `CannesBadge` appears in the `Hero` section when a film is a Cannes selection.
    -   Ensured Cannes films appear in the `FestivalsCarousel` on the homepage.
-   **Backend API**:
    -   Manually tested `/api/festival/cannes/films` endpoint with and without `tmdb_id`/`imdb_id` parameters, verifying correct data retrieval and parsing from the database.
    -   Manually tested `/api/festival/cannes/schedule` endpoint, verifying correct retrieval and structuring of screening data.

## Related Issues

#313 - #250