### PR TITLE
Group Fantasia 2026 catalog by section instead of Features/Shorts

### DIFF
--- a/pages/festival/fantasia-2026/index.vue
+++ b/pages/festival/fantasia-2026/index.vue
@@ -329,7 +329,7 @@ const CATEGORY_LABELS = {
     'Cheval Noir Competition': 'Cheval Noir Competition',
     'Septentrion Shadows': 'Septentrion Shadows',
     'Les Fantastiques Week-Ends du Cinéma Québécois': 'Les Fantastiques Week-Ends du Cinéma Québécois',
-    'TBA': 'TBA',
+    'TBA': 'TBA (To be announced)',
     OTHER: 'Other',
 };
 

--- a/pages/festival/fantasia-2026/index.vue
+++ b/pages/festival/fantasia-2026/index.vue
@@ -52,7 +52,7 @@
       <div v-else>
         <div v-if="activeTab === 'films'" class="films-grid">
             <!-- Initial rollout banner: lineup is still being imported -->
-            <div v-if="features.length === 0 && shorts.length === 0" class="rollout-banner">
+            <div v-if="orderedCategories.length === 0" class="rollout-banner">
               <div class="rollout-banner__icon">
                 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
               </div>
@@ -62,44 +62,26 @@
               </div>
             </div>
 
-            <div v-if="features.length > 0" class="film-category">
-                <div class="category-header" @click="featuresOpen = !featuresOpen">
+            <div
+              v-for="cat in orderedCategories"
+              :key="cat"
+              class="film-category"
+            >
+                <div class="category-header" @click="toggleCategoryOpen(cat)">
                     <h2 class="listing__title category-title">
-                        Features
-                        <span class="category-count">({{ features.length }})</span>
+                        {{ categoryLabel(cat) }}
+                        <span class="category-count">({{ (filmsByCategory[cat] || []).length }})</span>
                     </h2>
-                    <button class="expand-btn" :aria-label="featuresOpen ? 'Collapse' : 'Expand'">
-                        <svg v-if="featuresOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
+                    <button class="expand-btn" :aria-label="isCategoryOpen(cat) ? 'Collapse' : 'Expand'">
+                        <svg v-if="isCategoryOpen(cat)" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
                         <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
                     </button>
                 </div>
                 <transition name="slide">
-                    <div v-show="featuresOpen" class="listing__items">
+                    <div v-show="isCategoryOpen(cat)" class="listing__items">
                         <FantasiaCard
