### PR TITLE
harden Turso URL handling in enrichment sync scripts

### DIFF
--- a/scripts/syncHeroData.js
+++ b/scripts/syncHeroData.js
@@ -5,18 +5,44 @@ import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-const { TURSO_DATABASE_URL = '', TURSO_AUTH_TOKEN = '' } = process.env;
+const {
+    TURSO_DATABASE_URL = '',
+    TURSO_URL = '',
+    TURSO_AUTH_TOKEN = '',
+} = process.env;
+
+const rawUrl = TURSO_DATABASE_URL.trim() || TURSO_URL.trim();
+const normalizedUrl = rawUrl.startsWith('https://')
+    ? rawUrl.replace(/^https:\/\//, 'libsql://')
+    : rawUrl;
+
+if (!normalizedUrl) {
+    throw new Error(
+        'Missing TURSO_DATABASE_URL (or TURSO_URL) secret. Configure it with your Turso database URL.',
+    );
+}
 
 const db = createClient({
-    url: TURSO_DATABASE_URL.trim(),
+    url: normalizedUrl,
     authToken: TURSO_AUTH_TOKEN.trim(),
 });
 
-const result = await db.execute(`
-    SELECT tmdb_id, media_type, trailer_key, backdrop_path, poster_path, force_enrichment
-    FROM hero_selections
-    WHERE tmdb_id IS NOT NULL
-`);
+let result;
+try {
+    result = await db.execute(`
+        SELECT tmdb_id, media_type, trailer_key, backdrop_path, poster_path, force_enrichment
+        FROM hero_selections
+        WHERE tmdb_id IS NOT NULL
+    `);
+} catch (error) {
+    if (error?.code === 'SERVER_ERROR') {
+        throw new Error(
+            `Could not query Turso at "${normalizedUrl}". Verify TURSO_DATABASE_URL/TURSO_URL points to the primary database endpoint and that TURSO_AUTH_TOKEN is valid. Original error: ${error.message}`,
+        );
+    }
+
+    throw error;
+}
 
 const data = result.rows.map(row => ({
     tmdb_id: Number(row.tmdb_id),

--- a/scripts/syncNoirEnrichmentData.js
+++ b/scripts/syncNoirEnrichmentData.js
@@ -6,18 +6,44 @@ import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-const { TURSO_DATABASE_URL = '', TURSO_AUTH_TOKEN = '' } = process.env;
+const {
+    TURSO_DATABASE_URL = '',
+    TURSO_URL = '',
+    TURSO_AUTH_TOKEN = '',
+} = process.env;
+
+const rawUrl = TURSO_DATABASE_URL.trim() || TURSO_URL.trim();
+const normalizedUrl = rawUrl.startsWith('https://')
+    ? rawUrl.replace(/^https:\/\//, 'libsql://')
+    : rawUrl;
+
+if (!normalizedUrl) {
+    throw new Error(
+        'Missing TURSO_DATABASE_URL (or TURSO_URL) secret. Configure it with your Turso database URL.',
+    );
+}
 
 const db = createClient({
-    url: TURSO_DATABASE_URL.trim(),
+    url: normalizedUrl,
     authToken: TURSO_AUTH_TOKEN.trim(),
 });
 
-const result = await db.execute(`
-    SELECT tmdb_id, media_type, trailer_key, backdrop_path, poster_path, force_enrichment
-    FROM noir_historical
-    WHERE tmdb_id IS NOT NULL
-`);
+let result;
+try {
+    result = await db.execute(`
+        SELECT tmdb_id, media_type, trailer_key, backdrop_path, poster_path, force_enrichment
+        FROM noir_historical
+        WHERE tmdb_id IS NOT NULL
+    `);
+} catch (error) {
+    if (error?.code === 'SERVER_ERROR') {
+        throw new Error(
+            `Could not query Turso at "${normalizedUrl}". Verify TURSO_DATABASE_URL/TURSO_URL points to the primary database endpoint and that TURSO_AUTH_TOKEN is valid. Original error: ${error.message}`,
+        );
+    }
+
+    throw error;
+}
 
 const data = result.rows.map(row => ({
     tmdb_id: Number(row.tmdb_id),


### PR DESCRIPTION
### Motivation
- The scheduled enrichment workflow was failing with `LibsqlError: SERVER_ERROR: Server returned HTTP status 404`, usually caused by an incorrect or unexpected Turso endpoint format. 
- Improve robustness and diagnostics so the sync job fails with an actionable error instead of an opaque stacktrace.

### Description
- Update `scripts/syncHeroData.js` and `scripts/syncNoirEnrichmentData.js` to accept either `TURSO_DATABASE_URL` or `TURSO_URL` from the environment. 
- Normalize `https://...` Turso URLs to the `libsql://...` scheme before creating the `@libsql/client` client. 
- Add an explicit error when no Turso URL secret is provided to make misconfiguration clear. 
- Wrap the DB query in a `try/catch` and rethrow `SERVER_ERROR` failures with an actionable message that includes the normalized URL and guidance about verifying the endpoint and auth token.

### Testing
- Ran `node --check scripts/syncHeroData.js` and it completed successfully. 
- Ran `node --check scripts/syncNoirEnrichmentData.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd86591ab88326836464a0aedc0003)