### PR TITLE
Consolidate editorial taxonomy: 12 → 8 buckets + full archive recategorization

### DIFF
--- a/components/global/NewsCarousel.vue
+++ b/components/global/NewsCarousel.vue
@@ -103,6 +103,7 @@ import Loader from '@/components/Loader';
 import carousel from '~/mixins/Carousel';
 import striptags from 'striptags';
 import { formatDate, handleImageError } from '~/utils/helpers';
+import { categoryLabel } from '~/utils/categoryLabels';
 
 const AUTOPLAY_INTERVAL = 10000;
 
@@ -191,7 +192,7 @@ export default {
     // publisher name for external aggregated items.
     carouselBadge(article) {
       if (article?.editorial_category) {
-        return String(article.editorial_category).toUpperCase();
+        return categoryLabel(article.editorial_category);
       }
       return article?.source?.name || '';
     },

--- a/components/search/NewsResultCard.vue
+++ b/components/search/NewsResultCard.vue
@@ -30,6 +30,7 @@
 <script>
 import striptags from 'striptags';
 import { formatDate } from '~/utils/helpers';
+import { categoryLabel } from '~/utils/categoryLabels';
 
 export default {
   props: {
@@ -44,7 +45,7 @@ export default {
     // publisher name for external aggregated items.
     cardBadge() {
       if (this.item?.editorial_category) {
-        return String(this.item.editorial_category).toUpperCase();
+        return categoryLabel(this.item.editorial_category);
       }
       return this.item?.source?.name || '';
     }

--- a/pages/news/[slug].vue
+++ b/pages/news/[slug].vue
@@ -104,13 +104,13 @@
                 <NuxtLink
                   :to="{ path: '/news', query: { category: article.editorial_category } }"
                   class="sidebar-tag sidebar-tag--category sidebar-tag--primary"
-                >{{ article.editorial_category.toUpperCase() }}</NuxtLink>
+                >{{ categoryLabel(article.editorial_category) }}</NuxtLink>
                 <NuxtLink
                   v-for="sec in (article.secondary_categories || [])"
                   :key="sec"
                   :to="{ path: '/news', query: { category: sec } }"
                   class="sidebar-tag sidebar-tag--category"
-                >{{ sec.toUpperCase() }}</NuxtLink>
+                >{{ categoryLabel(sec) }}</NuxtLink>
               </div>
 
               <!-- Sources -->
@@ -431,6 +431,7 @@ import ArticleAIDisclosure from '@/components/global/ArticleAIDisclosure';
 import ArticleShareModal from '@/components/global/ArticleShareModal';
 import MarkdownIt from 'markdown-it'
 import { apiImgUrl, getCustomEnrichment } from '@/utils/api'
+import { categoryLabel } from '@/utils/categoryLabels'
 import { stripRelatedFooter, extractRelatedSlugs } from '@/utils/relatedFooter'
 
 const md = new MarkdownIt({ breaks: true, html: true })

--- a/pages/news/index.vue
+++ b/pages/news/index.vue
@@ -103,7 +103,7 @@
               role="tab"
               :aria-selected="categoryFilter === cat"
               @click="pickCategory(cat)"
-            >{{ cat }}</button>
+            >{{ categoryLabel(cat) }}</button>
           </div>
 
           <div v-if="pending" class="loading-grid">
@@ -292,6 +292,7 @@ import UserNav from '@/components/global/UserNav';
 import Loader from '@/components/Loader';
 import striptags from 'striptags';
 import { SOURCE_URLS } from '~/utils/newsSources';
+import { categoryLabel } from '~/utils/categoryLabels';
 
 useHead({
   title: 'Cinemagoria — Latest Film & TV News',
@@ -320,9 +321,8 @@ const topicFromArticle = ref(null);
 // An item matches when its primary OR any of its secondaries equals the picked
 // value — cross-cuts the archive without polluting the primary badge.
 const CATEGORY_OPTIONS = [
-  'feature', 'industry', 'festival', 'awards',
-  'production', 'trailer', 'acquisition', 'boxoffice',
-  'streaming', 'interview', 'review', 'opinion',
+  'festival', 'industry', 'trailer', 'review',
+  'awards', 'streaming', 'interview', 'documentary',
 ];
 const categoryFilter = ref(
   typeof route.query.category === 'string' && CATEGORY_OPTIONS.includes(route.query.category)
@@ -342,7 +342,7 @@ watch(() => route.query.category, (next) => {
 // brand-redundant "CINEMAGORIA" label), fall back to publisher name for
 // external aggregated items.
 function cardBadge(item) {
-  if (item?.editorial_category) return String(item.editorial_category).toUpperCase();
+  if (item?.editorial_category) return categoryLabel(item.editorial_category);
   return item?.source?.name || '';
 }
 

--- a/server/utils/rss-feed.ts
+++ b/server/utils/rss-feed.ts
@@ -21,18 +21,14 @@ const md = new MarkdownIt({ breaks: true, html: true })
 // sync with cinemagoria-es/utils/categoryLabels.js — if the user-facing
 // translation changes there, mirror it here.
 const CATEGORY_LABELS_ES: Record<string, string> = {
-    feature:     'Editorial',
-    industry:    'Industria',
     festival:    'Festival',
+    industry:    'Industria / Adquisiciones / Taquilla',
+    trailer:     'Tráiler / Teaser / Primeras Imágenes',
+    review:      'Crítica / Opinión',
     awards:      'Premios',
-    production:  'Producción',
-    trailer:     'Tráiler',
-    acquisition: 'Adquisición',
-    boxoffice:   'Desempeño Comercial',
     streaming:   'Streaming',
     interview:   'Entrevista',
-    review:      'Crítica',
-    opinion:     'Opinión',
+    documentary: 'Documentales',
 }
 
 const labelForFeed = (cat: string, isEs: boolean): string => {

--- a/utils/categoryLabels.js
+++ b/utils/categoryLabels.js
@@ -1,0 +1,20 @@
+// English display labels for the editorial taxonomy. The DB value (lowercase
+// token) is the canonical key used by URLs (?category=), the chip filter, the
+// article sidebar, and card badges. Some buckets are compound (one token,
+// several editorial angles). The ES channel resolves its own map in
+// server/utils/rss-feed.ts; the EN feed emits the raw token.
+export const CATEGORY_LABELS = {
+    festival:    'Festival',
+    industry:    'Industry / Acquisition / Box Office',
+    trailer:     'Trailer / Teaser / First Looks',
+    review:      'Review / Opinion',
+    awards:      'Awards',
+    streaming:   'Streaming',
+    interview:   'Interview',
+    documentary: 'Documentaries',
+};
+
+export function categoryLabel(cat) {
+    if (!cat) return '';
+    return CATEGORY_LABELS[String(cat).toLowerCase()] || String(cat);
+}


### PR DESCRIPTION
Closes #366.

Consolidates the editorial taxonomy from 12 to 8 buckets and recategorizes the full archive. See #366 for the editorial rationale and the #362 follow-up note it acts on.

## This PR — `cinemagoria-main` (EN frontend)
- `CATEGORY_OPTIONS` reduced to the 8 buckets (`festival, industry, trailer, review, awards, streaming, interview, documentary`).
- New `utils/categoryLabels.js` EN compound label map; every badge, chip, and kicker resolves through it (index filter, article sidebar, `NewsCarousel`, `NewsResultCard`) plus the ES feed labels in `server/utils/rss-feed.ts`.
- DB tokens and `?category=` URLs are unchanged; the primary-or-secondary filter behavior is preserved.

## Landed as direct commits (tracked by this issue)
- **`cinemagoria-rss-aggregator`** (`main`): enum 12→8 in `cms.ts` + `categorize.ts`; new reversible `consolidate-taxonomy.ts` + plan.
- **`cinemagoria-es`** (`es` branch): mirror of the 8 buckets + Spanish compound labels.
- `cinemagoria-stream` / `cinemagoria-estream`: no taxonomy/news system — no changes.

## Data migration (applied, reversible)
144 internal articles recategorized per-article (festival-priority, documentaries as a secondary dimension). Result — primary distribution: `festival 80, industry 28, trailer 18, streaming 14, review 3, interview 1`; `documentary`/`awards` appear only as secondaries. Zero rows remain on `feature`/`production`/`acquisition`/`boxoffice`/`opinion`. Pre-write backup retained.

Worked examples match the target state: `593 → trailer`, `765 → festival + documentary`, `767 → festival + trailer`, `770 → trailer`.
