### PR TITLE
Fix category-panel horizontal overflow on news index (901–1350px)

### DIFF
--- a/pages/news/index.vue
+++ b/pages/news/index.vue
@@ -999,6 +999,7 @@ watch(userEmail, (val) => {
 
 .news-main {
   flex-grow: 1;
+  min-width: 0;
 }
 
 .header-status {


### PR DESCRIPTION
Fixes a horizontal overflow on `pages/news/index.vue` between ~901px and ~1350px. It only affected this route because it is the only page with the editorial category-panel.

## Cause
`.news-main` is a flex item inside `.content-wrapper` (`display:flex`) with `flex-grow:1` but no `min-width:0`, so it kept the flex default `min-width:auto` and refused to shrink below the min-content width of the category chips (`flex-wrap:nowrap`, `flex-shrink:0`). That stretched the page wider than the viewport and defeated the panel's own `overflow-x:auto`, so the background and bottom nav looked "short".

## Fix
Add `min-width:0` to `.news-main` so it can shrink to the available width; the chips then scroll inside the panel as intended. The same one-line fix landed directly on `es`.

Refs #366.
