### PR TITLE
Shorten EN trailer taxonomy chip label

### DIFF
--- a/utils/categoryLabels.js
+++ b/utils/categoryLabels.js
@@ -6,7 +6,7 @@
 export const CATEGORY_LABELS = {
     festival:    'Festival',
     industry:    'Industry / Acquisition / Box Office',
-    trailer:     'Trailer / Teaser / First Looks',
+    trailer:     'Trailer / First Looks',
     review:      'Review / Opinion',
     awards:      'Awards',
     streaming:   'Streaming',


### PR DESCRIPTION
Follow-up to #366. Drops `Teaser` from the EN trailer bucket label so the news-index chip mirrors the shorter ES wording (`Avance / Primer Vistazo`) and stops overflowing.

- `Trailer / Teaser / First Looks` → `Trailer / First Looks`
- `industry` stays the long compound, parallel to ES.
- Token and `?category=trailer` unchanged.