### PR TITLE
Improve Notification Relevance with Multi-Signal Confidence Scoring

### DIFF
--- a/pages/notifications/index.vue
+++ b/pages/notifications/index.vue
@@ -520,7 +520,7 @@ export default {
         
         const data = await response.json();
         if (data.success) {
-          this.notifications = data.notifications;
+          this.notifications = (data.notifications || []).filter(n => this.isPlausibleNotification(n));
           if (data.pagination) {
             this.currentPage = data.pagination.current_page;
             this.perPage = data.pagination.per_page;
@@ -534,6 +534,20 @@ export default {
         this.loading = false;
         this.isLoadingPage = false;
       }
+    },
+
+    // Defense-in-depth backstop for the server-side trust gate
+    // (see docs/notifications/tmdb-trust-model.md): hide any notification whose
+    // release date is implausibly far in the future. New notifications are already
+    // trust-scored upstream; this also cleans up legacy rows dispatched before that
+    // gate existed. 
+    isPlausibleNotification(n) {
+      if (!n || !n.release_date) return true;        // no date → keep
+      const released = new Date(n.release_date);
+      if (isNaN(released.getTime())) return true;    // unparseable → keep
+      const maxFuture = new Date();
+      maxFuture.setFullYear(maxFuture.getFullYear() + 3);
+      return released <= maxFuture;
     },
 
     toggleFilter() {

--- a/pages/notifications/index.vue
+++ b/pages/notifications/index.vue
@@ -536,15 +536,13 @@ export default {
       }
     },
 
-    // Defense-in-depth backstop for the server-side trust gate
-    // (see docs/notifications/tmdb-trust-model.md): hide any notification whose
-    // release date is implausibly far in the future. New notifications are already
-    // trust-scored upstream; this also cleans up legacy rows dispatched before that
-    // gate existed. 
+    // Backstop for the server-side trust gate: drop implausibly far-future rows
+    // and clean up legacy notifications dispatched before that gate existed.
     isPlausibleNotification(n) {
-      if (!n || !n.release_date) return true;        // no date → keep
+      if (!n) return false;
+      if (!n.release_date) return true;
       const released = new Date(n.release_date);
-      if (isNaN(released.getTime())) return true;    // unparseable → keep
+      if (isNaN(released.getTime())) return true;
       const maxFuture = new Date();
       maxFuture.setFullYear(maxFuture.getFullYear() + 3);
       return released <= maxFuture;


### PR DESCRIPTION
Closes #374.

### What this solves

Today notifications are primarily generated from TMDB metadata associated with
tracked people and production companies.

This PR introduces an additional confidence evaluation layer before dispatching
a notification, allowing the system to better distinguish between highly
substantiated projects and titles with limited supporting signals.

The notification rule becomes:

> TMDB says it exists → evaluate confidence → decide whether it merits a notification.

### Why not the issue's original proposal

The issue suggested suppressing anything with `status = Rumored` or `Planned`.

While that would reduce noise, it would also suppress many legitimate projects
that spend months in those states before official materials, trailers, release
dates, or broader audience awareness emerge.

| Project | Status | Should notify? |
|---|---|---|
| A24 film announced by Variety | Rumored | ✅ Yes |
| Cannes title just added | Planned | ✅ Yes |
| Early-stage title with limited supporting signals | Rumored | Depends on confidence |

`status` alone is not a reliable indicator of notification quality.

Instead of treating specific statuses as automatic exclusions, this PR evaluates
multiple independent signals together to determine whether a title has enough
supporting evidence to justify a notification.

### The model — a weighted confidence score

Each candidate is scored on a combination of signals; no single field decides.

- `status` is **not** a disqualifier. Early-stage projects are an important part
  of the discovery experience.
- **User-editable fields cannot authorize a notification on their own.** Poster
  (+15), synopsis (+10), backdrop (+5) and status (+5) sum to at most 35,
  intentionally below the 45-point notification threshold.
- Crossing the threshold requires at least one stronger supporting signal such
  as audience engagement, production-company attribution, or external IDs.
- Low popularity is **never** a penalty. Niche festival, independent and genre
  projects often have little or no audience footprint when first added.
- Cast association alone is **not** rewarded, ensuring that person-linked
  notifications rely on broader supporting evidence rather than a single credit.
- Borderline candidates trigger one enrichment fetch (production companies,
  external IDs, status); clear-cut cases short-circuit without additional calls.

### Example evaluation

Example of a title with only basic metadata present:

| Signal | Effect |
|---|---|
| Status present | +5 |
| Poster + synopsis present | +25 |
| No production company | — |
| No external / IMDb ID | — |
| No audience engagement | — |
| Cast association only | not rewarded |
| **Total** | **30 / 100 → below the 45 threshold → not notified** |

The title remains discoverable throughout the platform but does not generate a
notification until additional supporting signals are present.

### Notification behavior

Notifications now require a stronger overall confidence profile rather than
relying solely on title existence in upstream metadata.

This provides two layers of protection:

1. Existing release-window constraints continue to limit notification candidates
   to relevant time horizons.

2. Confidence scoring independently evaluates supporting evidence and suppresses
   low-confidence candidates even when they fall within valid release windows.

As a result, notifications become more resilient to incomplete, speculative or
lightly-supported records while preserving visibility and discoverability across
the rest of the platform.

### Implementation

#### `cinemagoria-notifications-cron`

The scheduled engine (2×/day) now includes a self-contained, unit-tested
`src/trust.rs` scoring module.

In `src/main.rs`, the credit structs now deserialize the additional fields
required by the model (`popularity`, `vote_count`, `backdrop_path`), and a new
`should_notify` helper evaluates each candidate.

Clear cases short-circuit immediately, while borderline cases perform a single
enrichment fetch for production-company and external-ID verification.

The gate is applied in `check_new_releases` for both cast/crew and writer
notification paths, ensuring low-confidence titles are filtered before follower
notifications are generated.

Suppressed candidates are logged as:

```text
TRUST suppress [reason] ...
```

for operational monitoring.

#### `cinemagoria-follows-rust`

The same scoring logic is implemented in `api/gemini.rs`, which serves both the
Vercel deployment and the Cloud Run `server` binary.

The gate is applied inside `create_initial_notifications`, the synchronous path
executed immediately when a user follows a person.

This ensures consistent notification eligibility regardless of whether the
notification originates from a follow event or a scheduled scan.

#### `cinemagoria-main`

This PR also includes:

- The design documentation.
- A render-time backstop in `pages/notifications/index.vue`
  (`isPlausibleNotification`) that hides implausibly far-future legacy rows.
- Cleanup protection for notifications generated before confidence scoring
  existed.

Discovery behavior remains unchanged.

### Reference & tests

Full audit, pipeline trace and scoring model:

```text
docs/notifications/tmdb-trust-model.md
```

Unit tests cover:

- Established production → notify.
- Candidate with only user-editable metadata → suppress.
- In-production title with supporting footprint → notify.
- Empty shell / far-future record → suppress.
- Obscure low-popularity title with verified production attribution → notify.

Both services build clean.