### PR TITLE
KVIFF 2026: populate Schedule tab with official screenings

### DIFF
--- a/pages/festival/kviff-2026/index.vue
+++ b/pages/festival/kviff-2026/index.vue
@@ -154,13 +154,15 @@
                      </div>
 
                       <div class="film-info">
-                         <a
-                            href="https://www.kviff.com/en/programme"
-                            target="_blank"
+                         <component
+                            :is="screening.film.source_url ? 'a' : 'span'"
+                            :href="screening.film.source_url || ''"
+                            :target="screening.film.source_url ? '_blank' : ''"
                             class="film-title"
+                            :class="{'no-link': !screening.film.source_url}"
                          >
                             {{ screening.film.title }}
-                         </a>
+                         </component>
                          <div class="film-meta">
                              <span v-if="screening.film.director">Directed by {{ screening.film.director }}</span>
                              <span v-if="screening.film.director && screening.film.runtime"> • </span>

--- a/pages/festival/kviff-2026/index.vue
+++ b/pages/festival/kviff-2026/index.vue
@@ -149,7 +149,7 @@
                 <div v-show="isOpen(date)" class="screenings-list">
                   <div v-for="screening in dayScreenings" :key="screening.id" class="screening-card">
                      <div class="time-block">
-                        <span class="time">{{ formatTime(screening.start_time) }}</span>
+                        <span class="time">{{ formatTime(screening.start_time, screening.timezone) }}</span>
                         <span class="timezone">{{ screening.timezone }}</span>
                      </div>
 
@@ -386,15 +386,20 @@ function toggleCategoryOpen (cat) {
     categoryOpen.value = { ...categoryOpen.value, [cat]: !isCategoryOpen(cat) };
 }
 
+const FESTIVAL_TZ = 'Europe/Prague';
+
 const formatDate = (dateStr) => {
-    const options = { weekday: 'long', month: 'long', day: 'numeric' };
-    return new Date(dateStr).toLocaleDateString('en-US', options);
+    // dateStr is the festival-local day key (YYYY-MM-DD). Anchor to UTC so it
+    // renders the same calendar day regardless of the viewer's timezone.
+    const options = { weekday: 'long', month: 'long', day: 'numeric', timeZone: 'UTC' };
+    return new Date(`${dateStr}T00:00:00Z`).toLocaleDateString('en-US', options);
 };
 
-const formatTime = (timeStr) => {
+const formatTime = (timeStr, tz) => {
     return new Date(timeStr).toLocaleTimeString('en-US', {
         hour: '2-digit',
-        minute: '2-digit'
+        minute: '2-digit',
+        timeZone: tz || FESTIVAL_TZ
     });
 };
 


### PR DESCRIPTION
Closes #372.

Brings the KVIFF 2026 **Schedule** tab to life with the official screenings.

## Data (Turso — already applied)
- **442 screenings** inserted into `festival_screenings`, covering **137 / 137** of the KVIFF 2026 films currently in `festival_films`.
- Sourced from the official KVIFF catalogue (per-film screening blocks), matched to our films by the KVIFF film id embedded in `source_url` — exact id match, no fuzzy title matching.
- Each row carries `start_time` (ISO 8601, `Europe/Prague` → `+02:00`), `venue`, and `is_in_person = 1` (no online tier this edition).
- Integrity: 0 duplicates, weekday labels cross-checked 483/483, all dates within July 3–11, 0 null venues.

## Frontend (`pages/festival/kviff-2026/index.vue`)
- **Film links** now point at each film's own `source_url`, opening in a new tab (plain-span fallback when a film has no URL) — mirrors the `tribeca-2026` pattern, replacing the previous static link to the generic KVIFF programme page.
- **Timezone fix:** day headers and screening times render in `Europe/Prague` instead of the viewer's local zone. Previously a 09:00 Prague screening showed as e.g. 04:00 under the wrong day for UTC-negative viewers, despite the `Europe/Prague` label. `formatDate` now anchors the day key to UTC; `formatTime` uses the screening's timezone.

## Note
The schedule reflects the official catalogue (July 3–11). The July 1 *Bitter Christmas* prelude in Mariánské Lázně is a press-announced special event absent from every KVIFF catalogue/film page, so it is intentionally excluded.