### PR TITLE
Preserve Exact TMDB Release Dates During Rendering

### DIFF
--- a/components/movie/MovieInfo.vue
+++ b/components/movie/MovieInfo.vue
@@ -553,7 +553,11 @@ export default {
     },
     fullDate(date) {
       if (!date) return 'N/A';
-      return new Date(date).toLocaleDateString(process.env.API_COUNTRY === 'BR' ? 'pt-BR' : 'en-US', {
+      const parts = String(date).slice(0, 10).split('-');
+      if (parts.length !== 3) return date;
+      const [y, m, d] = parts.map(Number);
+      if (!y || !m || !d) return date;
+      return new Date(y, m - 1, d).toLocaleDateString(process.env.API_COUNTRY === 'BR' ? 'pt-BR' : 'en-US', {
         year: 'numeric',
         month: 'long',
         day: 'numeric'

--- a/components/tv/TvInfo.vue
+++ b/components/tv/TvInfo.vue
@@ -516,7 +516,11 @@ export default {
     },
     fullDate(date) {
       if (!date) return 'N/A';
-      return new Date(date).toLocaleDateString(process.env.API_COUNTRY === 'BR' ? 'pt-BR' : 'en-US', {
+      const parts = String(date).slice(0, 10).split('-');
+      if (parts.length !== 3) return date;
+      const [y, m, d] = parts.map(Number);
+      if (!y || !m || !d) return date;
+      return new Date(y, m - 1, d).toLocaleDateString(process.env.API_COUNTRY === 'BR' ? 'pt-BR' : 'en-US', {
         year: 'numeric',
         month: 'long',
         day: 'numeric'


### PR DESCRIPTION
<html><head></head><body><p>Closes #376.</p><h3>What this solves</h3><p>Release dates shown in the title information panels could render one calendar day<br>earlier or later than the date stored in TMDB.</p><p>TMDB provides release dates as date-only values (<code inline="">YYYY-MM-DD</code>). However, the<br>existing <code inline="">fullDate()</code> implementation parsed those values using:</p><pre><code class="language-js">new Date("2026-11-10")
</code></pre><p>JavaScript interprets this format as UTC midnight. When the resulting <code inline="">Date</code><br>object is later formatted through <code inline="">toLocaleDateString()</code>, the instant may shift<br>into the viewer's local timezone, causing the rendered day to move forward or<br>backward.</p><p>Example:</p>
TMDB value | Expected render | Possible render
-- | -- | --
2026-11-10 | November 10, 2026 | November 9, 2026 or November 11, 2026

<p>As a result, users in different timezones could see a release date that differs<br>from the canonical TMDB value.</p><h3>Root cause</h3><p>The issue was caused by treating a date-only string as a UTC timestamp.</p><pre><code class="language-js">new Date("YYYY-MM-DD")
</code></pre><p>creates a UTC-based date object, even though TMDB release dates represent<br>calendar dates rather than moments in time.</p><p>The subsequent locale formatting step introduced timezone-dependent day shifts.</p><h3>The fix</h3><p>Instead of relying on UTC parsing, the date string is now split into its<br>components and reconstructed as a local calendar date:</p><pre><code class="language-js">const [year, month, day] = date.split('-').map(Number)

return new Date(year, month - 1, day)
</code></pre><p>This creates a local-midnight <code inline="">Date</code> object without any UTC conversion.</p><p>The rendered value now preserves the exact TMDB calendar date regardless of:</p><ul><li><p>User timezone</p></li><li><p>Browser locale</p></li><li><p>SSR environment</p></li><li><p>Client-side rendering environment</p></li></ul><h3>Why only <code inline="">fullDate()</code> changed</h3><p>The existing <code inline="">releaseDateLabel()</code> and <code inline="">airDateLabel()</code> helpers were already<br>handling dates correctly and did not exhibit the offset issue.</p><p>They explicitly constructed local dates using:</p><pre><code class="language-js">date + 'T00:00:00'
</code></pre><p>As a result, only the <code inline="">fullDate()</code> implementation required modification.</p><h3>Implementation</h3><h4><code inline="">components/movie/MovieInfo.vue</code></h4><p>Updated the <code inline="">fullDate()</code> helper to avoid UTC parsing and preserve the exact<br>calendar date returned by TMDB.</p><h4><code inline="">components/tv/TvInfo.vue</code></h4><p>Applied the same fix to the <code inline="">fullDate()</code> helper used by TV titles.</p><h3>Repository coverage</h3><h4><code inline="">cinemagoria-main</code></h4><p>Applied to:</p><pre><code class="language-text">components/movie/MovieInfo.vue
components/tv/TvInfo.vue
</code></pre><p>Implemented in branch:</p><pre><code class="language-text">376-bug-release-date-rendering
</code></pre><p>Commit:</p><pre><code class="language-text">0527a7d7
</code></pre><h4><code inline="">cinemagoria-es</code></h4><p>Applied to:</p><pre><code class="language-text">components/movie/MovieInfo.vue
components/tv/TvInfo.vue
</code></pre><p>Commit:</p><pre><code class="language-text">982a5dca
</code></pre><h3>Result</h3><p>Release dates now render as the exact calendar day provided by TMDB.</p><p>A title with:</p><pre><code class="language-text">2026-11-10
</code></pre><p>will consistently display as:</p><pre><code class="language-text">November 10, 2026
</code></pre><p>across SSR, client-side rendering, and all supported timezones.</p></body></html>