### PR TITLE
Implement runtime phase resolution in SpotlightCarousel

### DIFF
--- a/components/SpotlightCarousel.vue
+++ b/components/SpotlightCarousel.vue
@@ -63,6 +63,7 @@
 <script>
 import carousel from '~/mixins/Carousel';
 import Card from '~/components/Card';
+import { resolveMoviePhase, resolveTvPhase } from '~/utils/resolvePhase';
 
 const DEFAULT_LABELS = {
   movie: {
@@ -122,7 +123,7 @@ export default {
       let n = 0;
       let last = null;
       for (const item of r) {
-        const phase = item.phase || item._phase || null;
+        const phase = this.resolvePhase(item);
         if (!phase) continue;
         if (phase !== last) { n++; last = phase; }
       }
@@ -131,16 +132,24 @@ export default {
   },
 
   methods: {
+    // Resuelve el phase correcto de un item en runtime, ignorando el valor
+    // almacenado en DB. Actúa como safety net ante el cron de recalculación.
+    resolvePhase(item) {
+      return this.mediaType === 'movie'
+        ? resolveMoviePhase(item)
+        : resolveTvPhase(item);
+    },
+
     // Returns the label to render BEFORE this card, or '' if no divider here.
     // First card always gets its phase header so the timeline is anchored;
     // the divider's --first variant carries extra left margin to clear
     // the carousel's left navigation arrow.
     dividerLabel(item, idx) {
-      const phase = item.phase || item._phase || null;
+      const phase = this.resolvePhase(item);
       if (!phase) return '';
       if (idx === 0) return this.labels[phase] || '';
       const prev = this.items.results[idx - 1];
-      const prevPhase = prev?.phase || prev?._phase || null;
+      const prevPhase = this.resolvePhase(prev);
       if (prevPhase === phase) return '';
       return this.labels[phase] || '';
     },

--- a/utils/resolvePhase.js
+++ b/utils/resolvePhase.js
@@ -23,10 +23,9 @@ export function resolveMoviePhase(item, today = new Date()) {
   const lastT = toDay(item.last_theatrical);
 
   if (!anchor && !firstT) return 'no_date';
-  if (anchor && anchor > _today) return 'coming_soon';
+  if ((anchor && anchor > _today) || (!anchor && firstT && firstT > _today)) return 'coming_soon';
   if (anchor && daysSince(anchor, _today) <= JUST_OUT_WINDOW_DAYS) return 'just_out';
   if (lastT && lastT >= _today) return 'now_playing';
-  if (firstT && firstT <= _today) return 'after_run';
   return 'after_run';
 }
 

--- a/utils/resolvePhase.js
+++ b/utils/resolvePhase.js
@@ -1,0 +1,47 @@
+const JUST_OUT_WINDOW_DAYS = 14;
+const LATEST_EPISODES_WINDOW_DAYS = 30;
+
+function toDay(str) {
+  if (!str) return null;
+  const [y, m, d] = str.split('-').map(Number);
+  return new Date(Date.UTC(y, m - 1, d));
+}
+
+function daysSince(date, today) {
+  return Math.floor((today - date) / 86_400_000);
+}
+
+function normalizeToday(today = new Date()) {
+  return new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()));
+}
+
+export function resolveMoviePhase(item, today = new Date()) {
+  const _today = normalizeToday(today);
+
+  const anchor = toDay(item.theatrical_anchor);
+  const firstT = toDay(item.first_theatrical);
+  const lastT = toDay(item.last_theatrical);
+
+  if (!anchor && !firstT) return 'no_date';
+  if (anchor && anchor > _today) return 'coming_soon';
+  if (anchor && daysSince(anchor, _today) <= JUST_OUT_WINDOW_DAYS) return 'just_out';
+  if (lastT && lastT >= _today) return 'now_playing';
+  if (firstT && firstT <= _today) return 'after_run';
+  return 'after_run';
+}
+
+export function resolveTvPhase(item, today = new Date()) {
+  const _today = normalizeToday(today);
+
+  const firstAir = toDay(item.first_air_date);
+  const nextAir = toDay(item.next_air_date);
+  const lastAir = toDay(item.last_air_date);
+  const status = item.status ?? '';
+
+  if (!firstAir) return 'no_date';
+  if (firstAir > _today) return 'premiering';
+  if (nextAir && nextAir > _today) return 'airing';
+  if (['Ended', 'Canceled'].includes(status)) return 'completed';
+  if (lastAir && daysSince(lastAir, _today) <= LATEST_EPISODES_WINDOW_DAYS) return 'latest_episodes';
+  return 'airing';
+}


### PR DESCRIPTION
## Summary

Fixes #333

Items in `SpotlightCarousel` were permanently stuck in their original
release group because the component read `item.phase` directly from the
database — a value written once at insertion time and never updated.
This PR fixes the issue at two layers: a runtime recalculation in the
frontend so grouping is always accurate on page load, and a daily cron
job that keeps the stored `phase` field in Turso in sync.

## Root Cause

`SpotlightCarousel.vue` consumed `item.phase || item._phase` verbatim
from the API response. The `phase` field is written by
`cinemagoria-candidates-selections` at selection time and had no
mechanism to be re-evaluated as dates passed. The frontend had no
fallback to recalculate grouping dynamically.

## Changes

### `cinemagoria-main` · `cinemagoria-es`

**`utils/resolvePhase.js`** _(new file)_
- Exports `resolveMoviePhase(item)` and `resolveTvPhase(item)`.
- All date comparisons are normalized to UTC midnight to prevent
  off-by-one errors in negative-offset timezones (e.g. UTC-3).
- Movie phase ladder: `no_date → coming_soon → just_out (≤14d from
  theatrical anchor) → now_playing (last_theatrical ≥ today) → after_run`.
- TV phase ladder: `no_date → premiering → airing (next_air_date in
  future) → latest_episodes (last_air_date ≤30d ago) → completed
  (Ended/Canceled) → airing (default for Returning Series)`.

**`components/SpotlightCarousel.vue`** _(modified)_
- Imports `resolveMoviePhase` and `resolveTvPhase` from
  `~/utils/resolvePhase`.
- Adds `resolvePhase(item)` method that dispatches to the correct
  function based on `this.mediaType`.
- `dividerCount` (computed) and `dividerLabel` (method) now call
  `this.resolvePhase(item)` instead of reading `item.phase` or
  `item._phase`. The stored DB value is no longer used for grouping.

### `cinemagoria-candidates-selections`

**`recalculate-spotlight-phases.js`** _(new file)_
- Queries all rows from `spotlight_movies` and `spotlight_tv`.
- Applies the same phase logic as the frontend utility.
- Updates only rows where the computed phase differs from the stored one,
  writing the new value and `updated_at` timestamp.

**`.github/workflows/recalculate-spotlight-phases.yml`** _(new file)_
- Scheduled daily at 00:05 UTC.
- `workflow_dispatch` enabled for manual execution.

## Affected Repos

| Repo | Files changed |
|------|--------------|
| `cinemagoria-main` | `utils/resolvePhase.js` (new), `components/SpotlightCarousel.vue` |
| `cinemagoria-es` | `utils/resolvePhase.js` (new), `components/SpotlightCarousel.vue` |
| `cinemagoria-candidates-selections` | `recalculate-spotlight-phases.js` (new), `.github/workflows/recalculate-spotlight-phases.yml` (new) |
| `cinemagoria-stream` | — _(no SpotlightCarousel, no changes)_ |
| `cinemagoria-estream` | — _(no SpotlightCarousel, no changes)_ |

## Verification

After deploying `cinemagoria-main` and `cinemagoria-es`, the following
reclassifications should be immediately visible without any backend
action:

**TV**
- `Widow's Bay` — `Premiering Soon` → `Airing` (`first_air_date: 2026-04-28`)

**Movies**
- `Faces of Death` — `Just Out` → `After Run` (`last_theatrical: 2026-04-23`)
- `Two Seasons, Two Strangers` — `Just Out` → `After Run` (`last_theatrical: 2026-04-24`)

Run the `Recalculate Spotlight Phases` workflow manually from GitHub
Actions after deploying `cinemagoria-candidates-selections` to sync the
stored `phase` field in Turso. The daily cron takes over from there.