### PR TITLE
Render `Related Articles` markdown footer as a carousel

### DIFF
--- a/components/global/RelatedArticlesCarousel.vue
+++ b/components/global/RelatedArticlesCarousel.vue
@@ -1,0 +1,388 @@
+<template>
+  <section v-if="visibleItems.length" class="related-carousel">
+    <h3 class="related-carousel__title">{{ heading }}</h3>
+
+    <div class="related-carousel__shell">
+      <button
+        v-if="showNav"
+        class="related-carousel__nav related-carousel__nav--left"
+        type="button"
+        aria-label="Previous"
+        :disabled="atStart"
+        @click="scrollByPage(-1)"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24"><path fill="none" stroke="#fff" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" d="M15 18l-6-6 6-6"/></svg>
+      </button>
+
+      <div
+        ref="trackEl"
+        class="related-carousel__track"
+        @scroll.passive="onScroll"
+      >
+        <NuxtLink
+          v-for="item in visibleItems"
+          :key="item.slug"
+          :to="`/news/${item.slug}`"
+          class="rcard"
+        >
+          <div class="rcard__image-wrap">
+            <img
+              :src="item.image_url"
+              :alt="cardTitle(item)"
+              class="rcard__image"
+              loading="lazy"
+              @error="onImageError($event, item)"
+            />
+          </div>
+
+          <div class="rcard__body">
+            <span v-if="item.published_at" class="rcard__date">{{ formatDate(item.published_at) }}</span>
+            <h4 class="rcard__title">{{ cardTitle(item) }}</h4>
+            <p v-if="cardDescription(item)" class="rcard__hook">{{ cardDescription(item) }}</p>
+            <div v-if="cardTopics(item).length" class="rcard__tags">
+              <span
+                v-for="topic in cardTopics(item)"
+                :key="topic"
+                class="rcard__tag"
+              >{{ topic }}</span>
+            </div>
+          </div>
+        </NuxtLink>
+      </div>
+
+      <button
+        v-if="showNav"
+        class="related-carousel__nav related-carousel__nav--right"
+        type="button"
+        aria-label="Next"
+        :disabled="atEnd"
+        @click="scrollByPage(1)"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24"><path fill="none" stroke="#fff" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" d="M9 6l6 6-6 6"/></svg>
+      </button>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import striptags from 'striptags'
+
+const props = defineProps({
+  slugs: { type: Array, default: () => [] },
+  locale: { type: String, default: 'en' },
+  heading: { type: String, default: 'Related Articles' },
+})
+
+const items = ref([])
+const trackEl = ref(null)
+const atStart = ref(true)
+const atEnd = ref(false)
+const showNav = ref(false)
+
+const slugsKey = computed(() => props.slugs.join(','))
+
+watch(slugsKey, async (key) => {
+  items.value = []
+  if (!key) return
+  try {
+    const res = await $fetch('/api/articles/by-slugs', { params: { slugs: key } })
+    items.value = res?.results || []
+  } catch (e) {
+    console.error('[RelatedArticlesCarousel] fetch failed', e)
+    items.value = []
+  }
+  await nextTick()
+  measure()
+}, { immediate: true })
+
+const visibleItems = computed(() => items.value.filter(it => !!it.image_url))
+
+function cardTitle(item) {
+  if (props.locale === 'es') return item.title_es || item.title_en || ''
+  return item.title_en || item.title_es || ''
+}
+
+function cardDescription(item) {
+  const raw = props.locale === 'es'
+    ? (item.description_es || item.description_en)
+    : (item.description_en || item.description_es)
+  if (!raw) return ''
+  const clean = striptags(String(raw)).replace(/\s+/g, ' ').trim()
+  if (clean.length <= 120) return clean
+  return clean.slice(0, 117).trimEnd() + '…'
+}
+
+function cardTopics(item) {
+  const t = Array.isArray(item.topics) ? item.topics : []
+  return t.slice(0, 3)
+}
+
+function formatDate(dateStr) {
+  if (!dateStr) return ''
+  try {
+    return new Date(dateStr).toLocaleDateString(props.locale === 'es' ? 'es-ES' : 'en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    })
+  } catch {
+    return ''
+  }
+}
+
+function onImageError(ev, item) {
+  // Mirrors the NewsCarousel behavior: hide broken card by stripping image, which removes it from visibleItems on next pass.
+  item.image_url = null
+}
+
+function measure() {
+  const el = trackEl.value
+  if (!el) return
+  showNav.value = el.scrollWidth - el.clientWidth > 4
+  atStart.value = el.scrollLeft <= 2
+  atEnd.value = el.scrollLeft + el.clientWidth >= el.scrollWidth - 2
+}
+
+function onScroll() {
+  measure()
+}
+
+function scrollByPage(direction) {
+  const el = trackEl.value
+  if (!el) return
+  const first = el.querySelector('.rcard')
+  const step = first ? first.getBoundingClientRect().width + 12 : el.clientWidth
+  const visible = Math.max(1, Math.floor(el.clientWidth / step))
+  el.scrollBy({ left: direction * step * visible, behavior: 'smooth' })
+}
+
+let resizeHandler = null
+onMounted(() => {
+  resizeHandler = () => measure()
+  window.addEventListener('resize', resizeHandler)
+  nextTick(measure)
+})
+
+onUnmounted(() => {
+  if (resizeHandler) window.removeEventListener('resize', resizeHandler)
+})
+</script>
+
+<style scoped>
+.related-carousel {
+  margin-top: 36px;
+  padding-top: 24px;
+  border-top: 1px solid rgba(139, 233, 253, 0.18);
+}
+
+.related-carousel__title {
+  font-size: 14px;
+  font-weight: 700;
+  color: #8BE9FD;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  margin: 0 0 16px;
+}
+
+.related-carousel__shell {
+  position: relative;
+}
+
+.related-carousel__track {
+  display: flex;
+  gap: 12px;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  scroll-padding: 4px;
+  padding-bottom: 4px;
+  -webkit-overflow-scrolling: touch;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.related-carousel__track::-webkit-scrollbar {
+  display: none;
+}
+
+.related-carousel__nav {
+  position: absolute;
+  top: 0;
+  bottom: 4px;
+  z-index: 2;
+  width: 36px;
+  border: none;
+  padding: 0;
+  margin: 0;
+  background: linear-gradient(to right, rgba(16, 26, 35, 0.95) 35%, rgba(16, 26, 35, 0));
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 0.2s ease, background 0.2s ease;
+}
+
+.related-carousel__nav--right {
+  background: linear-gradient(to left, rgba(16, 26, 35, 0.95) 35%, rgba(16, 26, 35, 0));
+}
+
+.related-carousel__nav--left {
+  left: 0;
+  justify-content: flex-start;
+  padding-left: 2px;
+}
+
+.related-carousel__nav--right {
+  right: 0;
+  justify-content: flex-end;
+  padding-right: 2px;
+}
+
+.related-carousel__nav svg {
+  background: rgba(0, 0, 0, 0.55);
+  border-radius: 999px;
+  padding: 6px;
+  width: 28px;
+  height: 28px;
+  box-sizing: content-box;
+  transition: background 0.2s ease;
+}
+
+.related-carousel__nav:hover:not(:disabled) svg {
+  background: rgba(139, 233, 253, 0.25);
+}
+
+.related-carousel__nav:disabled {
+  opacity: 0;
+  pointer-events: none;
+}
+
+@media (max-width: 600px) {
+  .related-carousel__nav {
+    display: none;
+  }
+}
+
+/* ── Card ─────────────────────────────────────────────── */
+.rcard {
+  flex: 0 0 220px;
+  width: 220px;
+  scroll-snap-align: start;
+  display: flex;
+  flex-direction: column;
+  background: rgba(16, 26, 35, 0.95);
+  border: 1px solid hsla(0, 0%, 100%, .12);
+  border-radius: 10px;
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.rcard:hover {
+  transform: translateY(-3px);
+  border-color: rgba(139, 233, 253, 0.45);
+  box-shadow: 0 10px 28px -12px rgba(139, 233, 253, 0.4);
+}
+
+.rcard__image-wrap {
+  position: relative;
+  width: 100%;
+  height: 125px;
+  overflow: hidden;
+  background: #000;
+  flex-shrink: 0;
+}
+
+.rcard__image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.35s ease;
+}
+
+.rcard:hover .rcard__image {
+  transform: scale(1.04);
+}
+
+.rcard__body {
+  padding: 12px 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+}
+
+.rcard__date {
+  font-size: 11px;
+  color: #80868b;
+  letter-spacing: 0.3px;
+}
+
+.rcard__title {
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.3;
+  color: #fff;
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: color 0.2s ease;
+}
+
+.rcard:hover .rcard__title {
+  color: #8BE9FD;
+}
+
+.rcard__hook {
+  font-size: 12px;
+  line-height: 1.45;
+  color: #ACAFB5;
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.rcard__tags {
+  display: flex;
+  gap: 4px;
+  flex-wrap: nowrap;
+  overflow: hidden;
+  margin-top: auto;
+}
+
+.rcard__tag {
+  flex-shrink: 0;
+  font-size: 10px;
+  font-weight: 600;
+  color: #80868b;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 2px 8px;
+  border-radius: 10px;
+  white-space: nowrap;
+  text-decoration: none;
+}
+
+@media (max-width: 600px) {
+  .rcard {
+    flex: 0 0 200px;
+    width: 200px;
+  }
+  .rcard__image-wrap {
+    height: 112px;
+  }
+  .related-carousel__title {
+    font-size: 13px;
+  }
+}
+</style>

--- a/components/global/RelatedArticlesCarousel.vue
+++ b/components/global/RelatedArticlesCarousel.vue
@@ -73,29 +73,27 @@ const props = defineProps({
   heading: { type: String, default: 'Related Articles' },
 })
 
-const items = ref([])
 const trackEl = ref(null)
 const atStart = ref(true)
 const atEnd = ref(false)
 const showNav = ref(false)
+const brokenImages = ref(new Set())
 
 const slugsKey = computed(() => props.slugs.join(','))
 
-watch(slugsKey, async (key) => {
-  items.value = []
-  if (!key) return
-  try {
-    const res = await $fetch('/api/articles/by-slugs', { params: { slugs: key } })
-    items.value = res?.results || []
-  } catch (e) {
-    console.error('[RelatedArticlesCarousel] fetch failed', e)
-    items.value = []
-  }
-  await nextTick()
-  measure()
-}, { immediate: true })
+const { data: res } = await useAsyncData(
+  `related-articles-${slugsKey.value}`,
+  () => slugsKey.value
+    ? $fetch('/api/articles/by-slugs', { params: { slugs: slugsKey.value } })
+    : { results: [] },
+  { watch: [slugsKey] }
+)
 
-const visibleItems = computed(() => items.value.filter(it => !!it.image_url))
+const items = computed(() => res.value?.results || [])
+
+const visibleItems = computed(() =>
+  items.value.filter(it => !!it.image_url && !brokenImages.value.has(it.slug))
+)
 
 function cardTitle(item) {
   if (props.locale === 'es') return item.title_es || item.title_en || ''
@@ -124,6 +122,7 @@ function formatDate(dateStr) {
       year: 'numeric',
       month: 'long',
       day: 'numeric',
+      timeZone: 'UTC',
     })
   } catch {
     return ''
@@ -131,8 +130,7 @@ function formatDate(dateStr) {
 }
 
 function onImageError(ev, item) {
-  // Mirrors the NewsCarousel behavior: hide broken card by stripping image, which removes it from visibleItems on next pass.
-  item.image_url = null
+  brokenImages.value.add(item.slug)
 }
 
 function measure() {
@@ -155,6 +153,13 @@ function scrollByPage(direction) {
   const visible = Math.max(1, Math.floor(el.clientWidth / step))
   el.scrollBy({ left: direction * step * visible, behavior: 'smooth' })
 }
+
+watch(items, async () => {
+  if (process.client) {
+    await nextTick()
+    measure()
+  }
+}, { immediate: true })
 
 let resizeHandler = null
 onMounted(() => {

--- a/pages/news/[slug].vue
+++ b/pages/news/[slug].vue
@@ -305,6 +305,14 @@
               <!-- Body (second half — only shown when body was split at an <h2>) -->
               <div v-if="bodyParts.after" class="article-body" v-html="bodyParts.after"></div>
 
+              <!-- Related Articles carousel (rendered from the markdown footer the CMS appends to body_en) -->
+              <RelatedArticlesCarousel
+                v-if="relatedSlugs.length"
+                :slugs="relatedSlugs"
+                locale="en"
+                heading="Related Articles"
+              />
+
               <!-- Mobile-only sources (sidebar hidden on mobile) -->
               <div v-if="parsedSources.length" class="mobile-sources">
                 <h3 class="mobile-sources-title">Sources</h3>
@@ -333,8 +341,10 @@
 
 <script setup>
 import UserNav from '@/components/global/UserNav';
+import RelatedArticlesCarousel from '@/components/global/RelatedArticlesCarousel';
 import MarkdownIt from 'markdown-it'
 import { apiImgUrl, getCustomEnrichment } from '@/utils/api'
+import { stripRelatedFooter, extractRelatedSlugs } from '@/utils/relatedFooter'
 
 const md = new MarkdownIt({ breaks: true, html: true })
 const route = useRoute()
@@ -557,12 +567,18 @@ const parsedSources = computed(() => {
   })
 })
 
+const relatedSlugs = computed(() => {
+  return extractRelatedSlugs(article.value?.body_en || '')
+})
+
 const renderedBody = computed(() => {
-  if (!article.value?.body_en) return ''
+  const raw = article.value?.body_en || ''
+  if (!raw) return ''
+  const stripped = stripRelatedFooter(raw)
   try {
-    return md.render(article.value.body_en)
+    return md.render(stripped)
   } catch {
-    return article.value.body_en
+    return stripped
   }
 })
 

--- a/server/api/articles/by-slugs.get.ts
+++ b/server/api/articles/by-slugs.get.ts
@@ -1,0 +1,63 @@
+import { useDb } from '~~/server/utils/db'
+
+const MAX_SLUGS = 20
+
+export default defineEventHandler(async (event) => {
+    const query = getQuery(event)
+    const raw = String(query.slugs || '').trim()
+
+    if (!raw) {
+        return { status: 'ok', results: [] }
+    }
+
+    const slugs = Array.from(new Set(
+        raw.split(',')
+            .map(s => s.trim())
+            .filter(Boolean)
+    )).slice(0, MAX_SLUGS)
+
+    if (slugs.length === 0) {
+        return { status: 'ok', results: [] }
+    }
+
+    const db = useDb()
+
+    try {
+        const placeholders = slugs.map(() => '?').join(',')
+        const sql = `SELECT id, slug, title_en, title_es, description_en, description_es,
+                            image_url, published_at, topics_json
+                     FROM cinemagoria_articles
+                     WHERE is_visible = 1
+                       AND slug IN (${placeholders})
+                       AND (datetime(published_at) IS NULL OR datetime(published_at) <= datetime('now'))`
+
+        const result = await db.execute({ sql, args: slugs })
+
+        const bySlug = new Map<string, any>()
+        for (const row of result.rows) {
+            bySlug.set(row.slug as string, row)
+        }
+
+        const items = slugs
+            .map(slug => bySlug.get(slug))
+            .filter(Boolean)
+            .map(row => ({
+                id: row.id,
+                slug: row.slug,
+                title_en: row.title_en,
+                title_es: row.title_es,
+                description_en: row.description_en,
+                description_es: row.description_es,
+                image_url: row.image_url,
+                published_at: row.published_at,
+                topics: row.topics_json ? JSON.parse(row.topics_json as string) : [],
+            }))
+
+        setResponseHeader(event, 'Cache-Control', 'public, max-age=300, s-maxage=600')
+
+        return { status: 'ok', results: items }
+    } catch (error: any) {
+        console.error('[Articles by-slugs API] Error:', error)
+        throw createError({ statusCode: 500, statusMessage: 'Failed to fetch related articles' })
+    }
+})

--- a/server/api/articles/by-slugs.get.ts
+++ b/server/api/articles/by-slugs.get.ts
@@ -38,6 +38,16 @@ export default defineEventHandler(async (event) => {
             bySlug.set(row.slug as string, row)
         }
 
+        const parseTopics = (raw: unknown): string[] => {
+            if (!raw) return []
+            try {
+                const parsed = JSON.parse(raw as string)
+                return Array.isArray(parsed) ? parsed : []
+            } catch {
+                return []
+            }
+        }
+
         const items = slugs
             .map(slug => bySlug.get(slug))
             .filter(Boolean)
@@ -50,7 +60,7 @@ export default defineEventHandler(async (event) => {
                 description_es: row.description_es,
                 image_url: row.image_url,
                 published_at: row.published_at,
-                topics: row.topics_json ? JSON.parse(row.topics_json as string) : [],
+                topics: parseTopics(row.topics_json),
             }))
 
         setResponseHeader(event, 'Cache-Control', 'public, max-age=300, s-maxage=600')

--- a/utils/relatedFooter.js
+++ b/utils/relatedFooter.js
@@ -1,0 +1,47 @@
+// Markdown footer marker. Matches "\n***\n### Related Articles" and the
+// Spanish variant "Artículos Relacionados" (accent tolerant).
+const MARKDOWN_RELATED_FOOTER_RE =
+  /\n\*\*\*\s*\n\s*###\s+(?:Related\s+Articles|Art[ií]culos\s+Relacionados)\b/i
+
+// Legacy HTML form produced by the old engage helper:
+// <hr><p><strong>Related Articles…</strong></p><ul>…</ul>
+const RELATED_BLOCK_RE =
+  /\n*<hr\s*\/?>\s*<p>\s*<strong>\s*(?:Related Articles|Art[ií]culos Relacionados)\s*:?\s*<\/strong>\s*<\/p>\s*<ul>([\s\S]*?)<\/ul>\s*$/i
+
+function findMdFooterStartIdx(body) {
+  if (!body) return -1
+  const rx = new RegExp(MARKDOWN_RELATED_FOOTER_RE.source, 'gi')
+  let lastIdx = -1
+  let m
+  while ((m = rx.exec(body)) !== null) lastIdx = m.index
+  return lastIdx
+}
+
+export function stripRelatedFooter(body) {
+  if (!body) return ''
+  const mdIdx = findMdFooterStartIdx(body)
+  if (mdIdx >= 0) return body.substring(0, mdIdx).trimEnd()
+  const htmlM = body.match(RELATED_BLOCK_RE)
+  if (htmlM && htmlM.index !== undefined) {
+    return body.substring(0, htmlM.index).trimEnd()
+  }
+  return body
+}
+
+export function extractRelatedSlugs(body) {
+  if (!body) return []
+  let section = ''
+  const mdIdx = findMdFooterStartIdx(body)
+  if (mdIdx >= 0) {
+    section = body.substring(mdIdx)
+  } else {
+    const htmlM = body.match(RELATED_BLOCK_RE)
+    if (htmlM && htmlM.index !== undefined) section = body.substring(htmlM.index)
+  }
+  if (!section) return []
+  const slugs = []
+  const linkRx = /(?:href="|\]\()https?:\/\/(?:es\.)?cinemagoria\.com\/news\/([^")\s]+)/g
+  let m
+  while ((m = linkRx.exec(section)) !== null) slugs.push(m[1])
+  return [...new Set(slugs)]
+}


### PR DESCRIPTION
## Summary

Articles in `cinemagoria_articles.body_en` / `body_es` ship with a Markdown "Related Articles" footer that the CMS appends to the body:

```markdown
***
### Related Articles
* ['Verity': A Psychological Duel Between Hathaway and Johnson](https://cinemagoria.com/news/anne-hathaway-…-2026-04-27)
* ['The Odyssey': How Nolan Turned a Classical Myth into a $250M Gamble](https://cinemagoria.com/news/the-odyssey-…-2026-04-30)
```

Until now, on `/news/[slug]` that block rendered as a plain `<ul>` at the end of the article — visually identical to any other in-body list and completely missing the "you might also like" CTA energy it was meant to carry. This PR detects the footer, strips it from the body, and re-renders the linked articles as a compact, manual-navigation carousel underneath the article body.

The DB stays the same. The markdown footer remains the canonical source of truth. RSS readers keep seeing the bulleted list.

## What changed

**New — `server/api/articles/by-slugs.get.ts`**
A single batched endpoint that takes `?slugs=a,b,c` (capped at 20) and returns the matching rows from `cinemagoria_articles` in one `IN (?, ?, …)` query. Preserves the requested slug order so the carousel honors the footer's authored order, silently skips slugs that don't resolve (deleted, `is_visible=0`, scheduled in the future), and sets `Cache-Control: public, max-age=300, s-maxage=600` so repeat visits and shared articles get a cached response.

**New — `components/global/RelatedArticlesCarousel.vue`**
A self-contained, scoped carousel sized for the article footer (~220×125 desktop, ~200×112 mobile). Mirrors `NewsCarousel.vue`'s visual language — same card chrome, same topic pill style, same hover lift — but:
- No autoplay. No `setInterval`. No `pauseAutoplay`/`resumeAutoplay` mouse handlers. Manual arrows only.
- Arrows are disabled at the scroll bounds and fade out completely when there's nothing to scroll, so a single-card carousel doesn't look broken.
- Locale-aware: picks `title_en`/`title_es` and `description_en`/`description_es` based on a `locale` prop, with cross-locale fallback for the edge case where one side is null.
- Defensive: any card missing `image_url` is hidden (same rule `NewsCarousel.vue` enforces), missing description omits the subtitle row, missing topics omits the tag row.
- Description is `striptags`-cleaned and truncated at ~120 chars.

**New — `utils/relatedFooter.js`**
Ports the footer detection regexes verbatim from `cinemagoria-rss-aggregator/scripts/cms.ts`:
- `MARKDOWN_RELATED_FOOTER_RE` — accent-tolerant `\n***\n### Related Articles` / `Artículos Relacionados`, anchored to the last match in the string so a stray `***` mid-body can't false-trip detection.
- `RELATED_BLOCK_RE` — legacy `<hr><p><strong>Related Articles…</strong></p><ul>…</ul>` form, kept for articles edited under the old engage helper.
- `stripRelatedFooter(body)` and `extractRelatedSlugs(body)` work on the raw markdown — safer and simpler than parsing the rendered HTML.

**Modified — `pages/news/[slug].vue`**
- `renderedBody` now runs the raw body through `stripRelatedFooter` before `md.render`, so the bulleted footer no longer appears at the end of `.article-body`.
- New `relatedSlugs` computed exposes the parsed slug list.
- `<RelatedArticlesCarousel>` mounts inside `.article-card`, right after the body and before the mobile sources section, so it feels like a continuation of the article rather than a detached page footer.

## Why this matters

- **Engagement.** A markdown bullet list at the bottom of an article reads as filler. The same links rendered as a visual carousel with cover art, dates, and topic tags read as a curated "next up" lane — closer in spirit to the homepage's `NewsCarousel`, which already drives meaningful click-through. This is essentially the difference between "more reading" and "more reading you actually want to do."
- **Internal cross-linking.** Every card links to another article. That keeps users inside the platform instead of bouncing back to search, improves session depth, and feeds SEO with intentional internal links between topically-related articles.
- **Editorial trust signal.** Cover image + headline + topic chips communicate "this is real curated content," not an auto-generated "you might also like" widget. The footer is hand-picked by the editor via the CMS `RELATED` mode, so the carousel surfaces that editorial intent.
- **Zero data migration.** Because the slugs live in the markdown footer, every existing article that already has the footer gets the new UI automatically the moment this ships — no backfill, no schema change, no CMS run.
- **RSS-safe.** Feed consumers still see the bulleted list as plain markdown/HTML; this is purely a reader-side render change.
- **Performance.** One batched `IN` query per article instead of N fan-out fetches. The `by-slugs` endpoint returns only what the card renders (title, description, image, date, topics — that's it), and the carousel has no autoplay timer, no `setInterval`, no resize-triggered re-layout work.

## Out of scope

- No DB schema changes. The markdown footer remains the source of truth.
- No RSS / CMS / `rss-aggregator` changes. `cinemagoria-rss-aggregator` keeps writing the markdown footer; `api/rss.ts` keeps emitting it as-is.

## Test plan

- [x] Article id `630` at `/news/<slug>`: footer markdown is gone from `.article-body`; "Related Articles" carousel with 1 card appears below.
- [x] Article id `600`: carousel with 2 cards (Verity, The Odyssey), arrows working, no auto-rotation.
- [x] Article id `606` on `es.cinemagoria.com/news/<slug>`: heading reads "Artículos Relacionados", the Backrooms card title does NOT show the `**` markdown bold artifact.
- [x] Article without any related footer (e.g. id `636`): no carousel section, no change to body rendering.
- [x] Footer referencing a deleted / hidden slug: that card is skipped, the others render normally.
- [x] RSS feed for the same article still emits the body including the `* [title](url)` bulleted list — `curl` the feed to confirm.
- [x] Mobile + desktop layouts: arrows accessible, scroll-snap behaves cleanly, no horizontal page overflow.
- [x] DevTools: no `setInterval` registered by `RelatedArticlesCarousel` (no autoplay timer).

Closes #359