### PR TITLE
Gate saved articles feature behind authentication and add mobile save button

### DIFF
--- a/pages/news/[slug].vue
+++ b/pages/news/[slug].vue
@@ -202,24 +202,25 @@ const isArticleSaved = ref(false)
 const savedLink = ref(null)
 const userEmail = ref(null)
 
-onMounted(async () => {
-  isMounted.value = true
+const handleAuthChange = () => {
   const email = localStorage.getItem('email')?.replace(/['"]+/g, '')
   userEmail.value = email || null
+  checkSavedStatus()
+}
+
+onMounted(async () => {
+  isMounted.value = true
+  handleAuthChange()
   await checkSavedStatus()
 
   if (typeof window !== 'undefined') {
-    window.addEventListener('auth-changed', () => {
-      const newEmail = localStorage.getItem('email')?.replace(/['"]+/g, '')
-      userEmail.value = newEmail || null
-      checkSavedStatus()
-    })
+    window.addEventListener('auth-changed', handleAuthChange)
   }
 })
 
 onUnmounted(() => {
   if (typeof window !== 'undefined') {
-    window.removeEventListener('auth-changed', checkSavedStatus)
+    window.removeEventListener('auth-changed', handleAuthChange)
   }
 })
 

--- a/pages/news/[slug].vue
+++ b/pages/news/[slug].vue
@@ -52,6 +52,7 @@
         </NuxtLink>
         <ClientOnly>
           <button
+            v-if="userEmail"
             class="hero-save-btn"
             :class="{ 'is-saved': isArticleSaved }"
             @click="toggleSave"
@@ -122,10 +123,24 @@
           <div class="article-main">
             <div class="article-card">
               <header class="article-header">
-                <NuxtLink to="/news" class="mobile-back-btn">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg>
-                  News
-                </NuxtLink>
+                <div class="mobile-header-row">
+                  <NuxtLink to="/news" class="mobile-back-btn">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+                    News
+                  </NuxtLink>
+                  <ClientOnly>
+                    <button
+                      v-if="userEmail"
+                      class="mobile-save-btn"
+                      :class="{ 'is-saved': isArticleSaved }"
+                      @click="toggleSave"
+                      :title="isArticleSaved ? 'Remove from saved' : 'Save article'"
+                    >
+                      <svg v-if="!isArticleSaved" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16z"/><line x1="12" x2="12" y1="7" y2="13"/><line x1="15" x2="9" y1="10" y2="10"/></svg>
+                      <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="is-saved-icon"><path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2Z"/><path d="m9 10 2 2 4-4"/></svg>
+                    </button>
+                  </ClientOnly>
+                </div>
                 <time :datetime="article.published_at" class="article-date">
                   {{ formatDate(article.published_at) }}
                 </time>
@@ -185,13 +200,20 @@ const { $bus } = useNuxtApp()
 const isMounted = ref(false)
 const isArticleSaved = ref(false)
 const savedLink = ref(null)
+const userEmail = ref(null)
 
 onMounted(async () => {
   isMounted.value = true
+  const email = localStorage.getItem('email')?.replace(/['"]+/g, '')
+  userEmail.value = email || null
   await checkSavedStatus()
 
   if (typeof window !== 'undefined') {
-    window.addEventListener('auth-changed', checkSavedStatus)
+    window.addEventListener('auth-changed', () => {
+      const newEmail = localStorage.getItem('email')?.replace(/['"]+/g, '')
+      userEmail.value = newEmail || null
+      checkSavedStatus()
+    })
   }
 })
 
@@ -925,6 +947,14 @@ useHead(() => {
   display: none;
 }
 
+.mobile-save-btn {
+  display: none;
+}
+
+.mobile-header-row {
+  display: none;
+}
+
 /* ── Responsive ──────────────────────────────────────────────────── */
 @media (max-width: 900px) {
   .content-wrapper {
@@ -961,6 +991,13 @@ useHead(() => {
     border-radius: 10px;
   }
 
+  .mobile-header-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 12px;
+  }
+
   /* Show back button on mobile */
   .mobile-back-btn {
     display: inline-flex;
@@ -970,11 +1007,42 @@ useHead(() => {
     font-size: 14px;
     font-weight: 600;
     text-decoration: none;
-    margin-bottom: 12px;
+    margin-bottom: 0;
   }
 
   .mobile-back-btn:hover {
     opacity: 0.8;
+  }
+
+  .mobile-save-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: 10px;
+    background: rgba(139, 233, 253, 0.1);
+    border: 1px solid rgba(139, 233, 253, 0.2);
+    color: #8BE9FD;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    padding: 0;
+    margin-bottom: 0;
+  }
+
+  .mobile-save-btn:hover {
+    background: rgba(139, 233, 253, 0.2);
+    border-color: #8BE9FD;
+  }
+
+  .mobile-save-btn.is-saved {
+    background: #8BE9FD;
+    border-color: #8BE9FD;
+    color: #000;
+  }
+
+  .mobile-save-btn .is-saved-icon {
+    stroke: #000;
   }
 
   .sidebar-card {

--- a/pages/news/index.vue
+++ b/pages/news/index.vue
@@ -392,6 +392,9 @@ onUnmounted(() => {
   if (observer) {
     observer.disconnect();
   }
+  if (typeof window !== 'undefined') {
+    window.removeEventListener('auth-changed', handleAuthChange);
+  }
 });
 
 watch([newsItems, () => route.query.highlight], ([items, highlightId]) => {
@@ -508,22 +511,21 @@ async function fetchSavedArticlesList() {
     }
 }
 
+const handleAuthChange = () => {
+  const email = localStorage.getItem('email');
+  userEmail.value = email || null;
+  if (isSavedView.value) fetchSavedArticlesList();
+};
+
 onMounted(() => {
   if (typeof window !== 'undefined') {
-    const email = localStorage.getItem('email');
-    userEmail.value = email || null;
+    handleAuthChange();
     
     if (isSavedView.value && userEmail.value) {
         fetchSavedArticlesList();
-    } else if (isSavedView.value && !userEmail.value) {
-         // Potentially redirect or just show empty states
     }
 
-    window.addEventListener('auth-changed', () => {
-       const newEmail = localStorage.getItem('email');
-       userEmail.value = newEmail || null;
-       if (isSavedView.value) fetchSavedArticlesList();
-    });
+    window.addEventListener('auth-changed', handleAuthChange);
   }
 });
 

--- a/pages/news/index.vue
+++ b/pages/news/index.vue
@@ -15,7 +15,7 @@
           <div class="sidebar-card">
             
             <div class="sidebar-header-actions" :class="{ 'active': isSearchActive }">
-              <NuxtLink :to="{ path: '/news', query: { view: 'saved' } }" class="saved-articles-link" :class="{ 'active': isSavedView }">
+              <NuxtLink v-if="userEmail" :to="{ path: '/news', query: { view: 'saved' } }" class="saved-articles-link" :class="{ 'active': isSavedView }">
                 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor" stroke="none"><path fill-rule="evenodd" d="M6.32 2.577a49.255 49.255 0 0 1 11.36 0c1.497.174 2.57 1.46 2.57 2.93V21a.75.75 0 0 1-1.085.67L12 18.089l-7.165 3.583A.75.75 0 0 1 3.75 21V5.507c0-1.47 1.073-2.756 2.57-2.93Z" clip-rule="evenodd" /></svg>
                 <span>Saved Articles</span>
               </NuxtLink>
@@ -208,6 +208,7 @@
                           />
                           <div class="card-source">{{ item.source.name }}</div>
                           <button
+                            v-if="userEmail"
                             class="bookmark-btn"
                             :class="{ 'is-saved': isSaved(item) }"
                             @click.prevent="toggleSave(item)"
@@ -237,6 +238,7 @@
                           <div class="card-source">{{ item.source.name }}</div>
 
                           <button 
+                            v-if="userEmail"
                             class="bookmark-btn"
                             :class="{ 'is-saved': isSaved(item) }"
                             @click.prevent="toggleSave(item)"


### PR DESCRIPTION
This PR introduces authentication-based access control for the "Saved Articles" feature and enhances the user experience on mobile devices by adding a dedicated save button to the article detail page header.

## Root Cause

Previously, the "Saved Articles" link on the news index page and the "Save" / "Bookmark" buttons on individual news articles were visible to all users, regardless of their authentication status. This presented an inconsistent user experience, as saving articles is a user-specific feature requiring authentication. Additionally, the mobile view of an article detail page lacked a prominent save button in its header, which could be cumbersome for users wishing to save articles on the go.

## Changes

*   **Authentication Gating**:
    *   The "Saved Articles" link on the `/news` index page is now conditionally rendered, visible only when a `userEmail` is present (i.e., the user is logged in).
    *   The "Bookmark" buttons displayed on individual news cards in both grid and list views on the `/news` index page are also conditionally rendered, appearing only for logged-in users.
    *   Similarly, the main "Save" button in the hero section of the `/news/[slug]` article detail page is now conditional, visible only when `userEmail` is available.
*   **Mobile UI Enhancement (`/news/[slug]`)**:
    *   A new `div` with class `mobile-header-row` has been introduced in the article header to house the back button and a new mobile-specific save button.
    *   A `mobile-save-btn` component is added to the article detail page, mirroring the functionality of the hero save button. This button is styled to be prominently displayed in the mobile header (specifically for viewports `max-width: 900px`).
    *   The `mobile-save-btn` is also conditionally rendered based on the presence of `userEmail`.
*   **Authentication State Management**:
    *   A `userEmail` ref has been added to the script setup of `pages/news/[slug].vue` to track the user's authentication status.
    *   `userEmail` is initialized from `localStorage` on `onMounted`.
    *   The `auth-changed` event listener is updated to also refresh the `userEmail` value from `localStorage`, ensuring the UI dynamically updates save button visibility upon login/logout without requiring a page refresh.
*   **Styling**:
    *   New CSS rules are added for `.mobile-save-btn` and `.mobile-header-row` to control their display and appearance specifically for mobile viewports, ensuring a clean and functional design.

## Verification

To verify these changes, please perform the following steps:

1.  **Unauthenticated User Scenarios**:
    *   Navigate to `/news`. Observe that the "Saved Articles" link in the sidebar is *not* visible.
    *   Observe that the "Bookmark" buttons on individual news cards are *not* visible.
    *   Navigate to any article detail page (e.g., `/news/some-article-slug`).
    *   Observe that the "Save" button in the hero section is *not* visible.
    *   Resize your browser window to a mobile viewport (`max-width: 900px`). Observe that the "Save" button in the article header is *not* visible.

2.  **Authenticated User Scenarios**:
    *   Log in to the application.
    *   Navigate to `/news`. Observe that the "Saved Articles" link in the sidebar *is* visible.
    *   Observe that the "Bookmark" buttons on individual news cards *are* visible.
    *   Verify that clicking a "Bookmark" button saves/unsaves the article as expected.
    *   Navigate to any article detail page.
    *   Observe that the "Save" button in the hero section *is* visible.
    *   Verify that clicking the hero "Save" button saves/unsaves the article as expected.
    *   Resize your browser window to a mobile viewport. Observe that the "Save" button in the article header *is* visible.
    *   Verify that clicking the mobile "Save" button saves/unsaves the article as expected.

3.  **Authentication State Change (Dynamic Update)**:
    *   **Scenario A (Logged in -> Logged out)**:
        *   Log in and navigate to an article detail page. Verify save buttons are visible.
        *   Log out (e.g., from a different tab or via an in-app logout flow).
        *   Return to the article detail page without refreshing. Verify the save buttons disappear.
    *   **Scenario B (Logged out -> Logged in)**:
        *   Ensure you are logged out and navigate to an article detail page. Verify save buttons are not visible.
        *   Log in.
        *   Return to the article detail page without refreshing. Verify the save buttons appear.

## Related Issues

- #316