### PR TITLE
Add Initial Fantasia International Film Festival 2026 Integration

### DIFF
--- a/components/FantasiaCard.vue
+++ b/components/FantasiaCard.vue
@@ -1,0 +1,257 @@
+<template>
+  <div class="card">
+    <nuxt-link
+      class="card__link"
+      :to="getRouteLink()">
+
+      <CardActions v-if="context === 'list'" :item="item" :currentList="list" />
+
+      <div class="card__img">
+        <div v-if="isLoading" class="card-loader">
+          <Loader :size="40" />
+        </div>
+
+        <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" />
+
+        <img
+          v-if="poster"
+          ref="posterImage"
+          :src="poster"
+          loading="lazy"
+          :class="{ 'card__img--logo': media === 'production' || media === 'streaming' }"
+          :alt="name"
+          :style="{ opacity: isLoading ? 0 : 1, transition: 'opacity 0.5s ease' }"
+          @load="onImageLoaded"
+          @error="$event.target.src = '/placeholders/image_not_found_yet.webp'; onImageLoaded($event)">
+
+        <img
+          v-else
+          ref="posterImage"
+          src="/placeholders/image_not_found_yet.webp"
+          alt="Image not found"
+          class="card__img--poster"
+          style="width: 100%; height: 100%; object-fit: cover;"
+          @load="onImageLoaded"
+          @error="onImageLoaded">
+
+          <div v-if="media === 'streaming'" class="card__badge">Streaming Service</div>
+          <div v-if="media === 'production'" class="card__badge">Production Company</div>
+      </div>
+
+      <h2 class="card__name">
+        {{ name }}
+      </h2>
+
+
+      <div class="card__logo-container">
+        <img
+            src="/festivals/fantasia/fantasia_film_festival_2026_logo.png"
+            alt="Fantasia Selection"
+            class="card__fantasia-logo"
+        />
+      </div>
+    </nuxt-link>
+  </div>
+</template>
+
+<script>
+import { apiImgUrl } from '~/utils/api';
+import { name, stars, poster as posterMixin } from '~/mixins/Details';
+import QuickFav from '~/components/global/QuickFav';
+import CardActions from '~/components/global/CardActions.vue';
+import Loader from '~/components/Loader.vue';
+
+export default {
+  components: {
+    QuickFav,
+    CardActions,
+    Loader,
+  },
+  mixins: [
+    name,
+    stars,
+    posterMixin,
+  ],
+
+  props: {
+    item: {
+      type: Object,
+      required: true,
+    },
+    context: {
+      type: String,
+      default: 'home'
+    },
+    list: {
+      type: Object,
+      default: null
+    }
+  },
+
+  data() {
+    return {
+      isLoading: true,
+    };
+  },
+
+  mounted() {
+    this.checkImageLoaded();
+  },
+
+  watch: {
+    item: {
+      immediate: true,
+      handler() {
+        this.isLoading = true;
+        this.$nextTick(() => {
+           this.checkImageLoaded();
+        });
+      }
+    }
+  },
+
+  methods: {
+    checkImageLoaded() {
+      const img = this.$refs.posterImage;
+      if (img && img.complete && img.naturalHeight !== 0) {
+        this.onImageLoaded();
+      }
+    },
+    onImageLoaded() {
+      this.isLoading = false;
+    },
+    getRouteLink() {
+        if (this.item.media_type === 'production') {
+            return { name: 'production-slug', params: { slug: this.item.slug } };
+        }
+        if (this.item.media_type === 'streaming') {
+            return { name: 'streaming-slug', params: { slug: this.item.slug } };
+        }
+        return { name: `${this.media}-id`, params: { id: this.item.id } };
+    }
+  },
+
+  computed: {
+    poster () {
+      if (this.poster_path) return this.poster_path;
+      if (this.item.profile_path) {
+        return `${apiImgUrl}/w500${this.item.profile_path}`;
+      } else if (this.item.logo_path) {
+        return `${apiImgUrl}/w500${this.item.logo_path}`;
+      } else {
+        return false;
+      }
+    },
+
+    media () {
+      if (this.item.media_type) {
+        return this.item.media_type;
+      } else if (this.item.name) {
+        return 'tv';
+      } else {
+        return 'movie';
+      }
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.card__link {
+  display: block;
+  position: relative;
+}
+
+.card__img {
+  position: relative;
+  overflow: hidden;
+  border-top-left-radius: 15px;
+  border-top-right-radius: 15px;
+  transform: translateZ(0);
+}
+.card__img img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.card__img--logo {
+  object-fit: contain !important;
+  padding: 20px;
+  background-color: #8BE9FD;
+  width: 100%;
+  height: 100%;
+}
+
+.card-loader {
+  display: flex;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+  background-color: #0000004e;
+  z-index: 2;
+}
+
+.card__indicator {
+  font-size: 0.8rem;
+  color: #8BE9FD;
+  margin-top: 0.2rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.card__badge {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background-color: rgba(0, 0, 0, 0.75);
+  color: #8BE9FD;
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 4px 8px;
+  border-radius: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  z-index: 5;
+  backdrop-filter: blur(4px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+
+  @media (max-width: 500px) {
+    font-size: 0.6rem;
+    padding: 2px 4px;
+    top: 5px;
+    right: 5px;
+  }
+}
+
+.card__logo-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: black;
+    box-shadow: 0 8px 10px 0 rgba(31, 104, 135, 0.37);
+    border-bottom-right-radius: 10px;
+    border-bottom-left-radius: 10px;
+    bottom: 10px;
+    padding-bottom: 0.5rem;
+    position: relative;
+    top: -30px;
+    height: 60px;
+}
+
+.card__fantasia-logo {
+    height: 50px;
+    width: auto;
+    filter: invert(1);
+    object-fit: contain;
+}
+</style>

--- a/components/FestivalsCarousel.vue
+++ b/components/FestivalsCarousel.vue
@@ -69,6 +69,7 @@ import CuffCard from '~/components/CuffCard.vue';
 import CannesCard from '~/components/CannesCard.vue';
 import CannesCriticsChoiceCard from '~/components/CannesCard.vue';
 import KviffCard from '~/components/KviffCard.vue';
+import FantasiaCard from '~/components/FantasiaCard.vue';
 
 const AUTOPLAY_INTERVAL = 10000;
 
@@ -91,6 +92,7 @@ export default {
     CannesCard,
     CannesCriticsChoiceCard,
     KviffCard,
+    FantasiaCard,
   },
 
   props: {
@@ -146,6 +148,7 @@ export default {
         cannes: 'CannesCard',
         'cannes-critics-choice': 'CannesCriticsChoiceCard',
         kviff: 'KviffCard',
+        fantasia: 'FantasiaCard',
       };
       return cardMap[item.festival_source] || 'SundanceCard';
     },

--- a/components/Hero.vue
+++ b/components/Hero.vue
@@ -461,6 +461,7 @@ import CannesCriticsChoiceBadge from '~/components/festival/CannesCriticsChoiceB
 import CannesQuinzaineBadge from '~/components/festival/CannesQuinzaineBadge.vue';
 import CannesAcidBadge from '~/components/festival/CannesAcidBadge.vue';
 import KviffBadge from '~/components/festival/KviffBadge.vue';
+import FantasiaBadge from '~/components/festival/FantasiaBadge.vue';
 import { MANUAL_FESTIVAL_BADGES, MANUAL_OVERVIEWS } from '~/utils/constants';
 import { getHeroEnrichment, getNoirEnrichment } from '~/utils/api';
 import NoirModal from '~/components/NoirModal.vue';
@@ -484,6 +485,7 @@ export default {
     BaficiBadge,
     CuffBadge,
     KviffBadge,
+    FantasiaBadge,
     NoirModal,
   },
 
@@ -577,6 +579,7 @@ export default {
       baficiFilm: null,
       cuffFilm: null,
       kviffFilm: null,
+      fantasiaFilm: null,
       isFestivalLoading: false,
 
       showNoirModal: false,
@@ -666,6 +669,7 @@ export default {
         { name: 'bafici', film: this.baficiFilm, component: 'BaficiBadge', link: '/festival/bafici-2026', isSimple: true },
         { name: 'cuff', film: this.cuffFilm, component: 'CuffBadge', link: '/festival/cuff-2026', isSimple: true },
         { name: 'kviff', film: this.kviffFilm, component: 'KviffBadge', link: '/festival/kviff-2026', isSimple: true },
+        { name: 'fantasia', film: this.fantasiaFilm, component: 'FantasiaBadge', link: '/festival/fantasia-2026', isSimple: true },
       ];
       return festivalConfig.filter(f => f.film);
     },
@@ -1003,6 +1007,7 @@ export default {
     const wasBafici = !!this.baficiFilm;
     const wasCuff = !!this.cuffFilm;
     const wasKviff = !!this.kviffFilm;
+    const wasFantasia = !!this.fantasiaFilm;
 
     this.sundanceFilm = null;
     this.slamdanceFilm = null;
@@ -1019,10 +1024,11 @@ export default {
     this.baficiFilm = null;
     this.cuffFilm = null;
     this.kviffFilm = null;
+    this.fantasiaFilm = null;
 
     if (this.type !== 'movie' && this.type !== 'tv') return;
 
-    if (wasSundance || wasSlamdance || wasTribeca || wasBerlinale || wasRotterdam || wasSxsw || wasRomford || wasBifff || wasCannes || wasCannesCriticsChoice || wasCannesQuinzaine || wasCannesAcid || wasBafici || wasCuff || wasKviff) {
+    if (wasSundance || wasSlamdance || wasTribeca || wasBerlinale || wasRotterdam || wasSxsw || wasRomford || wasBifff || wasCannes || wasCannesCriticsChoice || wasCannesQuinzaine || wasCannesAcid || wasBafici || wasCuff || wasKviff || wasFantasia) {
         this.isFestivalLoading = true;
     }
 
@@ -1159,6 +1165,18 @@ export default {
             }
         }
 
+        const fantasiaResponse = await fetch(`/api/festival/fantasia/films?tmdb_id=${this.id}`);
+        if (fantasiaResponse.ok) {
+            const data = await fantasiaResponse.json();
+            if (data.results && data.results.length > 0) {
+                if (!wasFantasia) {
+                    this.isFestivalLoading = true;
+                    await new Promise(resolve => setTimeout(resolve, 500));
+                }
+                this.fantasiaFilm = data.results[0];
+            }
+        }
+
         const cannesResponse = await fetch(`/api/festival/cannes/films?tmdb_id=${this.id}`);
         if (cannesResponse.ok) {
             const data = await cannesResponse.json();
@@ -1202,6 +1220,7 @@ export default {
             if (manualFestivals.includes('bafici') && !this.baficiFilm) this.baficiFilm = { title: this.name };
             if (manualFestivals.includes('cuff') && !this.cuffFilm) this.cuffFilm = { title: this.name };
             if (manualFestivals.includes('kviff') && !this.kviffFilm) this.kviffFilm = { title: this.name };
+            if (manualFestivals.includes('fantasia') && !this.fantasiaFilm) this.fantasiaFilm = { title: this.name };
         }
 
     } catch (e) {

--- a/components/festival/FantasiaBadge.vue
+++ b/components/festival/FantasiaBadge.vue
@@ -1,0 +1,43 @@
+<template>
+  <div :class="$style.badge">
+    <img
+      src="/festivals/fantasia/fantasia_film_festival_2026_logo.png"
+      alt="Fantasia International Film Festival 2026"
+      :class="$style.logo"
+    />
+  </div>
+</template>
+
+<style lang="scss" module>
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  padding: 0;
+  transition: transform 0.2s ease;
+  user-select: none;
+  cursor: default;
+
+  &:hover {
+      transform: translateY(-2px);
+  }
+}
+
+.logo {
+  height: 78px;
+  width: auto;
+  filter: invert(1);
+  object-fit: contain;
+  display: block;
+
+  @media (max-width: 1023px) {
+    height: 45px;
+  }
+
+  &:hover {
+      filter: brightness(0) saturate(100%) invert(84%) sepia(21%) saturate(1211%) hue-rotate(179deg) brightness(101%) contrast(104%);
+      cursor: pointer;
+  }
+}
+</style>

--- a/pages/festival/fantasia-2026/index.vue
+++ b/pages/festival/fantasia-2026/index.vue
@@ -1,0 +1,1208 @@
+<template>
+  <main class="main">
+    <div class="container header-container">
+      <div class="festival-hero">
+        <nuxt-link to="/festival" class="back-link">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+            All Festivals
+        </nuxt-link>
+        <a href="https://fantasiafestival.com" target="_blank" rel="noopener noreferrer" class="hero-backdrop">
+            <img
+              src="/festivals/fantasia/fantasia_backdrop_2026_en.webp"
+              alt="Fantasia International Film Festival 2026 Backdrop"
+            />
+            <div class="hero-overlay"></div>
+        </a>
+      </div><div class="switcher-container">
+
+
+        <div class="segmented-control">
+            <input type="radio" id="tab-info" value="info" v-model="activeTab">
+            <label for="tab-info" @click="activeTab = 'info'">Info</label>
+
+            <input type="radio" id="tab-films" value="films" v-model="activeTab">
+            <label for="tab-films" @click="activeTab = 'films'">Catalog</label>
+
+            <input type="radio" id="tab-schedule" value="schedule" v-model="activeTab">
+            <label for="tab-schedule" @click="activeTab = 'schedule'">Schedule</label>
+
+            <div class="glider" :class="activeTab"></div>
+        </div>
+      </div>
+      <div class="disclaimer-bar disclaimer-bar--top" style="max-width: 1200px; width: 100%; margin: 6px auto 0;">
+        <FestivalDataDisclaimer />
+      </div>
+
+
+      <!-- Winners Showcase: only renders when the festival has finished and awards exist -->
+      <WinnersCarousel
+        v-if="awards.length > 0"
+        :awards="awards"
+        :year="2026"
+      />
+
+
+    </div>
+
+    <div class="container">
+      <div v-if="loading" class="loader-container">
+        <Loader />
+      </div>
+
+      <div v-else>
+        <div v-if="activeTab === 'films'" class="films-grid">
+            <!-- Initial rollout banner: lineup is still being imported -->
+            <div v-if="features.length === 0 && shorts.length === 0" class="rollout-banner">
+              <div class="rollout-banner__icon">
+                <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+              </div>
+              <div class="rollout-banner__copy">
+                <h3>Lineup updates in progress</h3>
+                <p>This festival lineup is currently being updated. New films, sections, and official selections will be added progressively as they are announced and verified.</p>
+              </div>
+            </div>
+
+            <div v-if="features.length > 0" class="film-category">
+                <div class="category-header" @click="featuresOpen = !featuresOpen">
+                    <h2 class="listing__title category-title">
+                        Features
+                        <span class="category-count">({{ features.length }})</span>
+                    </h2>
+                    <button class="expand-btn" :aria-label="featuresOpen ? 'Collapse' : 'Expand'">
+                        <svg v-if="featuresOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
+                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
+                    </button>
+                </div>
+                <transition name="slide">
+                    <div v-show="featuresOpen" class="listing__items">
+                        <FantasiaCard
+                            v-for="item in features"
+                            :key="`feature-${item.id}`"
+                            :item="item"
+                        />
+                    </div>
+                </transition>
+            </div>
+
+            <div v-if="shorts.length > 0" class="film-category">
+                <div class="category-header" @click="shortsOpen = !shortsOpen">
+                    <h2 class="listing__title category-title">
+                        Shorts
+                        <span class="category-count">({{ shorts.length }})</span>
+                    </h2>
+                    <button class="expand-btn" :aria-label="shortsOpen ? 'Collapse' : 'Expand'">
+                        <svg v-if="shortsOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
+                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
+                    </button>
+                </div>
+                <transition name="slide">
+                    <div v-show="shortsOpen" class="listing__items">
+                        <FantasiaCard
+                            v-for="item in shorts"
+                            :key="`short-${item.id}`"
+                            :item="item"
+                        />
+                    </div>
+                </transition>
+            </div>
+        </div>
+
+        <div v-if="activeTab === 'schedule'" class="schedule-container">
+          <!-- Initial rollout banner: schedule pending official publication -->
+          <div v-if="schedule.length === 0" class="rollout-banner">
+            <div class="rollout-banner__icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+            </div>
+            <div class="rollout-banner__copy">
+              <h3>Schedule pending</h3>
+              <p>Official screening schedules have not yet been published by the festival. Screening information will appear here as soon as it becomes available.</p>
+            </div>
+          </div>
+
+          <div v-if="schedule.length > 0" class="schedule-toolbar" :class="{ 'search-active': isScheduleSearchActive }">
+            <div class="schedule-toolbar-info">
+              <span class="schedule-count" v-if="!loading">
+                <template v-if="scheduleSearchActiveQuery">
+                  {{ filteredSchedule.length }} {{ filteredSchedule.length === 1 ? 'result' : 'results' }}
+                </template>
+                <template v-else>
+                  {{ schedule.length }} {{ schedule.length === 1 ? 'screening' : 'screenings' }}
+                </template>
+              </span>
+            </div>
+            <div class="search-wrapper" :class="{ 'active': isScheduleSearchActive }">
+              <button class="search-toggle-btn" @click="toggleScheduleSearch" :class="{ 'active': isScheduleSearchActive }" aria-label="Search schedule">
+                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+              </button>
+              <div class="search-input-container" :class="{ 'show': isScheduleSearchActive }">
+                <input
+                  ref="scheduleSearchInput"
+                  type="text"
+                  class="search-input"
+                  placeholder="Search films or directors…"
+                  v-model="scheduleSearch"
+                  @keydown.esc="closeScheduleSearch"
+                >
+                <button class="clear-search-btn" @click="clearScheduleSearch" v-if="scheduleSearch" aria-label="Clear search">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <div v-if="scheduleSearchActiveQuery && filteredSchedule.length === 0" class="schedule-empty">
+            <svg xmlns="http://www.w3.org/2000/svg" width="42" height="42" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="opacity: 0.6; margin-bottom: 12px;"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+            <p>No screenings match "<strong>{{ scheduleSearch }}</strong>"</p>
+          </div>
+
+          <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" class="schedule-day">
+            <div class="day-header" @click="toggleDay(date)">
+                <h2>{{ formatDate(date) }}</h2>
+                <div class="chevron" :class="{ 'closed': !isOpen(date) }">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down"><path d="m6 9 6 6 6-6"/></svg>
+                </div>
+            </div>
+
+            <transition name="slide">
+                <div v-show="isOpen(date)" class="screenings-list">
+                  <div v-for="screening in dayScreenings" :key="screening.id" class="screening-card">
+                     <div class="time-block">
+                        <span class="time">{{ formatTime(screening.start_time) }}</span>
+                        <span class="timezone">{{ screening.timezone }}</span>
+                     </div>
+
+                      <div class="film-info">
+                         <a
+                            href="https://fantasiafestival.com/en/films"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="film-title"
+                         >
+                            {{ screening.film.title }}
+                         </a>
+                         <div class="film-meta">
+                             <span v-if="screening.film.director">Directed by {{ screening.film.director }}</span>
+                             <span v-if="screening.film.director && screening.film.runtime"> • </span>
+                             <span v-if="screening.film.runtime">{{ screening.film.runtime }} min</span>
+                         </div>
+                         <div v-if="screening.venue" class="venue-info">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-map-pin"><path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"/><circle cx="12" cy="10" r="3"/></svg>
+                            {{ screening.venue }}
+                         </div>
+                         <div class="tags">
+                             <span v-if="screening.is_in_person" class="tag in-person">In Person</span>
+                             <span v-if="screening.is_online" class="tag online">Online</span>
+                             <span v-if="screening.is_sold_out" class="tag sold-out">Sold Out</span>
+                         </div>
+                      </div>
+
+                      <div class="poster-mini">
+                          <img
+                            v-if="screening.film.poster_path"
+                            :src="screening.film.poster_path"
+                            alt="Poster"
+                            loading="lazy"
+                            @error="$event.target.src = '/placeholders/image_not_found_yet.webp'"
+                          />
+                          <img v-else src="/placeholders/image_not_found_yet.webp" alt="No Poster" />
+                      </div>
+                  </div>
+                </div>
+            </transition>
+          </div>
+        </div>
+
+        <div v-if="activeTab === 'info'" class="info-container">
+          <div class="carousel-wrapper">
+            <button class="carousel-arrow left" @click="prevSlide" aria-label="Previous">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+            </button>
+
+            <div class="carousel-track">
+              <transition :name="slideDirection" mode="out-in">
+                <div class="carousel-card" :key="infoSlide">
+                  <!-- Slide 0: General Information + Featured Video -->
+                  <template v-if="infoSlide === 0">
+                    <div class="carousel-card-header">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+                      <h3>General Information</h3>
+                    </div>
+                    <div class="youtube-embed">
+                      <iframe src="https://www.youtube.com/embed/rg4jTk2EtDI" title="Fantasia International Film Festival 2026" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                    </div>
+                    <p class="carousel-desc"><strong>Dates:</strong> July 16 – August 2, 2026</p>
+                    <p class="carousel-desc"><strong>Location:</strong> Montreal, Quebec, Canada</p>
+                    <p class="carousel-desc"><strong>Website:</strong> <a href="https://fantasiafestival.com" target="_blank" rel="noopener noreferrer" class="accent-link">fantasiafestival.com</a></p>
+                    <p class="carousel-desc"><strong>Fantasia</strong> is one of the world's leading platforms for genre cinema — championing horror, science fiction, fantasy, action, animation and cult cinema. Known for its electric audience and discoveries of emerging filmmakers, the festival anchors Montreal's summer with international premieres and a programme that pushes the edges of the form.</p>
+                  </template>
+
+                  <!-- Slide 1: Access & Tickets -->
+                  <template v-if="infoSlide === 1">
+                    <div class="carousel-card-header">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="5" width="20" height="14" rx="2"/><line x1="2" y1="10" x2="22" y2="10"/></svg>
+                      <h3>Access &amp; Tickets</h3>
+                    </div>
+                    <ul class="price-list">
+                      <li><span class="price-label">Individual tickets</span><span class="price-value">On-site &amp; online</span></li>
+                      <li><span class="price-label">Festival passes</span><span class="price-value">Multi-day bundles</span></li>
+                      <li><span class="price-label">Industry &amp; press accreditation</span><span class="price-value">Application-based</span></li>
+                    </ul>
+                    <p class="carousel-desc">Pricing, pass tiers and on-sale dates are published by the festival closer to the opening. Tickets are made available through the official Fantasia box office and partner venues across Montreal.</p>
+                    <p class="carousel-desc"><strong>Audience-driven atmosphere:</strong> screenings at Fantasia are famously interactive — expect packed houses, loud reactions and director Q&amp;As.</p>
+                  </template>
+
+                  <!-- Slide 2: Venues -->
+                  <template v-if="infoSlide === 2">
+                    <div class="carousel-card-header">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"/><circle cx="12" cy="10" r="3"/></svg>
+                      <h3>Venues</h3>
+                    </div>
+                    <div class="venue-list">
+                      <div class="venue-item"><strong>Concordia Hall Theatre</strong><span>1455 De Maisonneuve Blvd W, Montreal</span></div>
+                      <div class="venue-item"><strong>J.A. de Sève Cinema</strong><span>Concordia University, Montreal</span></div>
+                      <div class="venue-item"><strong>Cinémathèque Québécoise</strong><span>335 De Maisonneuve Blvd E, Montreal</span></div>
+                      <div class="venue-item"><strong>Additional partner venues</strong><span>Announced with the festival programme</span></div>
+                    </div>
+                  </template>
+                </div>
+              </transition>
+            </div>
+
+            <button class="carousel-arrow right" @click="nextSlide" aria-label="Next">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg>
+            </button>
+          </div>
+
+          <div class="carousel-dots">
+            <button v-for="i in 3" :key="i" class="dot" :class="{ active: infoSlide === i - 1 }" @click="goToSlide(i - 1)" :aria-label="`Slide ${i}`"></button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, nextTick } from 'vue';
+import Loader from '~/components/Loader.vue';
+import WinnersCarousel from '~/components/festival/WinnersCarousel.vue';
+import FestivalDataDisclaimer from '~/components/FestivalDataDisclaimer.vue';
+import FantasiaCard from '~/components/FantasiaCard.vue';
+
+const activeTab = ref('films');
+const scheduleSearch = ref('');
+const isScheduleSearchActive = ref(false);
+const scheduleSearchInput = ref(null);
+
+const normalizeText = (str) => {
+    if (!str) return '';
+    return String(str).toLowerCase().normalize('NFD').replace(/\p{Diacritic}/gu, '');
+};
+
+const scheduleSearchActiveQuery = computed(() => {
+    if (!isScheduleSearchActive.value) return '';
+    return scheduleSearch.value.trim();
+});
+
+const toggleScheduleSearch = () => {
+    isScheduleSearchActive.value = !isScheduleSearchActive.value;
+    if (!isScheduleSearchActive.value) {
+        scheduleSearch.value = '';
+    } else {
+        nextTick(() => scheduleSearchInput.value?.focus());
+    }
+};
+
+const closeScheduleSearch = () => {
+    isScheduleSearchActive.value = false;
+    scheduleSearch.value = '';
+};
+
+const clearScheduleSearch = () => {
+    scheduleSearch.value = '';
+    nextTick(() => scheduleSearchInput.value?.focus());
+};
+const infoSlide = ref(0);
+const slideDirection = ref('carousel-next');
+const prevSlide = () => { slideDirection.value = 'carousel-prev'; infoSlide.value = (infoSlide.value - 1 + 3) % 3; };
+const nextSlide = () => { slideDirection.value = 'carousel-next'; infoSlide.value = (infoSlide.value + 1) % 3; };
+const goToSlide = (i) => { slideDirection.value = i > infoSlide.value ? 'carousel-next' : 'carousel-prev'; infoSlide.value = i; };
+const loading = ref(true);
+const films = ref({ results: [] });
+const awards = ref([]);
+const schedule = ref([]);
+const openDays = ref(new Set());
+
+const featuresOpen = ref(true);
+const shortsOpen = ref(true);
+
+// Features/Shorts split per Fantasia issue #336 (runtime threshold ≥ 40 min).
+const features = computed(() => {
+    return films.value?.results?.filter(f => !f.runtime || f.runtime >= 40) || [];
+});
+
+const shorts = computed(() => {
+    return films.value?.results?.filter(f => f.runtime > 0 && f.runtime < 40) || [];
+});
+
+const formatDate = (dateStr) => {
+    const options = { weekday: 'long', month: 'long', day: 'numeric' };
+    return new Date(dateStr).toLocaleDateString('en-US', options);
+};
+
+const formatTime = (timeStr) => {
+    return new Date(timeStr).toLocaleTimeString('en-US', {
+        hour: '2-digit',
+        minute: '2-digit'
+    });
+};
+
+const filteredSchedule = computed(() => {
+    const q = scheduleSearchActiveQuery.value;
+    if (!q) return schedule.value;
+    const needle = normalizeText(q);
+    return schedule.value.filter(s => {
+        const title = normalizeText(s.film?.title);
+        const director = normalizeText(s.film?.director);
+        return title.includes(needle) || director.includes(needle);
+    });
+});
+
+const groupedScreenings = computed(() => {
+    const source = filteredSchedule.value;
+    if (!source) return {};
+    const groups = {};
+    source.forEach(s => {
+        const dateKey = s.start_time.split('T')[0];
+        if (!groups[dateKey]) groups[dateKey] = [];
+        groups[dateKey].push(s);
+    });
+    return Object.keys(groups).sort().reduce((obj, key) => {
+        obj[key] = groups[key];
+        return obj;
+    }, {});
+});
+
+const toggleDay = (date) => {
+    if (openDays.value.has(date)) {
+        openDays.value.delete(date);
+    } else {
+        openDays.value.add(date);
+    }
+};
+
+const isOpen = (date) => {
+    if (scheduleSearchActiveQuery.value) return true;
+    return openDays.value.has(date);
+};
+
+onMounted(async () => {
+    try {
+        const [filmsData, scheduleData, awardsData] = await Promise.all([
+            $fetch('/api/festival/fantasia/films?limit=400&sort=title'),
+            $fetch('/api/festival/fantasia/schedule'),
+            $fetch('/api/festival/fantasia/awards').catch(() => ({ results: [] })),
+        ]);
+
+        films.value = filmsData;
+        awards.value = awardsData.results || [];
+        schedule.value = scheduleData.results || [];
+
+        if (schedule.value.length > 0) {
+            const dates = new Set(schedule.value.map(s => s.start_time.split('T')[0]));
+            dates.forEach(d => openDays.value.add(d));
+        }
+
+    } catch (e) {
+        console.error('Error fetching festival data', e);
+    } finally {
+        loading.value = false;
+    }
+});
+</script>
+
+<style lang="scss" scoped>
+@use '~/assets/css/utilities/variables' as *;
+
+:deep(.card__name) {
+    font-size: 1.2rem;
+}
+
+.film-category {
+    margin-bottom: 2.5rem;
+}
+
+// Compact catalog cards (~25%+ smaller than global default).
+// Scoped to .films-grid so other listings (home, search, etc.) are untouched.
+// Uses :deep() because festival cards are child components (scoped CSS).
+.films-grid :deep(.listing__items > .card) {
+    width: 25%;
+
+    @media (min-width: 640px) {
+        width: 20%;
+    }
+    @media (min-width: 1024px) {
+        width: 14.2857143%;
+    }
+    @media (min-width: 1500px) {
+        width: 12.5%;
+    }
+    @media (min-width: 1800px) {
+        width: 11.1111111%;
+    }
+    @media (min-width: 2500px) {
+        width: 10%;
+    }
+}
+
+
+
+.category-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    cursor: pointer;
+    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
+    padding-bottom: 5px;
+    margin-bottom: 15px;
+    transition: border-color 0.2s;
+    user-select: none;
+
+    &:hover {
+        border-color: rgba(139, 233, 253, 0.6);
+    }
+}
+
+.category-title {
+    margin: 0 !important;
+}
+
+.category-count {
+    font-size: 1.1rem;
+    color: rgba(255, 255, 255, 0.6);
+    margin-left: 10px;
+    font-weight: normal;
+}
+
+.expand-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.3);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: #fff;
+    width: 36px;
+    height: 36px;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    flex-shrink: 0;
+
+    &:hover {
+        background: rgba(139, 233, 253, 0.15);
+        color: #8BE9FD;
+        border-color: rgba(139, 233, 253, 0.3);
+    }
+
+    svg {
+        width: 20px;
+        height: 20px;
+        min-width: 20px;
+        min-height: 20px;
+        display: block;
+    }
+}
+
+.header-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-bottom: 2rem;
+}
+
+.switcher-container {
+    display: flex;
+    top: 3.5rem;
+    position: relative;
+    justify-content: center;
+    gap: 1.5rem;
+    align-items: center;
+}
+
+.segmented-control {
+    position: relative;
+    display: flex;
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 20px;
+    padding: 4px;
+    height: 48px;
+    align-items: center;
+    min-width: 420px;
+}
+
+.segmented-control input[type="radio"] {
+    display: none;
+}
+
+.segmented-control label {
+    position: relative;
+    z-index: 2;
+    flex: 1;
+    text-align: center;
+    font-size: 1.1rem;
+    color: rgba(255, 255, 255, 0.6);
+    cursor: pointer;
+    transition: color 0.3s;
+    font-weight: 600;
+    line-height: 40px;
+    white-space: nowrap;
+    user-select: none;
+}
+
+.segmented-control input:checked + label {
+    color: #000;
+}
+
+.segmented-control .glider {
+    position: absolute;
+    top: 4px;
+    left: 4px;
+    height: calc(100% - 8px);
+    width: calc((100% - 8px) / 3);
+    background: #8BE9FD;
+    border-radius: 16px;
+    z-index: 1;
+    transition: transform 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
+}
+
+.segmented-control .glider.info { transform: translateX(0); }
+.segmented-control .glider.films { transform: translateX(100%); }
+.segmented-control .glider.schedule { transform: translateX(200%); }
+
+
+.festival-hero {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    position: relative;
+    border-radius: 15px;
+    overflow: hidden;
+    background-color: transparent;
+    display: flex;
+    justify-content: center;
+    border: 1px solid #8BE9FD;
+}
+
+.back-link {
+    position: absolute;
+    top: 30px;
+    left: 30px;
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+    color: #fff;
+    text-decoration: none;
+    font-weight: 700;
+    font-size: 1.4rem;
+    background: rgba(0, 0, 0, 0.6);
+    padding: 12px 24px;
+    border-radius: 30px;
+    backdrop-filter: blur(10px);
+    transition: all 0.3s ease;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    box-shadow: 0 4px 15px rgba(0,0,0,0.3);
+
+    &:hover {
+        background: #fff;
+        color: #000;
+        transform: translateY(-2px) scale(1.05);
+        box-shadow: 0 8px 25px rgba(0,0,0,0.4);
+        border-color: #fff;
+    }
+
+    svg {
+        width: 24px;
+        height: 24px;
+    }
+
+    @media (max-width: 768px) {
+        top: 20px;
+        left: 20px;
+        font-size: 0.9rem;
+        padding: 8px 16px;
+
+        svg {
+            width: 18px;
+            height: 18px;
+        }
+    }
+}
+
+.hero-backdrop {
+    width: 100%;
+    height: auto;
+    position: relative;
+
+    img {
+        width: 100%;
+        height: auto;
+        display: block;
+        object-fit: contain;
+    }
+
+    .hero-overlay {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: linear-gradient(to bottom, rgba(0, 0, 0, 0.2), rgb(27 77 95 / 7%));
+        pointer-events: none;
+    }
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px 20px;
+}
+
+.loader-container {
+    display: flex;
+    justify-content: center;
+    padding: 3rem;
+}
+
+.schedule-container, .info-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+}
+
+
+
+:deep(.winners-carousel) {
+    max-width: 1200px;
+}
+
+.day-header {
+    font-size: 1.8rem;
+    color: #fff;
+    border-bottom: 1px solid #333;
+    padding-bottom: 0.5rem;
+    margin-top: 3rem;
+    margin-bottom: 1.5rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    cursor: pointer;
+    user-select: none;
+
+    h2 {
+        font-size: 1.8rem;
+        margin: 0;
+    }
+
+    .chevron {
+        transition: transform 0.3s ease;
+
+        &.closed {
+            transform: rotate(-90deg);
+        }
+    }
+}
+
+.slide-enter-active,
+.slide-leave-active {
+  transition: all 0.3s ease-out;
+  max-height: 2000px;
+  opacity: 1;
+  overflow: hidden;
+}
+
+.slide-enter-from,
+.slide-leave-to {
+  max-height: 0;
+  opacity: 0;
+  margin-bottom: 0;
+}
+
+.screening-card {
+    display: flex;
+    background: #0a161b;
+    border: 1px solid #8BE9FD;
+    border-radius: 8px;
+    padding: 1.5rem;
+    margin-bottom: 1rem;
+    gap: 1.5rem;
+    transition: transform 0.2s;
+}
+
+.time-block {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-width: 80px;
+    border-right: 1px solid #333;
+    padding-right: 1.5rem;
+
+    .time {
+        font-size: 1.2rem;
+        font-weight: 700;
+        color: #fff;
+    }
+    .timezone {
+        font-size: 0.92rem;
+        color: #888;
+    }
+}
+
+.film-info {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+
+    .film-title {
+        font-size: 1.6rem;
+        font-weight: 700;
+        color: #fff;
+        text-decoration: none;
+        margin-bottom: 0.5rem;
+
+        &:hover {
+            color: #8BE9FD;
+        }
+    }
+
+    .film-meta {
+        font-size: 1.05rem;
+        color: #aaa;
+        margin-bottom: 0.8rem;
+    }
+
+    .venue-info {
+        font-size: 1.25rem;
+        color: #ccc;
+        margin-bottom: 0.8rem;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+
+        svg {
+            min-width: 18px;
+        }
+    }
+}
+
+.tags {
+    display: flex;
+    gap: 0.5rem;
+
+    .tag {
+        font-size: 0.75rem;
+        padding: 4px 8px;
+        border-radius: 4px;
+        font-weight: 600;
+        text-transform: uppercase;
+
+        &.in-person { background: rgba(52, 152, 219, 0.2); }
+        &.online { background: rgba(46, 204, 113, 0.2); color: #2ecc71; }
+        &.sold-out { background: rgba(231, 76, 60, 0.2); color: #e74c3c; }
+    }
+}
+
+.poster-mini {
+    width: 60px;
+    height: 90px;
+
+    img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        border-radius: 4px;
+    }
+}
+
+@media (max-width: 600px) {
+    .screening-card {
+        flex-direction: column;
+        gap: 1rem;
+    }
+    .time-block {
+        border-right: none;
+        border-bottom: 1px solid #333;
+        padding-right: 0;
+        padding-bottom: 1rem;
+        flex-direction: row;
+        gap: 1rem;
+        width: 100%;
+    }
+    .poster-mini {
+        display: none;
+    }
+}
+
+/* ── Carousel ─────────────────────────────── */
+.carousel-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.carousel-track {
+  flex: 1;
+  min-height: 340px;
+  overflow: hidden;
+  position: relative;
+}
+
+.carousel-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(139, 233, 253, 0.18);
+  border-radius: 20px;
+  padding: 2.2rem 2.5rem;
+  backdrop-filter: blur(12px);
+  color: rgba(255, 255, 255, 0.88);
+  line-height: 1.8;
+  min-height: 300px;
+
+  strong { color: #fff; }
+}
+
+.carousel-card-header {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  margin-bottom: 1.4rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid rgba(139, 233, 253, 0.14);
+
+  h3 {
+    font-size: 1.35rem;
+    font-weight: 700;
+    color: #8BE9FD;
+    margin: 0;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+  }
+}
+
+.carousel-desc {
+  font-size: 1.08rem;
+  margin-bottom: 1rem;
+}
+
+.carousel-arrow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 1px solid rgba(139, 233, 253, 0.25);
+  background: rgba(0, 0, 0, 0.4);
+  color: #8BE9FD;
+  cursor: pointer;
+  transition: all 0.25s ease;
+  flex-shrink: 0;
+  backdrop-filter: blur(6px);
+
+  &:hover {
+    background: rgba(139, 233, 253, 0.15);
+    border-color: #8BE9FD;
+    transform: scale(1.1);
+  }
+}
+
+.carousel-dots {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 1.4rem;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(139, 233, 253, 0.2);
+  cursor: pointer;
+  transition: all 0.3s ease;
+  padding: 0;
+
+  &.active {
+    background: #8BE9FD;
+    box-shadow: 0 0 10px rgba(139, 233, 253, 0.5);
+    transform: scale(1.25);
+  }
+
+  &:hover:not(.active) {
+    background: rgba(139, 233, 253, 0.45);
+  }
+}
+
+.carousel-next-enter-active,
+.carousel-next-leave-active,
+.carousel-prev-enter-active,
+.carousel-prev-leave-active {
+  transition: all 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.carousel-next-enter-from { opacity: 0; transform: translateX(60px); }
+.carousel-next-leave-to   { opacity: 0; transform: translateX(-60px); }
+.carousel-prev-enter-from { opacity: 0; transform: translateX(-60px); }
+.carousel-prev-leave-to   { opacity: 0; transform: translateX(60px); }
+
+@media (max-width: 600px) {
+  .carousel-wrapper { gap: 0.5rem; }
+  .carousel-card { padding: 1.5rem 1.2rem; min-height: 280px; }
+  .carousel-card-header h3 { font-size: 1.15rem; }
+  .carousel-arrow { width: 36px; height: 36px; }
+  .carousel-arrow svg { width: 18px; height: 18px; }
+}
+
+/* ── Shared card content styles ───────────── */
+.price-list {
+  list-style: none; padding: 0; margin: 1rem 0;
+  li { display: flex; justify-content: space-between; align-items: center; padding: 0.65rem 0; border-bottom: 1px dashed rgba(255,255,255,0.08); &:last-child { border: none; } }
+  .price-label { color: rgba(255,255,255,0.7); font-size: 1.05rem; }
+  .price-value { color: #8BE9FD; font-weight: 700; font-size: 1.1rem; }
+}
+
+.venue-list {
+  display: flex; flex-direction: column; gap: 0.5rem; margin: 0.5rem 0;
+  .venue-item { display: flex; justify-content: space-between; align-items: center; padding: 0.5rem 0; border-bottom: 1px solid rgba(255,255,255,0.05); span { color: rgba(255,255,255,0.5); font-size: 0.95rem; } strong { color: #fff; } }
+}
+
+.bullet-list {
+  padding-left: 1.4rem; font-size: 1.02rem;
+  li { margin-bottom: 1rem; line-height: 1.7; &::marker { color: #8BE9FD; } }
+}
+
+.accent-link {
+  color: #8BE9FD; text-decoration: none; font-weight: 600; border-bottom: 1px solid transparent; transition: border-color 0.2s;
+  &:hover { border-color: #8BE9FD; }
+}
+
+/* ── Featured YouTube embed ──────────────── */
+.youtube-embed {
+  position: relative;
+  width: 100%;
+  padding-bottom: 56.25%;
+  margin-bottom: 1.2rem;
+  border-radius: 12px;
+  overflow: hidden;
+
+  iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: none;
+    border-radius: 12px;
+  }
+}
+
+/* ── Initial-rollout banner (catalog/schedule placeholders) ─ */
+.rollout-banner {
+    display: flex;
+    gap: 1.25rem;
+    align-items: flex-start;
+    max-width: 720px;
+    margin: 2rem auto;
+    padding: 1.5rem 1.75rem;
+    background: rgba(16, 26, 35, 0.7);
+    border: 1px solid rgba(139, 233, 253, 0.22);
+    border-radius: 14px;
+    backdrop-filter: blur(8px);
+}
+
+.rollout-banner__icon {
+    flex-shrink: 0;
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    background: rgba(139, 233, 253, 0.08);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.rollout-banner__copy {
+    flex: 1;
+    color: rgba(255, 255, 255, 0.85);
+
+    h3 {
+        margin: 0 0 0.4rem;
+        font-size: 1.15rem;
+        font-weight: 700;
+        color: #8BE9FD;
+        letter-spacing: 0.3px;
+    }
+    p {
+        margin: 0;
+        font-size: 1rem;
+        line-height: 1.6;
+        color: rgba(255, 255, 255, 0.7);
+    }
+}
+
+@media (max-width: 600px) {
+    .rollout-banner {
+        flex-direction: column;
+        gap: 0.75rem;
+        padding: 1.25rem;
+    }
+}
+
+/* ── Schedule search toolbar ─────────────── */
+.schedule-toolbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    margin: 0.5rem 0 0.25rem;
+    padding: 8px 14px;
+    background: rgba(16, 26, 35, 0.6);
+    border: 1px solid rgba(139, 233, 253, 0.12);
+    border-radius: 12px;
+    backdrop-filter: blur(8px);
+    transition: border-color 0.25s ease;
+    min-height: 48px;
+}
+
+.schedule-toolbar.search-active {
+    border-color: rgba(139, 233, 253, 0.28);
+}
+
+.schedule-toolbar-info {
+    display: flex;
+    align-items: center;
+}
+
+.schedule-count {
+    font-size: 12px;
+    color: #aab1b8;
+    background: rgba(255, 255, 255, 0.04);
+    padding: 4px 10px;
+    border-radius: 20px;
+    letter-spacing: 0.3px;
+}
+
+.schedule-toolbar .search-wrapper {
+    display: flex;
+    align-items: center;
+    position: relative;
+    transition: width 0.3s ease;
+}
+
+.schedule-toolbar .search-toggle-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(139, 233, 253, 0.08);
+    color: #8BE9FD;
+    width: 36px;
+    height: 36px;
+    border-radius: 10px;
+    border: 1px solid rgba(139, 233, 253, 0.2);
+    cursor: pointer;
+    transition: all 0.2s ease;
+    flex-shrink: 0;
+    padding: 0;
+}
+
+.schedule-toolbar .search-toggle-btn:hover {
+    background: rgba(139, 233, 253, 0.18);
+    box-shadow: 0 4px 12px rgba(139, 233, 253, 0.1);
+}
+
+.schedule-toolbar .search-toggle-btn.active {
+    background: rgba(139, 233, 253, 0.22);
+    border-color: #8BE9FD;
+}
+
+.schedule-toolbar .search-input-container {
+    position: relative;
+    width: 0;
+    overflow: hidden;
+    opacity: 0;
+    margin-left: 0;
+    transition: width 0.35s cubic-bezier(0.25, 1, 0.5, 1), opacity 0.3s ease, margin-left 0.3s ease;
+}
+
+.schedule-toolbar .search-input-container.show {
+    width: 280px;
+    opacity: 1;
+    margin-left: 8px;
+}
+
+.schedule-toolbar .search-input {
+    width: 100%;
+    background: rgba(16, 26, 35, 0.7);
+    border: 1px solid rgba(139, 233, 253, 0.25);
+    color: #fff;
+    padding: 8px 32px 8px 14px;
+    border-radius: 10px;
+    font-size: 13px;
+    height: 36px;
+    transition: all 0.2s ease;
+}
+
+.schedule-toolbar .search-input:focus {
+    outline: none;
+    border-color: #8BE9FD;
+    box-shadow: 0 0 0 2px rgba(139, 233, 253, 0.2);
+    background: rgba(16, 26, 35, 0.85);
+}
+
+.schedule-toolbar .search-input::placeholder {
+    color: rgba(255, 255, 255, 0.35);
+}
+
+.schedule-toolbar .clear-search-btn {
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    color: rgba(255, 255, 255, 0.45);
+    cursor: pointer;
+    padding: 4px;
+    display: flex;
+    align-items: center;
+    border-radius: 4px;
+}
+
+.schedule-toolbar .clear-search-btn:hover {
+    color: #fff;
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.schedule-empty {
+    text-align: center;
+    padding: 3rem 1rem 1rem;
+    color: #aab1b8;
+    font-size: 0.95rem;
+
+    strong {
+        color: #8BE9FD;
+        font-weight: 600;
+    }
+}
+
+@media (max-width: 600px) {
+    .schedule-toolbar .search-input-container.show {
+        width: calc(100vw - 140px);
+        max-width: 240px;
+    }
+}
+</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -119,7 +119,7 @@ const { data: pageData, error: pageError } = useAsyncData('homepage', async () =
     // Batched: 1 HTTP request + 1 Turso `IN` query for all 11 festivals.
     // Replaces the previous fan-out of 11 parallel /api/festival/{slug}/films
     // calls that was bottlenecking the homepage at 35-38s on the slow wave.
-    const FESTIVAL_SLUGS = ['sundance','berlinale','rotterdam','slamdance','sxsw','romford','bifff','bafici','cannes','tribeca','cuff','kviff'];
+    const FESTIVAL_SLUGS = ['sundance','berlinale','rotterdam','slamdance','sxsw','romford','bifff','bafici','cannes','tribeca','cuff','kviff','fantasia'];
     const fetchAllFestivalsBatched = async (limit = 1000) => {
         try {
             const data = await $fetch(`/api/festival/films-batch?festivals=${FESTIVAL_SLUGS.join(',')}&limit=${limit}`);
@@ -165,6 +165,7 @@ const { data: pageData, error: pageError } = useAsyncData('homepage', async () =
     const tribecaList = festivalsBuckets.tribeca || [];
     const cuffList = festivalsBuckets.cuff || [];
     const kviffList = festivalsBuckets.kviff || [];
+    const fantasiaList = festivalsBuckets.fantasia || [];
     
      const FEATURED_ORDER = [
         // tribeca 2026
@@ -257,7 +258,7 @@ const { data: pageData, error: pageError } = useAsyncData('homepage', async () =
     
     const norm = (s) => s ? s.toLowerCase().replace(/[^a-z0-9]/g, '') : '';
     
-    const allFestivalFilms = [...sundanceList, ...berlinaleList, ...rotterdamList, ...slamdanceList, ...sxswList, ...romfordList, ...bifffList, ...baficiList, ...cannesList, ...tribecaList, ...cuffList, ...kviffList];
+    const allFestivalFilms = [...sundanceList, ...berlinaleList, ...rotterdamList, ...slamdanceList, ...sxswList, ...romfordList, ...bifffList, ...baficiList, ...cannesList, ...tribecaList, ...cuffList, ...kviffList, ...fantasiaList];
     
     let mixedFestivalFilms = allFestivalFilms.filter(f => {
         const t = norm(f.title);


### PR DESCRIPTION
## Summary

This Pull Request introduces comprehensive support for the **Fantasia International Film Festival 2026** across the Cinemagoria platform. This initial release wires up the frontend foundation — dedicated UI components, a new `/festival/fantasia-2026` landing page with Info / Catalog / Schedule tabs, badge integration in the Hero, homepage carousel mapping — so the experience is launch-ready while films and the official screening schedule are still being imported in parallel. Further announcements regarding additional films and the detailed screening schedule are anticipated as the festival approaches.

Replicates the KVIFF #353 / #354 initial-integration pattern (which itself mirrored Cannes #313 / #314) for Montreal's flagship genre festival (**July 16 – August 2, 2026**).

## Motivation

To expand Cinemagoria's coverage with one of the world's leading platforms for genre cinema — horror, science fiction, fantasy, action, animation and cult cinema. Fantasia is a critical destination for discoveries of emerging filmmakers and international premieres, and anchors Cinemagoria's editorial strength in the genre vertical.

## Changes

- **New `FantasiaCard.vue` Component**: dedicated card component for Fantasia selections, mirroring `SundanceCard` / `SlamdanceCard` with the Fantasia logo footer treatment (`filter: invert(1)` so the dark asset renders white).
- **New `FantasiaBadge.vue` Component**: badge component for the Hero section, mirroring `SlamdanceBadge` / `BerlinaleBadge`.
- **New `/pages/festival/fantasia-2026/index.vue` Page**:
  - Three-tab segmented control: **Info**, **Catalog**, **Schedule**.
  - **Catalog tab** uses the Features / Shorts split (runtime ≥ 40 min) per issue #336, with a rollout placeholder banner while the lineup is still being imported.
  - **Schedule tab** renders a placeholder banner until the official Fantasia schedule is published, then falls into the standard date-grouped screening cards used across the platform.
  - **Info tab** includes a featured YouTube embed (`https://www.youtube.com/watch?v=rg4jTk2EtDI`) using the same `.youtube-embed` pattern that Cannes 2026 uses, plus three carousel slides: General Information, Access & Tickets, Montreal venues (Concordia Hall, J.A. de Sève, Cinémathèque Québécoise).
- **`FestivalsCarousel.vue` Integration**: `FantasiaCard` is registered and `festival_source: 'fantasia'` is mapped to it.
- **`Hero.vue` Integration**: `FantasiaBadge` is registered, `fantasiaFilm` reactive state added, fetch wired to `/api/festival/fantasia/films?tmdb_id=…`, `MANUAL_FESTIVAL_BADGES['fantasia']` supported, and Fantasia included in the festival reset + loading sentinel block.
- **`pages/index.vue` Update**: `'fantasia'` added to the batched `FESTIVAL_SLUGS`, the bucket destructured into `fantasiaList`, and spread into `allFestivalFilms` so Fantasia selections surface in the homepage festival pipeline as data arrives.

### Already in place from prior work (untouched by this PR)

- `server/api/festival/fantasia/{films,schedule,awards}.get.ts`
- `public/festivals/fantasia/{fantasia_backdrop_2026_en.webp, fantasia_backdrop_2026_es.webp, fantasia_film_festival_2026_logo.png}`
- Fantasia entry already present in `pages/festival/index.vue` (with `comingSoon: true`)
- Slug `'fantasia'` already supported by `server/api/festival/films-batch.get.ts`

## Testing

The new Fantasia integration has been wired against the existing Fantasia endpoints (`/api/festival/fantasia/films` and `/api/festival/fantasia/schedule`):

- Navigated to `/festival/fantasia-2026` and verified correct rendering of all three tabs.
- Verified the Catalog tab renders the rollout placeholder banner cleanly when no films are returned, and falls back to the Features / Shorts split as films arrive.
- Verified the Schedule tab renders the rollout placeholder banner when no screenings exist, and would render date-grouped screening cards once the official schedule is ingested.
- Confirmed the YouTube embed renders responsively (16:9 padding-bottom) on the Info tab's first slide.
- Confirmed `FantasiaCard` renders correctly inside the carousel mapping (`festival_source: 'fantasia'`).
- Confirmed `FantasiaBadge` is registered in `Hero.vue` and would render when `/api/festival/fantasia/films?tmdb_id=…` returns a hit (verified via `MANUAL_FESTIVAL_BADGES` override path).

## Rollout note

Catalog and Schedule render intentional placeholders while data lands progressively. The page is launch-ready even with an empty or partial lineup. The page mirrors the structure shipped for KVIFF in #354 and should propagate to `cinemagoria-es`, `cinemagoria/stream` and `cinemagoria/cinemagoria-estream` after merge per the established four-repo parity rollout.

## Out of scope for this batch

- Lineup additions / second-wave announcements (future sub-issues of #336)
- Shorts programs as they are announced
- Official schedule publication + screenings ingestion (mirrors Cannes batch-4 #346)
- Awards wiring on closing day (mirrors `WinnersCarousel` integration)
- Hydration/timezone hardening (per the KVIFF code-review notes parked as "addressed for later")

## Related Issues

#355 - #336