### PR TITLE
Add requires_auth community gate + editorial taxonomy (#362)

### DIFF
--- a/components/global/AuthModal.vue
+++ b/components/global/AuthModal.vue
@@ -272,6 +272,20 @@ export default {
     // The community-gate banner + swapped copy only render when this specific
     // action triggered the modal.
     this.isCommunityGate = action === 'requires_auth_article';
+
+    // Capture the current URL so /auth-success brings the reader back where
+    // they triggered auth — instead of dumping them at the homepage.
+    // handleLogin (email/password) already sets this at submit time, but the
+    // Google OAuth path in GoogleLogin.vue does a hard redirect without going
+    // through the modal's submit, so we also capture here as the single
+    // entry-point catch-all. Auth-success.vue removes the key on consumption.
+    if (typeof window !== 'undefined') {
+      const path = window.location.pathname + window.location.search;
+      if (path && !path.startsWith('/login') && !path.startsWith('/register') && !path.startsWith('/auth-success')) {
+        localStorage.setItem('auth_return_url', path);
+      }
+    }
+
     this.resetForm();
     },
 

--- a/components/global/AuthModal.vue
+++ b/components/global/AuthModal.vue
@@ -2,19 +2,24 @@
   <div v-if="isOpen" class="auth-modal-overlay">
     <div class="auth-modal-container">
       <div class="auth-modal-header">
-        <h2>Sign in to continue</h2>
+        <h2>{{ isCommunityGate ? 'Join the community — free' : 'Sign in to continue' }}</h2>
         <button @click="closeModal" class="close-button">×</button>
       </div>
-      
+
       <div class="auth-modal-content">
+        <!-- Community-gate banner: only when triggered by a requires_auth article -->
+        <div v-if="isCommunityGate" class="community-gate-badge">
+          This article is only for members of the community.
+        </div>
+
         <div class="tabs">
-          <span 
+          <span
             :class="['tab', { active: activeTab === 'login' }]"
             @click="activeTab = 'login'"
           >
             Sign In
           </span>
-          <span 
+          <span
             :class="['tab', { active: activeTab === 'register' }]"
             @click="activeTab = 'register'"
           >
@@ -23,7 +28,7 @@
         </div>
 
         <div v-if="activeTab === 'login'" class="form-container">
-          <p class="modal-description">Please sign in to access more features</p>
+          <p class="modal-description">{{ isCommunityGate ? 'Open source and always free. Sign in or create a free account to keep reading.' : 'Please sign in to access more features' }}</p>
           <p class="modal-subtitle">No credit or debit card required.</p>
           
           <form @submit.prevent="handleLogin">
@@ -219,7 +224,13 @@ export default {
       hasSymbol: false,
       hasMinLength: false,
       showSuccessMessage: false,
-      pendingAction: null
+      pendingAction: null,
+      // Community-gate flag: set to true when the modal is opened with
+      // detail.action === 'requires_auth_article' (article page CTA or auto-open
+      // on a gated article). Drives the badge + swapped copy. Reset on close
+      // so subsequent triggers from auth.global.ts / festival / lists render
+      // the default copy.
+      isCommunityGate: false
     };
   },
   computed: {
@@ -252,19 +263,29 @@ export default {
   methods: {
     handleOpenEvent(event) {
       const action = event.detail ? event.detail.action : null;
+      const initialTab = event.detail && event.detail.initialTab;
+      if (initialTab === 'login' || initialTab === 'register') {
+        this.activeTab = initialTab;
+      }
       this.open(action);
     },
     open(action = null) {
     this.isOpen = true;
     this.pendingAction = action;
+    // The community-gate banner + swapped copy only render when this specific
+    // action triggered the modal.
+    this.isCommunityGate = action === 'requires_auth_article';
     this.resetForm();
     },
-    
+
     close() {
       this.isOpen = false;
       this.pendingAction = null;
+      // Always reset the community-gate flag so the next open from a different
+      // surface (auth.global.ts, festival, lists, etc.) renders default copy.
+      this.isCommunityGate = false;
       this.resetForm();
-      this.$emit('close'); 
+      this.$emit('close');
     },
     
     closeModal() {
@@ -459,6 +480,23 @@ export default {
 
 .auth-modal-content {
   padding: 25px;
+}
+
+/* Community-gate banner — only rendered when the modal is opened with
+   action: 'requires_auth_article' (anonymous reader on a gated article). */
+.community-gate-badge {
+  display: block;
+  margin: 0 0 18px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: 1px solid rgba(139, 233, 253, 0.45);
+  background: rgba(139, 233, 253, 0.10);
+  color: #8BE9FD;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  text-align: center;
+  text-transform: none;
 }
 
 .modal-description {

--- a/components/global/AuthModal.vue
+++ b/components/global/AuthModal.vue
@@ -2,16 +2,11 @@
   <div v-if="isOpen" class="auth-modal-overlay">
     <div class="auth-modal-container">
       <div class="auth-modal-header">
-        <h2>{{ isCommunityGate ? 'Join the community — free' : 'Sign in to continue' }}</h2>
+        <h2>{{ isCommunityGate ? 'Join the community.' : 'Sign in to continue' }}</h2>
         <button @click="closeModal" class="close-button">×</button>
       </div>
 
       <div class="auth-modal-content">
-        <!-- Community-gate banner: only when triggered by a requires_auth article -->
-        <div v-if="isCommunityGate" class="community-gate-badge">
-          This article is only for members of the community.
-        </div>
-
         <div class="tabs">
           <span
             :class="['tab', { active: activeTab === 'login' }]"
@@ -28,7 +23,9 @@
         </div>
 
         <div v-if="activeTab === 'login'" class="form-container">
-          <p class="modal-description">{{ isCommunityGate ? 'Open source and always free. Sign in or create a free account to keep reading.' : 'Please sign in to access more features' }}</p>
+          <!-- In community-gate mode the inline card on the article page already
+               framed the context — skip the description here to avoid repetition. -->
+          <p v-if="!isCommunityGate" class="modal-description">Please sign in to access more features</p>
           <p class="modal-subtitle">No credit or debit card required.</p>
           
           <form @submit.prevent="handleLogin">
@@ -480,23 +477,6 @@ export default {
 
 .auth-modal-content {
   padding: 25px;
-}
-
-/* Community-gate banner — only rendered when the modal is opened with
-   action: 'requires_auth_article' (anonymous reader on a gated article). */
-.community-gate-badge {
-  display: block;
-  margin: 0 0 18px;
-  padding: 10px 14px;
-  border-radius: 10px;
-  border: 1px solid rgba(139, 233, 253, 0.45);
-  background: rgba(139, 233, 253, 0.10);
-  color: #8BE9FD;
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.3px;
-  text-align: center;
-  text-transform: none;
 }
 
 .modal-description {

--- a/components/global/NewsCarousel.vue
+++ b/components/global/NewsCarousel.vue
@@ -59,7 +59,7 @@
 
             <div class="card-content">
               <div class="card-meta">
-                <span v-if="article.source && article.source.name" class="source-badge">{{ article.source.name }}</span>
+                <span v-if="carouselBadge(article)" class="source-badge">{{ carouselBadge(article) }}</span>
                 <span class="card-date">{{ formatDate(article.published_at) }}</span>
               </div>
 
@@ -185,6 +185,15 @@ export default {
     sanitizeDescription(desc) {
       if (!desc) return '';
       return striptags(desc);
+    },
+    // Display badge: prefer the editorial category for internal articles
+    // (replaces the brand-redundant "CINEMAGORIA" label), fall back to the
+    // publisher name for external aggregated items.
+    carouselBadge(article) {
+      if (article?.editorial_category) {
+        return String(article.editorial_category).toUpperCase();
+      }
+      return article?.source?.name || '';
     },
     onImageLoad(id) {
        this.loadingMap[id] = false; 

--- a/components/search/NewsResultCard.vue
+++ b/components/search/NewsResultCard.vue
@@ -15,7 +15,7 @@
         />
         <img v-else src="/placeholders/placeholder_news.webp" alt="Placeholder" class="news-card__img" />
         
-        <span v-if="item.source && item.source.name" class="news-card__source">{{ item.source.name }}</span>
+        <span v-if="cardBadge" class="news-card__source">{{ cardBadge }}</span>
       </div>
 
       <div class="news-card__content">
@@ -36,6 +36,17 @@ export default {
     item: {
       type: Object,
       required: true
+    }
+  },
+  computed: {
+    // Display badge: prefer the editorial category for internal articles
+    // (replaces the brand-redundant "CINEMAGORIA" label), fall back to the
+    // publisher name for external aggregated items.
+    cardBadge() {
+      if (this.item?.editorial_category) {
+        return String(this.item.editorial_category).toUpperCase();
+      }
+      return this.item?.source?.name || '';
     }
   },
   methods: {

--- a/pages/news/[slug].vue
+++ b/pages/news/[slug].vue
@@ -304,24 +304,26 @@
                 </div>
               </div>
 
-              <!-- Body — full when public OR reader is signed in.
-                   Teaser + CTA card when requires_auth = 1 AND reader anonymous. -->
+              <!-- Body — fully rendered when public OR reader is signed in.
+                   Replaced by an inline gate card when requires_auth = 1 AND
+                   reader is anonymous. The card cuts the body entirely (no
+                   teaser, no fade) so the gate is visually instantaneous and
+                   does not depend on modal open timing. -->
               <template v-if="!isGated">
                 <div class="article-body" v-html="bodyParts.before"></div>
               </template>
-              <template v-else>
-                <div class="article-body article-body--teaser">
-                  <p>{{ teaserText }}</p>
-                  <div class="article-body__fade"></div>
+              <div v-else class="gate-card" role="region" aria-label="Members-only article">
+                <div class="gate-card__accent"></div>
+                <div class="gate-card__icon-wrap" aria-hidden="true">
+                  <svg class="gate-card__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+                    <rect x="4" y="11" width="16" height="10" rx="2"></rect>
+                    <path d="M8 11V7a4 4 0 0 1 8 0v4"></path>
+                  </svg>
                 </div>
-                <div class="gate-card">
-                  <div class="gate-card__eyebrow">Exclusive to the community</div>
-                  <h3 class="gate-card__title">Open source and always <strong>free</strong></h3>
-                  <p class="gate-card__sub">Sign in or create a free account to keep reading. No subscription, no credit or debit card.</p>
-                  <button type="button" class="gate-card__cta" @click="openGateModal">Join Free</button>
-                  <button type="button" class="gate-card__link" @click="openGateModal">Already have an account? Sign in</button>
-                </div>
-              </template>
+                <h3 class="gate-card__title">For our community</h3>
+                <p class="gate-card__sub">Sign in or create an account to read this article.</p>
+                <button type="button" class="gate-card__cta" @click="openGateModal">Continue</button>
+              </div>
 
               <!-- Carousel in the middle (when both trailer and carousel exist).
                    If no <h2> subtitles are found, bodyParts.after is empty and
@@ -427,9 +429,11 @@ const isArticleSaved = ref(false)
 const savedLink = ref(null)
 const userEmail = ref(null)
 // Logged-in derived from access_token (UX gate only — see middleware/auth.global.ts).
-// Defaults to true on SSR so the server render does NOT show the teaser flash —
-// hydration on the client will flip to the correct value before paint.
-const isLoggedIn = ref(true)
+// Default false so SSR renders the gate for gated articles (anonymous is the
+// common case pre-July-1). Logged-in readers get a brief gate flash before the
+// body re-renders on hydration; that's the accepted Phase 1 tradeoff in
+// exchange for an instant gate for anonymous readers.
+const isLoggedIn = ref(false)
 const carouselIndex = ref(0)
 const isShareModalOpen = ref(false)
 
@@ -458,19 +462,6 @@ onMounted(async () => {
 
   if (typeof window !== 'undefined') {
     window.addEventListener('auth-changed', handleAuthChange)
-  }
-
-  // Community gate: when the article requires auth and the reader is anonymous,
-  // auto-open the AuthModal with the requires_auth_article action so the modal
-  // shows the "free / community" copy. The teaser + CTA card stay visible behind
-  // so dismissing the modal still lets the reader re-trigger it.
-  if (isGated.value && typeof window !== 'undefined') {
-    window.dispatchEvent(new CustomEvent('open-auth-modal', {
-      detail: {
-        action: 'requires_auth_article',
-        context: { slug: article.value?.slug, title: article.value?.title_en }
-      }
-    }))
   }
 })
 
@@ -721,23 +712,12 @@ const bodyParts = computed(() => {
 
 // ── Community gate (requires_auth) ──────────────────────────────────
 // An article is "gated" when requires_auth = 1 AND the visitor is not signed in.
-// Server-rendered HTML defaults isLoggedIn = true so SSR shows the full body
-// (no flash); the client onMounted handler then reads localStorage and flips
-// the ref, causing a single re-render. Anonymous readers see: kicker + hero +
-// title + topics + trailer/carousel + ~200-char body teaser + fade + CTA card.
+// Server-rendered HTML defaults isLoggedIn = false so SSR ships the inline gate
+// card for gated articles (anonymous is the common case pre-July-1). On
+// hydration the client reads localStorage and re-renders with the full body
+// for signed-in readers.
 const isGated = computed(() => {
   return Number(article.value?.requires_auth) === 1 && !isLoggedIn.value
-})
-
-// Plain-text teaser: strip HTML tags from the rendered body, take up to ~200
-// chars cutting at the last word boundary, append an ellipsis.
-const teaserText = computed(() => {
-  const html = renderedBody.value || ''
-  const text = html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim()
-  if (text.length <= 200) return text
-  const slice = text.slice(0, 200)
-  const lastSpace = slice.lastIndexOf(' ')
-  return (lastSpace > 100 ? slice.slice(0, lastSpace) : slice) + '…'
 })
 
 function openGateModal() {
@@ -1186,84 +1166,89 @@ useHead(() => {
   letter-spacing: -0.02em;
 }
 
-/* Community gate — teaser fade + CTA card. Visual language matches the
-   glassmorphism cyan baseline of the rest of the article surface. */
-.article-body--teaser {
+/* Community gate — inline card that replaces the body entirely.
+   Borrows the auth-success.vue visual language: glassmorphism, top accent
+   gradient, floatIn entrance, minimal copy. No teaser, no fade — the gate
+   appears instantly and the body is never rendered for anonymous readers. */
+.gate-card {
   position: relative;
-  max-height: 200px;
+  margin: 28px 0 40px;
+  padding: 36px 28px 32px;
+  border-radius: 18px;
+  background: rgba(3, 4, 6, 0.65);
+  box-shadow:
+    0 18px 44px rgba(0, 0, 0, 0.45),
+    0 0 0 1px rgba(31, 84, 103, 0.5),
+    inset 0 0 22px rgba(139, 233, 253, 0.05);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  text-align: center;
   overflow: hidden;
+  animation: gateFloatIn 0.5s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-.article-body__fade {
+.gate-card__accent {
   position: absolute;
+  top: 0;
   left: 0;
   right: 0;
-  bottom: 0;
-  height: 120px;
-  pointer-events: none;
-  background: linear-gradient(to bottom, rgba(3, 4, 6, 0) 0%, rgba(3, 4, 6, 0.95) 90%);
+  height: 2px;
+  background: linear-gradient(90deg, transparent, #8BE9FD, #1F5467, transparent);
+  opacity: 0.85;
 }
 
-.gate-card {
-  margin: 22px 0 40px;
-  padding: 32px 28px;
-  border-radius: 18px;
-  border: 1px solid rgba(139, 233, 253, 0.32);
-  background:
-    radial-gradient(circle at 12% 0%, rgba(31, 84, 103, 0.30), transparent 55%),
-    radial-gradient(circle at 90% 100%, rgba(139, 233, 253, 0.10), transparent 50%),
-    rgba(3, 4, 6, 0.85);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-  text-align: center;
-  box-shadow: 0 8px 28px rgba(139, 233, 253, 0.10);
+.gate-card__icon-wrap {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 52px;
+  margin: 0 auto 14px;
+  border-radius: 50%;
+  background: rgba(139, 233, 253, 0.08);
+  border: 1px solid rgba(139, 233, 253, 0.25);
 }
 
-.gate-card__eyebrow {
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 1.2px;
-  text-transform: uppercase;
+.gate-card__icon {
+  width: 24px;
+  height: 24px;
   color: #8BE9FD;
-  margin-bottom: 10px;
+  filter: drop-shadow(0 0 8px rgba(139, 233, 253, 0.35));
 }
 
 .gate-card__title {
-  font-size: 24px;
+  font-size: 22px;
   font-weight: 800;
   color: #fff;
-  margin: 0 0 10px;
+  margin: 0 0 6px;
   letter-spacing: -0.01em;
-}
-
-.gate-card__title strong {
-  color: #8BE9FD;
-  font-weight: 800;
+  text-shadow: 0 0 18px rgba(139, 233, 253, 0.18);
 }
 
 .gate-card__sub {
-  font-size: 15px;
-  color: #ACAFB5;
-  line-height: 1.6;
+  font-size: 14px;
+  color: #a0aab2;
+  line-height: 1.5;
   margin: 0 0 22px;
+  font-weight: 300;
 }
 
 .gate-card__cta {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 12px 32px;
-  border-radius: 12px;
+  padding: 11px 30px;
+  border-radius: 10px;
   border: 1px solid rgba(139, 233, 253, 0.6);
   background: linear-gradient(135deg, #1F5467, #8BE9FD);
   color: #03242C;
   font-family: inherit;
   font-size: 14px;
   font-weight: 700;
+  letter-spacing: 0.2px;
   cursor: pointer;
   transition: transform 0.18s ease, box-shadow 0.18s ease;
   box-shadow: 0 4px 14px rgba(139, 233, 253, 0.25);
-  margin-bottom: 12px;
 }
 
 .gate-card__cta:hover {
@@ -1271,22 +1256,9 @@ useHead(() => {
   box-shadow: 0 6px 20px rgba(139, 233, 253, 0.40);
 }
 
-.gate-card__link {
-  display: block;
-  margin: 0 auto;
-  padding: 6px 10px;
-  background: transparent;
-  border: none;
-  color: #8BE9FD;
-  font-family: inherit;
-  font-size: 13px;
-  cursor: pointer;
-  text-decoration: underline;
-  text-decoration-color: rgba(139, 233, 253, 0.4);
-}
-
-.gate-card__link:hover {
-  color: #a5eefe;
+@keyframes gateFloatIn {
+  from { opacity: 0; transform: translateY(12px) scale(0.985); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
 }
 
 .article-lead {

--- a/pages/news/[slug].vue
+++ b/pages/news/[slug].vue
@@ -205,6 +205,13 @@
                     </span>
                   </NuxtLink>
                 </div>
+                <!-- Editorial kicker: primary category, clickable to /news?category=… -->
+                <NuxtLink
+                  v-if="kickerLabel"
+                  :to="{ path: '/news', query: { category: article.editorial_category } }"
+                  class="article-kicker"
+                >{{ kickerLabel }}</NuxtLink>
+
                 <h1 class="article-title">{{ article.title_en }}</h1>
 
                 <!-- Cover image inline for mobile -->
@@ -297,13 +304,30 @@
                 </div>
               </div>
 
-              <!-- Body (first half — or full body when there's no split) -->
-              <div class="article-body" v-html="bodyParts.before"></div>
+              <!-- Body — full when public OR reader is signed in.
+                   Teaser + CTA card when requires_auth = 1 AND reader anonymous. -->
+              <template v-if="!isGated">
+                <div class="article-body" v-html="bodyParts.before"></div>
+              </template>
+              <template v-else>
+                <div class="article-body article-body--teaser">
+                  <p>{{ teaserText }}</p>
+                  <div class="article-body__fade"></div>
+                </div>
+                <div class="gate-card">
+                  <div class="gate-card__eyebrow">Exclusive to the community</div>
+                  <h3 class="gate-card__title">Open source and always <strong>free</strong></h3>
+                  <p class="gate-card__sub">Sign in or create a free account to keep reading. No subscription, no credit or debit card.</p>
+                  <button type="button" class="gate-card__cta" @click="openGateModal">Join Free</button>
+                  <button type="button" class="gate-card__link" @click="openGateModal">Already have an account? Sign in</button>
+                </div>
+              </template>
 
               <!-- Carousel in the middle (when both trailer and carousel exist).
                    If no <h2> subtitles are found, bodyParts.after is empty and
-                   this block ends up effectively at the end of the body. -->
-              <div v-if="article.trailer_youtube_id && article.carousel_assets?.length" class="article-carousel">
+                   this block ends up effectively at the end of the body.
+                   Hidden when gated — the body collapsed to a teaser. -->
+              <div v-if="!isGated && article.trailer_youtube_id && article.carousel_assets?.length" class="article-carousel">
                 <div class="carousel-viewport">
                   <div class="carousel-track" :style="{ transform: `translateX(-${carouselIndex * 100}%)` }">
                     <div v-for="(img, i) in article.carousel_assets" :key="i" class="carousel-slide">
@@ -332,7 +356,7 @@
               </div>
 
               <!-- Body (second half — only shown when body was split at an <h2>) -->
-              <div v-if="bodyParts.after" class="article-body" v-html="bodyParts.after"></div>
+              <div v-if="!isGated && bodyParts.after" class="article-body" v-html="bodyParts.after"></div>
 
               <!-- AI editorial disclosure + error-report modal -->
               <ArticleAIDisclosure
@@ -402,6 +426,10 @@ const isMounted = ref(false)
 const isArticleSaved = ref(false)
 const savedLink = ref(null)
 const userEmail = ref(null)
+// Logged-in derived from access_token (UX gate only — see middleware/auth.global.ts).
+// Defaults to true on SSR so the server render does NOT show the teaser flash —
+// hydration on the client will flip to the correct value before paint.
+const isLoggedIn = ref(true)
 const carouselIndex = ref(0)
 const isShareModalOpen = ref(false)
 
@@ -419,6 +447,7 @@ watch(() => route.params.slug, () => {
 const handleAuthChange = () => {
   const email = localStorage.getItem('email')?.replace(/['"]+/g, '')
   userEmail.value = email || null
+  isLoggedIn.value = !!localStorage.getItem('access_token')
   checkSavedStatus()
 }
 
@@ -429,6 +458,19 @@ onMounted(async () => {
 
   if (typeof window !== 'undefined') {
     window.addEventListener('auth-changed', handleAuthChange)
+  }
+
+  // Community gate: when the article requires auth and the reader is anonymous,
+  // auto-open the AuthModal with the requires_auth_article action so the modal
+  // shows the "free / community" copy. The teaser + CTA card stay visible behind
+  // so dismissing the modal still lets the reader re-trigger it.
+  if (isGated.value && typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent('open-auth-modal', {
+      detail: {
+        action: 'requires_auth_article',
+        context: { slug: article.value?.slug, title: article.value?.title_en }
+      }
+    }))
   }
 })
 
@@ -675,6 +717,43 @@ const bodyParts = computed(() => {
   if (indices.length === 0) return { before: html, after: '' }
   const midIdx = indices[Math.floor(indices.length / 2)]
   return { before: html.slice(0, midIdx), after: html.slice(midIdx) }
+})
+
+// ── Community gate (requires_auth) ──────────────────────────────────
+// An article is "gated" when requires_auth = 1 AND the visitor is not signed in.
+// Server-rendered HTML defaults isLoggedIn = true so SSR shows the full body
+// (no flash); the client onMounted handler then reads localStorage and flips
+// the ref, causing a single re-render. Anonymous readers see: kicker + hero +
+// title + topics + trailer/carousel + ~200-char body teaser + fade + CTA card.
+const isGated = computed(() => {
+  return Number(article.value?.requires_auth) === 1 && !isLoggedIn.value
+})
+
+// Plain-text teaser: strip HTML tags from the rendered body, take up to ~200
+// chars cutting at the last word boundary, append an ellipsis.
+const teaserText = computed(() => {
+  const html = renderedBody.value || ''
+  const text = html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim()
+  if (text.length <= 200) return text
+  const slice = text.slice(0, 200)
+  const lastSpace = slice.lastIndexOf(' ')
+  return (lastSpace > 100 ? slice.slice(0, lastSpace) : slice) + '…'
+})
+
+function openGateModal() {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(new CustomEvent('open-auth-modal', {
+    detail: {
+      action: 'requires_auth_article',
+      context: { slug: article.value?.slug, title: article.value?.title_en }
+    }
+  }))
+}
+
+// Kicker badge: primary editorial category, upper-cased for display.
+const kickerLabel = computed(() => {
+  const cat = article.value?.editorial_category
+  return cat ? String(cat).toUpperCase() : ''
 })
 
 function formatDate(dateStr) {
@@ -1076,6 +1155,28 @@ useHead(() => {
   margin-bottom: 16px;
 }
 
+/* Editorial kicker — primary category above the title */
+.article-kicker {
+  display: inline-block;
+  margin-bottom: 14px;
+  padding: 5px 13px;
+  border-radius: 999px;
+  border: 1px solid rgba(139, 233, 253, 0.5);
+  background: rgba(139, 233, 253, 0.12);
+  color: #8BE9FD;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.8px;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: background 0.18s ease, color 0.18s ease;
+}
+
+.article-kicker:hover {
+  background: #8BE9FD;
+  color: #03242C;
+}
+
 .article-title {
   font-size: clamp(28px, 4vw, 38px);
   font-weight: 800;
@@ -1083,6 +1184,109 @@ useHead(() => {
   color: #fff;
   margin: 0 0 20px;
   letter-spacing: -0.02em;
+}
+
+/* Community gate — teaser fade + CTA card. Visual language matches the
+   glassmorphism cyan baseline of the rest of the article surface. */
+.article-body--teaser {
+  position: relative;
+  max-height: 200px;
+  overflow: hidden;
+}
+
+.article-body__fade {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 120px;
+  pointer-events: none;
+  background: linear-gradient(to bottom, rgba(3, 4, 6, 0) 0%, rgba(3, 4, 6, 0.95) 90%);
+}
+
+.gate-card {
+  margin: 22px 0 40px;
+  padding: 32px 28px;
+  border-radius: 18px;
+  border: 1px solid rgba(139, 233, 253, 0.32);
+  background:
+    radial-gradient(circle at 12% 0%, rgba(31, 84, 103, 0.30), transparent 55%),
+    radial-gradient(circle at 90% 100%, rgba(139, 233, 253, 0.10), transparent 50%),
+    rgba(3, 4, 6, 0.85);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  text-align: center;
+  box-shadow: 0 8px 28px rgba(139, 233, 253, 0.10);
+}
+
+.gate-card__eyebrow {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  color: #8BE9FD;
+  margin-bottom: 10px;
+}
+
+.gate-card__title {
+  font-size: 24px;
+  font-weight: 800;
+  color: #fff;
+  margin: 0 0 10px;
+  letter-spacing: -0.01em;
+}
+
+.gate-card__title strong {
+  color: #8BE9FD;
+  font-weight: 800;
+}
+
+.gate-card__sub {
+  font-size: 15px;
+  color: #ACAFB5;
+  line-height: 1.6;
+  margin: 0 0 22px;
+}
+
+.gate-card__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 32px;
+  border-radius: 12px;
+  border: 1px solid rgba(139, 233, 253, 0.6);
+  background: linear-gradient(135deg, #1F5467, #8BE9FD);
+  color: #03242C;
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+  box-shadow: 0 4px 14px rgba(139, 233, 253, 0.25);
+  margin-bottom: 12px;
+}
+
+.gate-card__cta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(139, 233, 253, 0.40);
+}
+
+.gate-card__link {
+  display: block;
+  margin: 0 auto;
+  padding: 6px 10px;
+  background: transparent;
+  border: none;
+  color: #8BE9FD;
+  font-family: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-color: rgba(139, 233, 253, 0.4);
+}
+
+.gate-card__link:hover {
+  color: #a5eefe;
 }
 
 .article-lead {

--- a/pages/news/[slug].vue
+++ b/pages/news/[slug].vue
@@ -98,6 +98,21 @@
                 </div>
               </div>
 
+              <!-- Editorial taxonomy — primary (highlighted) + secondaries. -->
+              <h3 v-if="article.editorial_category" class="sidebar-title" style="margin-top: 20px;">Categories</h3>
+              <div v-if="article.editorial_category" class="sidebar-tags sidebar-tags--categories">
+                <NuxtLink
+                  :to="{ path: '/news', query: { category: article.editorial_category } }"
+                  class="sidebar-tag sidebar-tag--category sidebar-tag--primary"
+                >{{ article.editorial_category.toUpperCase() }}</NuxtLink>
+                <NuxtLink
+                  v-for="sec in (article.secondary_categories || [])"
+                  :key="sec"
+                  :to="{ path: '/news', query: { category: sec } }"
+                  class="sidebar-tag sidebar-tag--category"
+                >{{ sec.toUpperCase() }}</NuxtLink>
+              </div>
+
               <!-- Sources -->
               <h3 v-if="parsedSources.length" class="sidebar-title" style="margin-top: 20px;">Sources</h3>
               <div v-if="parsedSources.length" class="sidebar-sources">
@@ -205,13 +220,6 @@
                     </span>
                   </NuxtLink>
                 </div>
-                <!-- Editorial kicker: primary category, clickable to /news?category=… -->
-                <NuxtLink
-                  v-if="kickerLabel"
-                  :to="{ path: '/news', query: { category: article.editorial_category } }"
-                  class="article-kicker"
-                >{{ kickerLabel }}</NuxtLink>
-
                 <h1 class="article-title">{{ article.title_en }}</h1>
 
                 <!-- Cover image inline for mobile -->
@@ -261,8 +269,9 @@
 
               <!-- Trailer embed (always at top when trailer exists) -->
               <!-- Supports YouTube (default) and Vimeo via trailer_provider.
-                   Legacy rows w/ NULL provider render as YouTube — no break. -->
-              <div v-if="article.trailer_youtube_id" class="article-trailer">
+                   Legacy rows w/ NULL provider render as YouTube — no break.
+                   Hidden when gated so the embed never loads pre-auth. -->
+              <div v-if="article.trailer_youtube_id && !isGated" class="article-trailer">
                 <div class="trailer-wrapper">
                   <iframe
                     :src="trailerEmbedSrc"
@@ -275,8 +284,8 @@
                 </div>
               </div>
 
-              <!-- Carousel at top (only when there's no trailer) -->
-              <div v-if="article.carousel_assets?.length && !article.trailer_youtube_id" class="article-carousel">
+              <!-- Carousel at top (only when there's no trailer). Hidden on gated articles. -->
+              <div v-if="article.carousel_assets?.length && !article.trailer_youtube_id && !isGated" class="article-carousel">
                 <div class="carousel-viewport">
                   <div class="carousel-track" :style="{ transform: `translateX(-${carouselIndex * 100}%)` }">
                     <div v-for="(img, i) in article.carousel_assets" :key="i" class="carousel-slide">
@@ -320,9 +329,9 @@
                     <path d="M8 11V7a4 4 0 0 1 8 0v4"></path>
                   </svg>
                 </div>
-                <h3 class="gate-card__title">For our community</h3>
-                <p class="gate-card__sub">Sign in or create an account to read this article.</p>
-                <button type="button" class="gate-card__cta" @click="openGateModal">Continue</button>
+                <h3 class="gate-card__title">Community Exclusive</h3>
+                <p class="gate-card__sub">Create a free account or log in to read the full story.</p>
+                <button type="button" class="gate-card__cta" @click="openGateModal">Sign in or join</button>
               </div>
 
               <!-- Carousel in the middle (when both trailer and carousel exist).
@@ -360,8 +369,12 @@
               <!-- Body (second half — only shown when body was split at an <h2>) -->
               <div v-if="!isGated && bodyParts.after" class="article-body" v-html="bodyParts.after"></div>
 
-              <!-- AI editorial disclosure + error-report modal -->
+              <!-- AI editorial disclosure + error-report modal.
+                   Hidden when gated: the reader is not seeing the body, so a
+                   disclosure about how the body was produced has no surface to
+                   attach to. -->
               <ArticleAIDisclosure
+                v-if="!isGated"
                 :article-id="article.id"
                 :article-slug="article.slug"
                 :article-title="article.title_en"
@@ -730,12 +743,6 @@ function openGateModal() {
   }))
 }
 
-// Kicker badge: primary editorial category, upper-cased for display.
-const kickerLabel = computed(() => {
-  const cat = article.value?.editorial_category
-  return cat ? String(cat).toUpperCase() : ''
-})
-
 function formatDate(dateStr) {
   if (!dateStr) return ''
   try {
@@ -1009,6 +1016,42 @@ useHead(() => {
   border-color: rgba(139, 233, 253, 0.3);
 }
 
+/* Editorial taxonomy chips: primary gets the cyan accent, secondaries match
+   the Topics neutral style so the visual hierarchy mirrors the data model
+   (one primary + up to 2 secondaries). */
+.sidebar-tags--categories {
+  align-items: center;
+}
+
+.sidebar-tag--category {
+  text-decoration: none;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 700;
+  font-size: 11px;
+  padding: 3px 10px;
+  transition: all 0.2s ease;
+}
+
+.sidebar-tag--category:hover {
+  color: #8BE9FD;
+  background: rgba(139, 233, 253, 0.1);
+  border-color: rgba(139, 233, 253, 0.3);
+}
+
+.sidebar-tag--primary {
+  color: #8BE9FD;
+  background: rgba(139, 233, 253, 0.12);
+  border-color: rgba(139, 233, 253, 0.5);
+}
+
+.sidebar-tag--primary:hover {
+  background: #8BE9FD;
+  color: #03242C;
+  border-color: #8BE9FD;
+}
+
 .sidebar-sources {
   display: flex;
   flex-direction: column;
@@ -1133,28 +1176,6 @@ useHead(() => {
   font-size: 14px;
   color: #80868b;
   margin-bottom: 16px;
-}
-
-/* Editorial kicker — primary category above the title */
-.article-kicker {
-  display: inline-block;
-  margin-bottom: 14px;
-  padding: 5px 13px;
-  border-radius: 999px;
-  border: 1px solid rgba(139, 233, 253, 0.5);
-  background: rgba(139, 233, 253, 0.12);
-  color: #8BE9FD;
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.8px;
-  text-decoration: none;
-  text-transform: uppercase;
-  transition: background 0.18s ease, color 0.18s ease;
-}
-
-.article-kicker:hover {
-  background: #8BE9FD;
-  color: #03242C;
 }
 
 .article-title {

--- a/pages/news/index.vue
+++ b/pages/news/index.vue
@@ -51,27 +51,6 @@
             </div>
           </div>
 
-          <div v-if="showCategoryChips && !isSavedView" class="category-chips" role="tablist" aria-label="Filter by editorial category">
-            <button
-              type="button"
-              class="category-chip"
-              :class="{ 'category-chip--active': !categoryFilter }"
-              role="tab"
-              :aria-selected="!categoryFilter"
-              @click="pickCategory(null)"
-            >All</button>
-            <button
-              v-for="cat in CATEGORY_OPTIONS"
-              :key="cat"
-              type="button"
-              class="category-chip"
-              :class="{ 'category-chip--active': categoryFilter === cat }"
-              role="tab"
-              :aria-selected="categoryFilter === cat"
-              @click="pickCategory(cat)"
-            >{{ cat.toUpperCase() }}</button>
-          </div>
-
           <div class="header-status">
             <h2 class="status-title" v-if="isSavedView">Saved Articles</h2>
             <h2 class="status-title" v-else-if="selectedSource">
@@ -102,6 +81,31 @@
               </span>
             </ClientOnly>
           </div>
+
+          <!-- Editorial category filter — sits below the Cinemagoria header
+               status so the article count is anchored first, the filter is
+               offered second. Minimal text-only chips inside the panel. -->
+          <div v-if="showCategoryChips && !isSavedView" class="category-panel" role="tablist" aria-label="Filter by editorial category">
+            <button
+              type="button"
+              class="category-chip"
+              :class="{ 'category-chip--active': !categoryFilter }"
+              role="tab"
+              :aria-selected="!categoryFilter"
+              @click="pickCategory(null)"
+            >All</button>
+            <button
+              v-for="cat in CATEGORY_OPTIONS"
+              :key="cat"
+              type="button"
+              class="category-chip"
+              :class="{ 'category-chip--active': categoryFilter === cat }"
+              role="tab"
+              :aria-selected="categoryFilter === cat"
+              @click="pickCategory(cat)"
+            >{{ cat }}</button>
+          </div>
+
           <div v-if="pending" class="loading-grid">
              <div class="loader-container">
                 <Loader />
@@ -1847,53 +1851,60 @@ watch(userEmail, (val) => {
   line-clamp: 3;
 }
 
-/* ── Editorial category chip filter (Cinemagoria-only view) ─────────── */
-.category-chips {
+/* ── Editorial category filter (Cinemagoria-only view) ─────────────────
+   Panel borrows the header-status glassmorphism so it reads as part of the
+   same group of controls. Chips are text-only inside the panel — the panel
+   carries the visual frame, the chips just label their state. */
+.category-panel {
   display: flex;
   flex-wrap: nowrap;
-  gap: 8px;
+  align-items: center;
+  gap: 2px;
+  margin-bottom: 25px;
+  padding: 8px 14px;
+  background: rgba(3, 4, 6, 0.7);
+  background-image:
+    radial-gradient(circle at 15% 0%, rgba(31, 84, 103, 0.2), transparent 55%);
+  border: 1px solid rgba(139, 233, 253, 0.18);
+  border-radius: 15px;
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
   overflow-x: auto;
   scrollbar-width: none;
   -ms-overflow-style: none;
-  padding: 6px 2px 14px;
-  margin: 6px 0 6px;
 }
 
-.category-chips::-webkit-scrollbar {
+.category-panel::-webkit-scrollbar {
   display: none;
 }
 
 .category-chip {
   flex-shrink: 0;
-  padding: 6px 14px;
+  padding: 6px 12px;
   border-radius: 999px;
-  border: 1px solid rgba(139, 233, 253, 0.18);
-  background: rgba(3, 4, 6, 0.55);
-  color: #cfd8df;
+  border: none;
+  background: transparent;
+  color: rgba(207, 216, 223, 0.55);
   font-family: inherit;
   font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.5px;
+  font-weight: 600;
+  letter-spacing: 0.8px;
   text-transform: uppercase;
   cursor: pointer;
-  transition: background 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+  transition: color 0.15s ease, background 0.15s ease;
   white-space: nowrap;
 }
 
 .category-chip:hover {
   color: #8BE9FD;
-  border-color: rgba(139, 233, 253, 0.5);
 }
 
 .category-chip--active {
-  background: #8BE9FD;
-  border-color: #8BE9FD;
-  color: #03242C;
+  background: rgba(139, 233, 253, 0.12);
+  color: #8BE9FD;
 }
 
 .category-chip--active:hover {
-  background: #a5eefe;
-  border-color: #a5eefe;
-  color: #03242C;
+  background: rgba(139, 233, 253, 0.18);
 }
 </style>

--- a/pages/news/index.vue
+++ b/pages/news/index.vue
@@ -330,6 +330,14 @@ const categoryFilter = ref(
     : null
 );
 
+// Keep the ref in sync with ?category= on browser back/forward and direct URL
+// navigations. Chip clicks update the URL via pickCategory(); the watcher
+// re-applies that change idempotently. Invalid / missing values reset to null.
+watch(() => route.query.category, (next) => {
+  categoryFilter.value =
+    typeof next === 'string' && CATEGORY_OPTIONS.includes(next) ? next : null;
+});
+
 // Display badge: prefer editorial category for internal items (replaces the
 // brand-redundant "CINEMAGORIA" label), fall back to publisher name for
 // external aggregated items.

--- a/pages/news/index.vue
+++ b/pages/news/index.vue
@@ -51,7 +51,27 @@
             </div>
           </div>
 
-          
+          <div v-if="showCategoryChips && !isSavedView" class="category-chips" role="tablist" aria-label="Filter by editorial category">
+            <button
+              type="button"
+              class="category-chip"
+              :class="{ 'category-chip--active': !categoryFilter }"
+              role="tab"
+              :aria-selected="!categoryFilter"
+              @click="pickCategory(null)"
+            >All</button>
+            <button
+              v-for="cat in CATEGORY_OPTIONS"
+              :key="cat"
+              type="button"
+              class="category-chip"
+              :class="{ 'category-chip--active': categoryFilter === cat }"
+              role="tab"
+              :aria-selected="categoryFilter === cat"
+              @click="pickCategory(cat)"
+            >{{ cat.toUpperCase() }}</button>
+          </div>
+
           <div class="header-status">
             <h2 class="status-title" v-if="isSavedView">Saved Articles</h2>
             <h2 class="status-title" v-else-if="selectedSource">
@@ -77,7 +97,7 @@
                   {{ localSavedArticlesList.length }} {{ localSavedArticlesList.length === 1 ? 'article' : 'articles' }}
                 </template>
                 <template v-else-if="!pending">
-                  {{ newsItems.length }} {{ newsItems.length === 1 ? 'article' : 'articles' }}
+                  {{ filteredItems.length }} {{ filteredItems.length === 1 ? 'article' : 'articles' }}
                 </template>
               </span>
             </ClientOnly>
@@ -156,7 +176,7 @@
                   </div>
                </div>
 
-               <div v-else-if="newsItems.length > 0">
+               <div v-else-if="filteredItems.length > 0">
                   <div class="news-grid">
                     <div 
                       v-for="item in displayedItems" 
@@ -171,7 +191,7 @@
                               :alt="item.title"
                               loading="lazy"
                           />
-                          <div class="card-source">{{ item.source.name }}</div>
+                          <div class="card-source">{{ cardBadge(item) }}</div>
                           <button
                             v-if="userEmail"
                             class="bookmark-btn"
@@ -200,7 +220,7 @@
                               class="img-lazy"
                           />
                           
-                          <div class="card-source">{{ item.source.name }}</div>
+                          <div class="card-source">{{ cardBadge(item) }}</div>
 
                           <button 
                             v-if="userEmail"
@@ -291,6 +311,43 @@ const searchQuery = ref('');
 const isSearchActive = ref(false);
 const debouncedSearchQuery = refDebounced(searchQuery, 500);
 const topicFromArticle = ref(null);
+
+// Editorial taxonomy filter (Cinemagoria-only). Synced to ?category=<value>.
+// An item matches when its primary OR any of its secondaries equals the picked
+// value — cross-cuts the archive without polluting the primary badge.
+const CATEGORY_OPTIONS = [
+  'feature', 'industry', 'festival', 'awards',
+  'production', 'trailer', 'acquisition', 'boxoffice',
+  'streaming', 'interview', 'review', 'opinion',
+];
+const categoryFilter = ref(
+  typeof route.query.category === 'string' && CATEGORY_OPTIONS.includes(route.query.category)
+    ? route.query.category
+    : null
+);
+
+// Display badge: prefer editorial category for internal items (replaces the
+// brand-redundant "CINEMAGORIA" label), fall back to publisher name for
+// external aggregated items.
+function cardBadge(item) {
+  if (item?.editorial_category) return String(item.editorial_category).toUpperCase();
+  return item?.source?.name || '';
+}
+
+// Category chip is visible only when looking at Cinemagoria-internal articles
+// (the only ones that carry editorial_category). Hidden during external-source
+// view and during active search (mixed sources, filter would only hit internal).
+const showCategoryChips = computed(() => {
+  if (isSearchActive.value && debouncedSearchQuery.value) return false;
+  return !selectedSource.value || selectedSource.value === 'Cinemagoria';
+});
+
+function pickCategory(cat) {
+  categoryFilter.value = cat; // null = "All"
+  const query = { ...route.query };
+  if (cat) query.category = cat; else delete query.category;
+  router.replace({ query });
+}
 
 // Handle ?q= and ?from= query params (arriving from topic click in article page)
 onMounted(() => {
@@ -393,8 +450,22 @@ const visibleLimit = ref(20);
 const sentinel = ref(null);
 let observer = null;
 
+// Apply category filter client-side. Match expansion: primary OR any secondary.
+// Non-Cinemagoria items have no editorial_category and never match — fine,
+// the chip row only shows when source is Cinemagoria so external items are
+// already out of view at that point.
+const filteredItems = computed(() => {
+  const cat = categoryFilter.value;
+  if (!cat) return newsItems.value;
+  return newsItems.value.filter(item => {
+    if (item.editorial_category === cat) return true;
+    const secs = Array.isArray(item.secondary_categories) ? item.secondary_categories : [];
+    return secs.includes(cat);
+  });
+});
+
 const displayedItems = computed(() => {
-  return newsItems.value.slice(0, visibleLimit.value);
+  return filteredItems.value.slice(0, visibleLimit.value);
 });
 
 watch(selectedSource, () => {
@@ -1774,5 +1845,55 @@ watch(userEmail, (val) => {
 .card-desc {
   -webkit-line-clamp: 3;
   line-clamp: 3;
+}
+
+/* ── Editorial category chip filter (Cinemagoria-only view) ─────────── */
+.category-chips {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 8px;
+  overflow-x: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  padding: 6px 2px 14px;
+  margin: 6px 0 6px;
+}
+
+.category-chips::-webkit-scrollbar {
+  display: none;
+}
+
+.category-chip {
+  flex-shrink: 0;
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(139, 233, 253, 0.18);
+  background: rgba(3, 4, 6, 0.55);
+  color: #cfd8df;
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+  white-space: nowrap;
+}
+
+.category-chip:hover {
+  color: #8BE9FD;
+  border-color: rgba(139, 233, 253, 0.5);
+}
+
+.category-chip--active {
+  background: #8BE9FD;
+  border-color: #8BE9FD;
+  color: #03242C;
+}
+
+.category-chip--active:hover {
+  background: #a5eefe;
+  border-color: #a5eefe;
+  color: #03242C;
 }
 </style>

--- a/server/api/article/[slug].get.ts
+++ b/server/api/article/[slug].get.ts
@@ -23,7 +23,8 @@ export default defineEventHandler(async (event) => {
         const result = await db.execute({
             sql: `SELECT id, slug, title_en, body_en, description_en, title_es, body_es, description_es,
                          image_url, sources_json, topics_json, published_at, created_at, is_visible,
-                         trailer_youtube_id, trailer_provider, carousel_assets, related_tmdb_ids
+                         trailer_youtube_id, trailer_provider, carousel_assets, related_tmdb_ids,
+                         requires_auth, editorial_category, secondary_categories_json
                   FROM cinemagoria_articles
                   WHERE slug = ? AND is_visible = 1
                   LIMIT 1`,
@@ -58,6 +59,20 @@ export default defineEventHandler(async (event) => {
                 trailer_provider: (row.trailer_provider as string) || 'youtube',
                 carousel_assets: row.carousel_assets ? (row.carousel_assets as string).split(',').map(u => u.trim()).filter(Boolean) : [],
                 related_tmdb_ids: row.related_tmdb_ids ? JSON.parse(row.related_tmdb_ids as string) : [],
+                // requires_auth: 0 = public (body always rendered), 1 = community-gated
+                // (anonymous reader sees teaser + AuthModal; signed-in reader sees full body).
+                requires_auth: Number(row.requires_auth ?? 0) === 1 ? 1 : 0,
+                // Editorial taxonomy. Primary is NOT NULL DEFAULT 'feature' at the DB layer.
+                // Secondaries arrive as a JSON array (≤ 2) or NULL; expose as a plain array.
+                editorial_category: (row.editorial_category as string) || 'feature',
+                secondary_categories: (() => {
+                    try {
+                        const raw = row.secondary_categories_json
+                        if (!raw) return [] as string[]
+                        const parsed = JSON.parse(raw as string)
+                        return Array.isArray(parsed) ? parsed.map((s: any) => String(s)) : []
+                    } catch { return [] as string[] }
+                })(),
             }
         }
     } catch (error: any) {

--- a/server/api/news.get.ts
+++ b/server/api/news.get.ts
@@ -21,7 +21,8 @@ export default defineEventHandler(async (event) => {
             const descCol = lang === 'es' ? 'description_es' : 'description_en'
 
             let sql = `SELECT id, slug, ${titleCol} AS title, ${descCol} AS description,
-                              image_url, published_at, topics_json
+                              image_url, published_at, topics_json,
+                              requires_auth, editorial_category, secondary_categories_json
                        FROM cinemagoria_articles
                        WHERE is_visible = 1 AND is_cinemagoria = 1
                          AND (datetime(published_at) IS NULL OR datetime(published_at) <= datetime('now'))`
@@ -43,11 +44,24 @@ export default defineEventHandler(async (event) => {
                 image: row.image_url,
                 published_at: row.published_at,
                 description: row.description,
+                // source.name stays 'Cinemagoria' — it's the identity marker the page
+                // uses for filter (selectedSource) and the mixed-source sort tiebreak.
+                // The display badge swap lives in the UI layer via editorial_category.
                 source: { name: 'Cinemagoria' },
                 video_id: null,
                 is_internal: true,
                 slug: row.slug,
-                topics: row.topics_json ? JSON.parse(row.topics_json as string) : []
+                topics: row.topics_json ? JSON.parse(row.topics_json as string) : [],
+                requires_auth: Number(row.requires_auth ?? 0) === 1 ? 1 : 0,
+                editorial_category: (row.editorial_category as string) || 'feature',
+                secondary_categories: (() => {
+                    try {
+                        const raw = row.secondary_categories_json
+                        if (!raw) return [] as string[]
+                        const parsed = JSON.parse(raw as string)
+                        return Array.isArray(parsed) ? parsed.map((s: any) => String(s)) : []
+                    } catch { return [] as string[] }
+                })(),
             }))
 
             return {
@@ -94,7 +108,8 @@ export default defineEventHandler(async (event) => {
             const descCol = lang === 'es' ? 'description_es' : 'description_en'
 
             let cineSql = `SELECT id, slug, ${titleCol} AS title, ${descCol} AS description,
-                                  image_url, published_at, topics_json
+                                  image_url, published_at, topics_json,
+                                  requires_auth, editorial_category, secondary_categories_json
                            FROM cinemagoria_articles
                            WHERE is_visible = 1 AND is_cinemagoria = 1
                              AND (datetime(published_at) IS NULL OR datetime(published_at) <= datetime('now'))`
@@ -120,7 +135,17 @@ export default defineEventHandler(async (event) => {
                 video_id: null,
                 is_internal: true,
                 slug: row.slug,
-                topics: row.topics_json ? JSON.parse(row.topics_json as string) : []
+                topics: row.topics_json ? JSON.parse(row.topics_json as string) : [],
+                requires_auth: Number(row.requires_auth ?? 0) === 1 ? 1 : 0,
+                editorial_category: (row.editorial_category as string) || 'feature',
+                secondary_categories: (() => {
+                    try {
+                        const raw = row.secondary_categories_json
+                        if (!raw) return [] as string[]
+                        const parsed = JSON.parse(raw as string)
+                        return Array.isArray(parsed) ? parsed.map((s: any) => String(s)) : []
+                    } catch { return [] as string[] }
+                })(),
             }))
 
             items.push(...cineItems)

--- a/server/utils/rss-feed.ts
+++ b/server/utils/rss-feed.ts
@@ -243,14 +243,16 @@ export async function buildNewsFeed(lang: FeedLang): Promise<string> {
             media.push(`      <media:content url="${escapeXml(cover)}" medium="image"/>`)
             media.push(`      <media:thumbnail url="${escapeXml(cover)}"/>`)
         }
-        if (carousel && carousel !== cover) {
-            media.push(`      <media:content url="${escapeXml(carousel)}" medium="image"/>`)
-        }
-        if (ytId) {
-            const videoWatchUrl = provider === 'vimeo'
-                ? `https://vimeo.com/${escapeXml(ytId)}`
-                : `https://www.youtube.com/watch?v=${escapeXml(ytId)}`
-            media.push(`      <media:content url="${videoWatchUrl}" type="text/html" medium="video"/>`)
+        if (!isGated) {
+            if (carousel && carousel !== cover) {
+                media.push(`      <media:content url="${escapeXml(carousel)}" medium="image"/>`)
+            }
+            if (ytId) {
+                const videoWatchUrl = provider === 'vimeo'
+                    ? `https://vimeo.com/${escapeXml(ytId)}`
+                    : `https://www.youtube.com/watch?v=${escapeXml(ytId)}`
+                media.push(`      <media:content url="${videoWatchUrl}" type="text/html" medium="video"/>`)
+            }
         }
 
         return `    <item>

--- a/server/utils/rss-feed.ts
+++ b/server/utils/rss-feed.ts
@@ -137,14 +137,13 @@ export async function buildNewsFeed(lang: FeedLang): Promise<string> {
 
         const parts: string[] = []
         if (isGated) {
-            // Gated CDATA: description + sign-in legend only. No body, no
-            // trailer block, no carousel, no inline cover figure.
-            if (description) {
-                parts.push(`<p><em>${escapeXml(description)}</em></p>`)
-            }
+            // Gated CDATA: just the sign-in legend. The <description> tag
+            // above already carries the description — repeating it inside
+            // <content:encoded> as <em> would be redundant. Body, trailer,
+            // carousel and inline cover are all dropped.
             const legend = isEs
-                ? `<p>Para leer el artículo completo, iniciá sesión o creá una cuenta <strong>gratis</strong> en <a href="${loginUrl}">${loginUrl}</a> — sin tarjeta de crédito ni débito.</p>`
-                : `<p>To read the full article, sign in or create a <strong>free</strong> account at <a href="${loginUrl}">${loginUrl}</a> — no credit or debit card required.</p>`
+                ? `<p>Para leer el artículo completo, iniciá sesión o creá una cuenta gratuita en <a href="${loginUrl}">${loginUrl}</a>.</p>`
+                : `<p>To read the full article, sign in or create a free account at <a href="${loginUrl}">${loginUrl}</a>.</p>`
             parts.push(legend)
         } else {
             if (cover) {

--- a/server/utils/rss-feed.ts
+++ b/server/utils/rss-feed.ts
@@ -45,13 +45,22 @@ const splitAtMiddleH2 = (html: string): { before: string; after: string } => {
     return { before: html.slice(0, mid), after: html.slice(mid) }
 }
 
+// Editorial taxonomy facet URI prefixes used in <category domain="…"> tags.
+// Distinguishes the primary editorial label and any secondaries from the
+// free-form topic tags, without leaking the brand into either side. Feed
+// consumers that ignore the domain attribute still see all three layers as
+// plain categories — backward-compatible.
+const CATEGORY_PRIMARY_DOMAIN = 'https://cinemagoria.com/news/category/primary'
+const CATEGORY_SECONDARY_DOMAIN = 'https://cinemagoria.com/news/category/secondary'
+
 export async function buildNewsFeed(lang: FeedLang): Promise<string> {
     const db = useDb()
 
     const result = await db.execute({
         sql: `SELECT slug, title_en, title_es, description_en, description_es,
                      body_en, body_es, image_url, published_at,
-                     trailer_youtube_id, trailer_provider, carousel_assets, topics_json
+                     trailer_youtube_id, trailer_provider, carousel_assets, topics_json,
+                     requires_auth, editorial_category, secondary_categories_json
               FROM cinemagoria_articles
               WHERE is_visible = 1 AND is_cinemagoria = 1
                 AND (datetime(published_at) IS NULL OR datetime(published_at) <= datetime('now'))
@@ -105,6 +114,14 @@ export async function buildNewsFeed(lang: FeedLang): Promise<string> {
         const provider = ((row.trailer_provider as string) || 'youtube') as 'youtube' | 'vimeo'
         const carousel = firstCarousel(row.carousel_assets)
 
+        // Community gate: when requires_auth = 1, the CDATA collapses to
+        // description + a sign-in legend. The body, trailer block, carousel
+        // figure, and inline cover are dropped from the CDATA. Top-level
+        // <title>, <description>, <media:*>, and <category> tags stay so the
+        // feed reader still has a recognizable card layout.
+        const isGated = Number(row.requires_auth ?? 0) === 1
+        const loginUrl = `${selfBase}/login`
+
         let bodyHtml = ''
         try { bodyHtml = md.render(bodyMd) } catch { bodyHtml = `<p>${escapeXml(bodyMd)}</p>` }
 
@@ -119,49 +136,61 @@ export async function buildNewsFeed(lang: FeedLang): Promise<string> {
             : ''
 
         const parts: string[] = []
-        if (cover) {
-            parts.push(`<figure><img src="${escapeXml(cover)}" alt="${escapeXml(title)}" /></figure>`)
-        }
-        if (description) {
-            parts.push(`<p><em>${escapeXml(description)}</em></p>`)
-        }
-        if (ytId) {
-            if (provider === 'vimeo') {
-                // Vimeo path — thumb URL is per-video (hash-based), so we look
-                // it up via oEmbed (pre-fetched above into vimeoMap). If the
-                // lookup failed, fall back to a text-only link so the feed
-                // never breaks because of a single bad video.
-                const watch = `https://vimeo.com/${escapeXml(ytId)}`
-                const thumb = vimeoMap.get(ytId)?.thumbnail_url || ''
-                const label = isEs ? 'Ver el tráiler en Vimeo' : 'Watch the trailer on Vimeo'
-                if (thumb) {
-                    parts.push(
-                        `<p><a href="${watch}"><img src="${escapeXml(thumb)}" alt="${escapeXml(title)} — trailer" /></a><br/><a href="${watch}">▶ ${label}</a></p>`
-                    )
-                } else {
-                    parts.push(`<p><a href="${watch}">▶ ${label}</a></p>`)
-                }
-            } else {
-                // YouTube path — unchanged from pre-Vimeo behavior.
-                const watch = `https://www.youtube.com/watch?v=${escapeXml(ytId)}`
-                const thumb = `https://img.youtube.com/vi/${escapeXml(ytId)}/hqdefault.jpg`
-                parts.push(
-                    `<p><a href="${watch}"><img src="${thumb}" alt="${escapeXml(title)} — trailer" /></a><br/><a href="${watch}">▶ ${isEs ? 'Ver el tráiler en YouTube' : 'Watch the trailer on YouTube'}</a></p>`
-                )
+        if (isGated) {
+            // Gated CDATA: description + sign-in legend only. No body, no
+            // trailer block, no carousel, no inline cover figure.
+            if (description) {
+                parts.push(`<p><em>${escapeXml(description)}</em></p>`)
             }
-        }
-        if (ytId && showCarousel) {
-            // Trailer + carousel: carousel goes mid-body, like the site.
-            const { before, after } = splitAtMiddleH2(bodyHtml)
-            parts.push(before)
-            parts.push(carouselFigure)
-            if (after) parts.push(after)
-        } else if (showCarousel) {
-            // Carousel, no trailer: image sits before the body, like the site.
-            parts.push(carouselFigure)
-            parts.push(bodyHtml)
+            const legend = isEs
+                ? `<p>Para leer el artículo completo, iniciá sesión o creá una cuenta <strong>gratis</strong> en <a href="${loginUrl}">${loginUrl}</a> — sin tarjeta de crédito ni débito.</p>`
+                : `<p>To read the full article, sign in or create a <strong>free</strong> account at <a href="${loginUrl}">${loginUrl}</a> — no credit or debit card required.</p>`
+            parts.push(legend)
         } else {
-            parts.push(bodyHtml)
+            if (cover) {
+                parts.push(`<figure><img src="${escapeXml(cover)}" alt="${escapeXml(title)}" /></figure>`)
+            }
+            if (description) {
+                parts.push(`<p><em>${escapeXml(description)}</em></p>`)
+            }
+            if (ytId) {
+                if (provider === 'vimeo') {
+                    // Vimeo path — thumb URL is per-video (hash-based), so we look
+                    // it up via oEmbed (pre-fetched above into vimeoMap). If the
+                    // lookup failed, fall back to a text-only link so the feed
+                    // never breaks because of a single bad video.
+                    const watch = `https://vimeo.com/${escapeXml(ytId)}`
+                    const thumb = vimeoMap.get(ytId)?.thumbnail_url || ''
+                    const label = isEs ? 'Ver el tráiler en Vimeo' : 'Watch the trailer on Vimeo'
+                    if (thumb) {
+                        parts.push(
+                            `<p><a href="${watch}"><img src="${escapeXml(thumb)}" alt="${escapeXml(title)} — trailer" /></a><br/><a href="${watch}">▶ ${label}</a></p>`
+                        )
+                    } else {
+                        parts.push(`<p><a href="${watch}">▶ ${label}</a></p>`)
+                    }
+                } else {
+                    // YouTube path — unchanged from pre-Vimeo behavior.
+                    const watch = `https://www.youtube.com/watch?v=${escapeXml(ytId)}`
+                    const thumb = `https://img.youtube.com/vi/${escapeXml(ytId)}/hqdefault.jpg`
+                    parts.push(
+                        `<p><a href="${watch}"><img src="${thumb}" alt="${escapeXml(title)} — trailer" /></a><br/><a href="${watch}">▶ ${isEs ? 'Ver el tráiler en YouTube' : 'Watch the trailer on YouTube'}</a></p>`
+                    )
+                }
+            }
+            if (ytId && showCarousel) {
+                // Trailer + carousel: carousel goes mid-body, like the site.
+                const { before, after } = splitAtMiddleH2(bodyHtml)
+                parts.push(before)
+                parts.push(carouselFigure)
+                if (after) parts.push(after)
+            } else if (showCarousel) {
+                // Carousel, no trailer: image sits before the body, like the site.
+                parts.push(carouselFigure)
+                parts.push(bodyHtml)
+            } else {
+                parts.push(bodyHtml)
+            }
         }
         const contentHtml = parts.filter(Boolean).join('\n')
 
@@ -171,10 +200,43 @@ export async function buildNewsFeed(lang: FeedLang): Promise<string> {
             if (Array.isArray(parsed)) topics = parsed.map((t: any) => String(t)).filter(Boolean)
         } catch { /* ignore malformed topics */ }
 
-        const categories = topics
-            .slice(0, 6)
-            .map(t => `      <category>${escapeXml(t)}</category>`)
-            .join('\n')
+        // Editorial taxonomy: emit primary first with its domain attribute,
+        // then any secondaries with the secondary domain, then the free-form
+        // topics as plain <category>. Taxonomy stays exposed even on gated
+        // items — it's metadata, not body, and helps Feedly filtering. Feed
+        // consumers that ignore the domain attribute treat all three layers
+        // as plain categories (backward-compatible).
+        const primaryCategory = row.editorial_category
+            ? String(row.editorial_category).trim().toLowerCase()
+            : ''
+        let secondaryCategories: string[] = []
+        try {
+            const parsedSecs = row.secondary_categories_json
+                ? JSON.parse(row.secondary_categories_json as string)
+                : []
+            if (Array.isArray(parsedSecs)) {
+                secondaryCategories = parsedSecs
+                    .map((s: any) => String(s).trim().toLowerCase())
+                    .filter(Boolean)
+                    .slice(0, 2)
+            }
+        } catch { /* ignore malformed secondaries */ }
+
+        const taxonomyLines: string[] = []
+        if (primaryCategory) {
+            taxonomyLines.push(
+                `      <category domain="${CATEGORY_PRIMARY_DOMAIN}">${escapeXml(primaryCategory)}</category>`
+            )
+        }
+        for (const sec of secondaryCategories) {
+            taxonomyLines.push(
+                `      <category domain="${CATEGORY_SECONDARY_DOMAIN}">${escapeXml(sec)}</category>`
+            )
+        }
+        for (const t of topics.slice(0, 6)) {
+            taxonomyLines.push(`      <category>${escapeXml(t)}</category>`)
+        }
+        const categories = taxonomyLines.join('\n')
 
         const media: string[] = []
         if (cover) {


### PR DESCRIPTION
Closes #362.

## Summary

Adds a per-article community gate (`requires_auth`) and an editorial taxonomy (`editorial_category` + `secondary_categories_json`) on `cinemagoria_articles`, surfaced end-to-end across the news index, article page, RSS feed, and the CMS authoring flow.

## What ships in this PR

**Schema** (already applied to prod via `scripts/migrate-add-taxonomy-and-gate.ts` + `scripts/flush-categorize-progress.ts`):
- `requires_auth INTEGER NOT NULL DEFAULT 0`
- `editorial_category TEXT NOT NULL DEFAULT 'feature'`
- `secondary_categories_json TEXT DEFAULT NULL`
- Three supporting indexes (editorial_category+published_at, requires_auth, is_visible+is_cinemagoria+published_at).
- All 136 `is_cinemagoria = 1` rows backfilled with the operator's category picks captured via `scripts/categorize.ts`.

**Frontend (`cinemagoria-main`):**
- `/api/article/[slug]` + `/api/news` return the three new fields.
- `pages/news/[slug].vue`: sidebar Categories block (primary + secondaries, clickable to `?category=`); inline glassmorphism gate-card when `requires_auth = 1 && !logged_in`; trailer / carousel / AI disclosure hidden under the gate, cover/hero stays.
- `pages/news/index.vue`: editorial chip filter wrapped in glassmorphism panel below the header-status block; minimal text-only chips; match expanded to primary OR secondary.
- `components/global/AuthModal.vue`: title swap to "Join the community." when opened with `action: 'requires_auth_article'`; captures `auth_return_url` on open so the OAuth round-trip lands the reader back on the article instead of the homepage.
- `components/global/NewsCarousel.vue`, `components/search/NewsResultCard.vue`: brand-redundant CINEMAGORIA label replaced with the editorial category for internal items.

**RSS feed (`server/utils/rss-feed.ts`, byte-identical between main and es):**
- Three `<category>` layers per item: primary + secondaries with `domain` attribute, topics as plain `<category>`. Taxonomy stays exposed on gated items.
- Gated items: `<content:encoded>` collapses to one sign-in legend pointing at `/login`. Trailer and carousel `<media:content>` blocks dropped. Cover `<enclosure>` + `<media:thumbnail>` + `<media:content>` kept.

**CMS (`cinemagoria-rss-aggregator/scripts/cms.ts`):**
- `modeAdd` and `modeRecover` capture editorial_category + secondaries at the end of the flow, right before Cloudinary uploads, via a shared `promptEditorialTaxonomy()` helper that mirrors the UX of `scripts/categorize.ts`.
- `modeModify` submenu gains `Categories (primary + secondaries)` and `Toggle REQUIRES_AUTH`. "Current state" block surfaces both.
- Three companion scripts already on `main`: `scripts/categorize.ts` (interactive backfill + DB writer), `scripts/migrate-add-taxonomy-and-gate.ts` (idempotent schema migration), `scripts/flush-categorize-progress.ts` (one-shot flush of the JSON progress to DB).

**`cinemagoria-es`:**
- Mirrors every frontend / RSS / Terms change.
- `server/utils/rss-feed.ts` verified byte-identical with main.

**Terms (`pages/usage-policies/index.vue`):**
- New paragraph announcing the policy effective 2026-07-01, present in cinemagoria-main, -es, -stream, -estream. The cinemagoria-main Terms change already landed as #363.

## Test plan

- [x] `npm run dev` on main and es; visit `/news/<gated-slug>` while signed out → gate card renders SSR; no trailer/carousel/AI disclosure; cover stays.
- [x] Click "Sign in or join" → AuthModal opens with community copy.
- [x] Complete Google OAuth round-trip → redirected back to the article URL (not `/`).
- [x] Article body now renders in full; sidebar Categories pills clickable to `/news?category=…`.
- [x] Toggle the test article's `requires_auth` 1 → 0 via `npm run cms` MODIFY → reload → full body, no gate.
- [x] `curl https://cinemagoria.com/feed?cb=1 | xmllint --format -` for the gated item: three `<category>` layers present; `<content:encoded>` CDATA only contains the sign-in legend; cover present, carousel/video absent.
- [x] News index chip filter: pick `industry` → confirms expanded match surfaces secondaries (known-issue flagged in [#issuecomment-4715053553](https://github.com/cinemagoria/cinemagoria/issues/362#issuecomment-4715053553) for future reduction).