### PR TITLE
docs(terms): announce community-gated articles effective 2026-07-01

### DIFF
--- a/pages/usage-policies/index.vue
+++ b/pages/usage-policies/index.vue
@@ -12,7 +12,7 @@
         <p class="heroDates">
           <span><strong>Effective:</strong> March 27, 2024</span>
           <span class="heroDot">&middot;</span>
-          <span><strong>Last updated:</strong> June 13, 2026</span>
+          <span><strong>Last updated:</strong> June 15, 2026</span>
         </p>
       </div>
     </header>
@@ -100,6 +100,7 @@ const sections = [
     body: `<p>The platform integrates data from public APIs and metadata providers. All trademarks and assets belong to their respective owners. Information is presented under fair use principles and for non-commercial purposes. Rights holders or publishers who wish to request content removal (<em>opt-out</em>) may contact the team as indicated in <strong>Section 8</strong>.</p>
 <p><strong>Festival data coverage:</strong> festival lineups are collected from public sources. Data availability may be incomplete, particularly for short films or works with limited presence in public sources. As a result, the number of titles displayed for a given festival may differ from its official program. These differences reflect technical limitations of external data sources and not editorial decisions.</p>
 <p><strong>News aggregation:</strong> content is obtained from publicly available RSS feeds for indexing purposes. Original news content is not modified, and only the information provided by such sources (such as title, description, and metadata) is displayed, in the format in which it is distributed. Full articles cannot be read within the platform: all interactions redirect to the original site, which is the sole environment where the complete content can be accessed, ensuring that traffic, impressions, and monetization remain exclusively with the original publisher. Additionally, the platform may publish its own editorial content generated in an automated or assisted manner from multiple public sources. Such content may involve processes of synthesis, reformulation, or automated structuring of the original information, without implying literal reproduction or exact correspondence with the source material, and is provided exclusively for informational purposes, and may contain errors, omissions, inaccuracies, inconsistencies, or unintentional interpretations relative to the original sources. Images are used solely for identification purposes under fair use principles.</p>
+<p><strong>Community-gated editorial articles (effective July 1, 2026):</strong> select editorial pieces published on or after this date may be marked as community-gated. Such articles remain fully present in the public RSS feed in terms of title, description, editorial category, cover image, and topic metadata; however, the complete body text is delivered only to readers signed into a free account on the platform. The feed item explicitly invites the reader to sign in or create a free account in order to read the complete article. <strong>The platform does not charge any subscription or fee, does not require any credit or debit card, and remains open source and free for all readers.</strong> All articles published before July 1, 2026, and any article not bearing this mark, remain fully public both on the web and in RSS.</p>
 <p>Icons and visual assets are licensed under Creative Commons Attribution 4.0. Data provided by TMDB, JustWatch, MDBList, and Trakt.</p>`,
   },
   {


### PR DESCRIPTION
Adds a paragraph to "Data Sources and Attributions" stating that select editorial pieces published on or after 2026-07-01 may be marked as community-gated: full RSS metadata stays public, the body text is delivered only after signing into a free account. Reinforces that no subscription or card is ever required, and that all pre-July-1 articles remain fully public on the web and in RSS.

Bumps "Last updated" to 2026-06-15.

Refs #362