### PR TITLE
Normalize and validate Turso DB URL in sync scripts with improved error handling

### DIFF
--- a/scripts/syncHeroData.js
+++ b/scripts/syncHeroData.js
@@ -5,18 +5,66 @@ import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-const { TURSO_DATABASE_URL = '', TURSO_AUTH_TOKEN = '' } = process.env;
+const {
+    TURSO_DATABASE_URL = '',
+    TURSO_URL = '',
+    TURSO_AUTH_TOKEN = '',
+} = process.env;
 
-const db = createClient({
-    url: TURSO_DATABASE_URL.trim(),
-    authToken: TURSO_AUTH_TOKEN.trim(),
-});
+const sanitizeUrl = value => value.trim().replace(/^['"]|['"]$/g, '');
+const toLibsqlUrl = value => {
+    if (value.startsWith('http://')) {
+        return value.replace(/^http:\/\//, 'libsql://');
+    }
+    if (value.startsWith('https://')) {
+        return value.replace(/^https:\/\//, 'libsql://');
+    }
+    if (/^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//.test(value)) {
+        return value;
+    }
+    return `libsql://${value}`;
+};
 
-const result = await db.execute(`
-    SELECT tmdb_id, media_type, trailer_key, backdrop_path, poster_path, force_enrichment
-    FROM hero_selections
-    WHERE tmdb_id IS NOT NULL
-`);
+const rawUrl = sanitizeUrl(TURSO_DATABASE_URL) || sanitizeUrl(TURSO_URL);
+const normalizedUrl = toLibsqlUrl(rawUrl);
+
+if (!normalizedUrl) {
+    throw new Error(
+        'Missing TURSO_DATABASE_URL (or TURSO_URL) secret. Configure it with your Turso database URL.',
+    );
+}
+
+let db;
+try {
+    db = createClient({
+        url: normalizedUrl,
+        authToken: TURSO_AUTH_TOKEN.trim(),
+    });
+} catch (error) {
+    if (error?.code === 'URL_INVALID') {
+        throw new Error(
+            `Invalid Turso URL format: "${normalizedUrl}". Set TURSO_DATABASE_URL (or TURSO_URL) to something like "libsql://<db-name>-<org>.turso.io".`,
+        );
+    }
+    throw error;
+}
+
+let result;
+try {
+    result = await db.execute(`
+        SELECT tmdb_id, media_type, trailer_key, backdrop_path, poster_path, force_enrichment
+        FROM hero_selections
+        WHERE tmdb_id IS NOT NULL
+    `);
+} catch (error) {
+    if (error?.code === 'SERVER_ERROR') {
+        throw new Error(
+            `Could not query Turso at "${normalizedUrl}". Verify TURSO_DATABASE_URL/TURSO_URL points to the primary database endpoint and that TURSO_AUTH_TOKEN is valid. Original error: ${error.message}`,
+        );
+    }
+
+    throw error;
+}
 
 const data = result.rows.map(row => ({
     tmdb_id: Number(row.tmdb_id),

--- a/scripts/syncNoirEnrichmentData.js
+++ b/scripts/syncNoirEnrichmentData.js
@@ -6,18 +6,66 @@ import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-const { TURSO_DATABASE_URL = '', TURSO_AUTH_TOKEN = '' } = process.env;
+const {
+    TURSO_DATABASE_URL = '',
+    TURSO_URL = '',
+    TURSO_AUTH_TOKEN = '',
+} = process.env;
 
-const db = createClient({
-    url: TURSO_DATABASE_URL.trim(),
-    authToken: TURSO_AUTH_TOKEN.trim(),
-});
+const sanitizeUrl = value => value.trim().replace(/^['"]|['"]$/g, '');
+const toLibsqlUrl = value => {
+    if (value.startsWith('http://')) {
+        return value.replace(/^http:\/\//, 'libsql://');
+    }
+    if (value.startsWith('https://')) {
+        return value.replace(/^https:\/\//, 'libsql://');
+    }
+    if (/^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//.test(value)) {
+        return value;
+    }
+    return `libsql://${value}`;
+};
 
-const result = await db.execute(`
-    SELECT tmdb_id, media_type, trailer_key, backdrop_path, poster_path, force_enrichment
-    FROM noir_historical
-    WHERE tmdb_id IS NOT NULL
-`);
+const rawUrl = sanitizeUrl(TURSO_DATABASE_URL) || sanitizeUrl(TURSO_URL);
+const normalizedUrl = toLibsqlUrl(rawUrl);
+
+if (!normalizedUrl) {
+    throw new Error(
+        'Missing TURSO_DATABASE_URL (or TURSO_URL) secret. Configure it with your Turso database URL.',
+    );
+}
+
+let db;
+try {
+    db = createClient({
+        url: normalizedUrl,
+        authToken: TURSO_AUTH_TOKEN.trim(),
+    });
+} catch (error) {
+    if (error?.code === 'URL_INVALID') {
+        throw new Error(
+            `Invalid Turso URL format: "${normalizedUrl}". Set TURSO_DATABASE_URL (or TURSO_URL) to something like "libsql://<db-name>-<org>.turso.io".`,
+        );
+    }
+    throw error;
+}
+
+let result;
+try {
+    result = await db.execute(`
+        SELECT tmdb_id, media_type, trailer_key, backdrop_path, poster_path, force_enrichment
+        FROM noir_historical
+        WHERE tmdb_id IS NOT NULL
+    `);
+} catch (error) {
+    if (error?.code === 'SERVER_ERROR') {
+        throw new Error(
+            `Could not query Turso at "${normalizedUrl}". Verify TURSO_DATABASE_URL/TURSO_URL points to the primary database endpoint and that TURSO_AUTH_TOKEN is valid. Original error: ${error.message}`,
+        );
+    }
+
+    throw error;
+}
 
 const data = result.rows.map(row => ({
     tmdb_id: Number(row.tmdb_id),


### PR DESCRIPTION
### Motivation
- Make the two sync scripts resilient to different Turso URL formats and environment variable names. 
- Allow `TURSO_URL` as a fallback to `TURSO_DATABASE_URL` and accept quoted, HTTP(S) or libsql URL forms. 
- Provide clearer errors when the URL format or the database query fails to aid debugging.

### Description
- Add `TURSO_URL` fallback and normalize the raw secret by trimming and stripping surrounding quotes using `sanitizeUrl`. 
- Introduce `toLibsqlUrl` to convert `http://` or `https://` Turso endpoints to `libsql://` and to prepend `libsql://` when needed. 
- Validate the normalized URL and wrap `createClient` and `db.execute` calls in `try/catch` blocks to surface friendly errors for `URL_INVALID` and `SERVER_ERROR`. 
- Preserve existing result mapping and output file locations while trimming `TURSO_AUTH_TOKEN` before use.

### Testing
- No automated tests were added or run for these script changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd86591ab88326836464a0aedc0003)