-                            v-for="item in features"
-                            :key="`feature-${item.id}`"
-                            :item="item"
-                        />
-                    </div>
-                </transition>
-            </div>
-
-            <div v-if="shorts.length > 0" class="film-category">
-                <div class="category-header" @click="shortsOpen = !shortsOpen">
-                    <h2 class="listing__title category-title">
-                        Shorts
-                        <span class="category-count">({{ shorts.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="shortsOpen ? 'Collapse' : 'Expand'">
-                        <svg v-if="shortsOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
-                    </button>
-                </div>
-                <transition name="slide">
-                    <div v-show="shortsOpen" class="listing__items">
-                        <FantasiaCard
-                            v-for="item in shorts"
-                            :key="`short-${item.id}`"
+                            v-for="item in (filmsByCategory[cat] || [])"
+                            :key="`${cat}-${item.id}`"
                             :item="item"
                         />
                     </div>
@@ -333,17 +315,54 @@ const awards = ref([]);
 const schedule = ref([]);
 const openDays = ref(new Set());
 
-const featuresOpen = ref(true);
-const shortsOpen = ref(true);
+// Fantasia 2026 first-wave sections (#357). The OTHER bucket catches any
+// section that arrives in later waves before it gets added to CATEGORY_ORDER,
+// so newly announced films never disappear between releases.
+const CATEGORY_ORDER = [
+    'Cheval Noir Competition',
+    'Septentrion Shadows',
+    'Les Fantastiques Week-Ends du Cinéma Québécois',
+    'TBA',
+];
 
-// Features/Shorts split per Fantasia issue #336 (runtime threshold ≥ 40 min).
-const features = computed(() => {
-    return films.value?.results?.filter(f => !f.runtime || f.runtime >= 40) || [];
+const CATEGORY_LABELS = {
+    'Cheval Noir Competition': 'Cheval Noir Competition',
+    'Septentrion Shadows': 'Septentrion Shadows',
+    'Les Fantastiques Week-Ends du Cinéma Québécois': 'Les Fantastiques Week-Ends du Cinéma Québécois',
+    'TBA': 'TBA',
+    OTHER: 'Other',
+};
+
+const categoryOpen = ref({});
+
+const filmsByCategory = computed(() => {
+    const map = Object.fromEntries(CATEGORY_ORDER.map((c) => [c, []]));
+    map.OTHER = [];
+    for (const f of films.value?.results || []) {
+        const key = String(f.category || f.section || '').trim();
+        if (key && map[key] !== undefined) map[key].push(f);
+        else map.OTHER.push(f);
+    }
+    return map;
 });
 
-const shorts = computed(() => {
-    return films.value?.results?.filter(f => f.runtime > 0 && f.runtime < 40) || [];
+const orderedCategories = computed(() => {
+    const out = CATEGORY_ORDER.filter((c) => (filmsByCategory.value[c] || []).length > 0);
+    if ((filmsByCategory.value.OTHER || []).length > 0) out.push('OTHER');
+    return out;
 });
+
+function categoryLabel (cat) {
+    return CATEGORY_LABELS[cat] || cat;
+}
+
+function isCategoryOpen (cat) {
+    return categoryOpen.value[cat] !== false;
+}
+
+function toggleCategoryOpen (cat) {
+    categoryOpen.value = { ...categoryOpen.value, [cat]: !isCategoryOpen(cat) };
+}
 
 const formatDate = (dateStr) => {
     const options = { weekday: 'long', month: 'long', day: 'numeric' };


### PR DESCRIPTION
## Summary

Refactor the Fantasia 2026 catalog tab to group films by **selection section** (mirroring KVIFF #353 / #354) instead of the Features / Shorts runtime split shipped in #356. The festival's first-wave selections have started landing in the database under named sections, and that is the natural way users discover the lineup.

## Motivation

The Features / Shorts split made sense at launch when no films had been imported yet — it was simply a fallback shape. Now that the first wave is in, sections are the right grouping. Mirror the same `CATEGORY_ORDER` + `filmsByCategory` + `orderedCategories` + `categoryLabel` + `isCategoryOpen` + `toggleCategoryOpen` pattern used by Tribeca and KVIFF so the festival pages stay structurally consistent.

## Changes

- `pages/festival/fantasia-2026/index.vue`:
  - Replaces the `features` / `shorts` computeds and `featuresOpen` / `shortsOpen` toggles with section-aware state.
  - New `CATEGORY_ORDER`:
    1. `Cheval Noir Competition`
    2. `Septentrion Shadows`
    3. `Les Fantastiques Week-Ends du Cinéma Québécois`
    4. `TBA` *(placeholder for films whose official section is still pending)*
  - `OTHER` bucket catches any section that arrives in later waves before it gets added to `CATEGORY_ORDER`, so newly announced films never disappear between releases.
  - Rollout placeholder banner now triggers on `orderedCategories.length === 0` instead of `features.length === 0 && shorts.length === 0`.

## Testing

- Verified the catalog grid renders one collapsible group per active section, populated by `f.category || f.section`.
- Confirmed the placeholder banner still appears when no films are returned.
- Verified that a film whose `section` is not in `CATEGORY_ORDER` lands in the `OTHER` bucket and remains visible.

## Out of scope

- Additional sections not yet announced (Camera Lucida, Underground, DocAsia historically — will be added in subsequent sub-issues if/when films land under them).
- Endpoint changes — `/api/festival/fantasia/films` already returns `section` / `category` fields.

After merge, the same change will be propagated to `cinemagoria/cinemagoria@es`, `cinemagoria/stream`, `cinemagoria/cinemagoria-estream` per the established 4-repo parity rollout (direct commits, no issues / branches / PRs on those mirrors).

## Related Issues

#357 - #336