### PR TITLE
Migrate CUFF and BAFICI festival page styles

### DIFF
--- a/pages/festival/bafici-2026/index.vue
+++ b/pages/festival/bafici-2026/index.vue
@@ -48,54 +48,79 @@
       </div>
 
       <div v-else>
-        <div v-if="activeTab === 'films'" class="films-grid">
-            <div v-if="features.length > 0" class="film-category">
-                <div class="category-header" @click="featuresOpen = !featuresOpen">
-                    <h2 class="listing__title category-title">
-                        Features
-                        <span class="category-count">({{ features.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="featuresOpen ? 'Collapse' : 'Expand'">
-                        <svg v-if="featuresOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
-                    </button>
-                </div>
-                <transition name="slide">
-                    <div v-show="featuresOpen" class="listing__items">
-                        <BaficiCard 
-                            v-for="item in features"
-                            :key="`feature-${item.id}`"
-                            :item="item" 
-                        />
-                    </div>
-                </transition>
+        <div v-if="activeTab === 'films'" class="selection">
+          <div v-if="orderedCategories.length === 0" class="rollout-banner">
+            <div class="rollout-banner__icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
             </div>
+            <div class="rollout-banner__copy">
+              <h3>Lineup updates in progress</h3>
+              <p>This festival lineup is currently being updated. New films, sections, and official selections will be added progressively as they are announced and verified.</p>
+            </div>
+          </div>
+          <div v-else class="selection-layout">
+            <aside class="selection-nav" aria-label="Jump to section">
+              <template v-if="officialNav.length">
+                <div class="nav-group-label">Catalog</div>
+                <button
+                  v-for="sec in officialNav"
+                  :key="sec.key"
+                  class="nav-item"
+                  :class="{ active: activeSection === sec.key }"
+                  @click="scrollToSection(sec.key)"
+                >
+                  <span class="nav-item-label">{{ sec.label }}</span>
+                  <span class="nav-item-count">{{ sec.count }}</span>
+                </button>
+              </template>
+            </aside>
 
-            <div v-if="shorts.length > 0" class="film-category">
-                <div class="category-header" @click="shortsOpen = !shortsOpen">
-                    <h2 class="listing__title category-title">
-                        Shorts
-                        <span class="category-count">({{ shorts.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="shortsOpen ? 'Collapse' : 'Expand'">
-                        <svg v-if="shortsOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
+            <div ref="selectionContentRef" class="selection-content">
+              <section
+                v-for="sec in selectionSections"
+                :key="sec.key"
+                :data-key="sec.key"
+                class="sel-section"
+              >
+                <div class="sel-section-header" @click="onSectionHeaderClick(sec.key)">
+                  <h2 class="sel-section-title">{{ sec.label }}</h2>
+                  <div class="sel-section-meta">
+                    <span class="sel-section-count">{{ sec.count }} {{ sec.count === 1 ? 'film' : 'films' }}</span>
+                    <button v-if="isMobile" class="expand-btn" :aria-label="isSectionOpen(sec.key) ? 'Collapse' : 'Expand'">
+                      <svg v-if="isSectionOpen(sec.key)" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
+                      <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
                     </button>
+                  </div>
                 </div>
                 <transition name="slide">
-                    <div v-show="shortsOpen" class="listing__items">
-                        <BaficiCard 
-                            v-for="item in shorts"
-                            :key="`short-${item.id}`"
-                            :item="item" 
-                        />
+                  <div v-show="!isMobile || isSectionOpen(sec.key)" class="sel-section-body">
+                    <div class="listing__items">
+                      <BaficiCard
+                        v-for="item in sec.films"
+                        :key="`${sec.key}-${item.id}`"
+                        :item="item"
+                      />
                     </div>
+                  </div>
                 </transition>
+              </section>
             </div>
+          </div>
         </div>
 
         <div v-if="activeTab === 'schedule'" class="schedule-container">
-          <div class="schedule-toolbar" :class="{ 'search-active': isScheduleSearchActive }">
+          <!-- Initial rollout banner: schedule pending official publication -->
+          <div v-if="schedule.length === 0" class="rollout-banner">
+            <div class="rollout-banner__icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+            </div>
+            <div class="rollout-banner__copy">
+              <h3>Schedule pending</h3>
+              <p>Official screening schedules have not yet been published by the festival. Screening information will appear here as soon as it becomes available.</p>
+            </div>
+          </div>
+
+          <div v-if="schedule.length > 0" class="schedule-toolbar" :class="{ 'search-active': isScheduleSearchActive }">
             <div class="schedule-toolbar-info">
               <span class="schedule-count" v-if="!loading">
                 <template v-if="scheduleSearchActiveQuery">
@@ -131,30 +156,48 @@
             <p>No screenings match "<strong>{{ scheduleSearch }}</strong>"</p>
           </div>
 
-          <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" class="schedule-day">
-            <div class="day-header" @click="toggleDay(date)">
+          <div v-if="scheduleDays.length" class="schedule-layout">
+            <aside class="schedule-nav" aria-label="Jump to day">
+              <div class="nav-group-label">Days</div>
+              <button
+                v-for="day in scheduleDays"
+                :key="day.date"
+                class="nav-item"
+                :class="{ active: activeDay === day.date }"
+                @click="scrollToDay(day.date)"
+              >
+                <span class="nav-item-label">{{ day.label }}</span>
+                <span class="nav-item-count">{{ day.count }}</span>
+              </button>
+            </aside>
+
+            <div ref="scheduleContentRef" class="schedule-content">
+              <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" :data-day="date" class="schedule-day">
+            <div class="day-header" @click="onDayHeaderClick(date)">
                 <h2>{{ formatDate(date) }}</h2>
-                <div class="chevron" :class="{ 'closed': !isOpen(date) }">
+                <div v-if="isMobile" class="chevron" :class="{ 'closed': !isOpen(date) }">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down"><path d="m6 9 6 6 6-6"/></svg>
                 </div>
             </div>
-            
+
             <transition name="slide">
-                <div v-show="isOpen(date)" class="screenings-list">
+                <div v-show="!isMobile || isOpen(date)" class="screenings-list">
                   <div v-for="screening in dayScreenings" :key="screening.id" class="screening-card">
                      <div class="time-block">
-                        <span class="time">{{ formatTime(screening.start_time) }}</span>
+                        <span class="time">{{ formatTime(screening.start_time, screening.timezone) }}</span>
                         <span class="timezone">{{ screening.timezone }}</span>
                      </div>
-                     
+
                       <div class="film-info">
-                         <a 
-                            :href="screening.film.source_url || 'https://bafici.org'"
-                            target="_blank"
+                         <component
+                            :is="screening.film.source_url ? 'a' : 'span'"
+                            :href="screening.film.source_url || ''"
+                            :target="screening.film.source_url ? '_blank' : ''"
                             class="film-title"
+                            :class="{'no-link': !screening.film.source_url}"
                          >
                             {{ screening.film.title }}
-                         </a>
+                         </component>
                          <div class="film-meta">
                              <span v-if="screening.film.director">Directed by {{ screening.film.director }}</span>
                              <span v-if="screening.film.director && screening.film.runtime"> • </span>
@@ -170,13 +213,13 @@
                              <span v-if="screening.is_sold_out" class="tag sold-out">Sold Out</span>
                          </div>
                       </div>
-                      
+
                       <div class="poster-mini">
-                          <img 
-                            v-if="screening.film.poster_path" 
-                            :src="screening.film.poster_path" 
-                            alt="Poster" 
-                            loading="lazy" 
+                          <img
+                            v-if="screening.film.poster_path"
+                            :src="screening.film.poster_path"
+                            alt="Poster"
+                            loading="lazy"
                             @error="$event.target.src = '/placeholders/image_not_found_yet.webp'"
                           />
                           <img v-else src="/placeholders/image_not_found_yet.webp" alt="No Poster" />
@@ -184,6 +227,8 @@
                   </div>
                 </div>
             </transition>
+          </div>
+            </div>
           </div>
         </div>
 
@@ -284,7 +329,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, nextTick } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount, nextTick, watch } from 'vue';
 import Loader from '~/components/Loader.vue';
 import WinnersCarousel from '~/components/festival/WinnersCarousel.vue';
 import FestivalDataDisclaimer from '~/components/FestivalDataDisclaimer.vue';
@@ -335,28 +380,103 @@ const prevSlide = () => { slideDirection.value = 'carousel-prev'; infoSlide.valu
 const nextSlide = () => { slideDirection.value = 'carousel-next'; infoSlide.value = (infoSlide.value + 1) % 4; };
 const goToSlide = (i) => { slideDirection.value = i > infoSlide.value ? 'carousel-next' : 'carousel-prev'; infoSlide.value = i; };
 
-const featuresOpen = ref(true);
-const shortsOpen = ref(true);
+const CATEGORY_ORDER = [
+    'Official Selection',
+    'Argentine Competition',
+    'Shorts',
+];
 
-const features = computed(() => {
-    return films.value?.results?.filter(f => !f.runtime || f.runtime >= 40) || [];
-});
-
-const shorts = computed(() => {
-    return films.value?.results?.filter(f => f.runtime > 0 && f.runtime < 40) || [];
-});
-
-const formatDate = (dateStr) => {
-    const options = { weekday: 'long', month: 'long', day: 'numeric' };
-    const [year, month, day] = dateStr.split('-').map(Number);
-    return new Date(year, month - 1, day).toLocaleDateString('en-US', options);
+const CATEGORY_LABELS = {
+    'Official Selection': 'Official Selection',
+    'Argentine Competition': 'Argentine Competition',
+    'Shorts': 'Shorts',
+    OTHER: 'Other',
 };
 
-const formatTime = (timeStr) => {
-    return new Date(timeStr).toLocaleTimeString('en-US', { 
-        hour: '2-digit', 
+const activeSection = ref('');
+const selectionContentRef = ref(null);
+let sectionObserver = null;
+const isMobile = ref(false);
+let mobileMql = null;
+const sectionOpen = ref({});
+const isSectionOpen = (key) => sectionOpen.value[key] !== false;
+const toggleSection = (key) => { sectionOpen.value = { ...sectionOpen.value, [key]: !isSectionOpen(key) }; };
+const onSectionHeaderClick = (key) => { if (!isMobile.value) return; toggleSection(key); };
+const activeDay = ref('');
+const scheduleContentRef = ref(null);
+let dayObserver = null;
+
+const filmsByCategory = computed(() => {
+    const map = Object.fromEntries(CATEGORY_ORDER.map((c) => [c, []]));
+    map.OTHER = [];
+    for (const f of films.value?.results || []) {
+        const key = String(f.category || f.section || '').trim();
+        if (key && map[key] !== undefined) map[key].push(f);
+        else map.OTHER.push(f);
+    }
+    return map;
+});
+
+const orderedCategories = computed(() => {
+    const out = CATEGORY_ORDER.filter((c) => (filmsByCategory.value[c] || []).length > 0);
+    if ((filmsByCategory.value.OTHER || []).length > 0) out.push('OTHER');
+    return out;
+});
+
+function categoryLabel (cat) {
+    return CATEGORY_LABELS[cat] || cat;
+}
+
+const selectionSections = computed(() => orderedCategories.value.map((cat) => {
+    const items = filmsByCategory.value[cat] || [];
+    return { key: cat, label: categoryLabel(cat), films: items, count: items.length };
+}));
+const officialNav = computed(() => selectionSections.value);
+
+const scrollToSection = (key) => {
+    activeSection.value = key;
+    const root = selectionContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-key]');
+    for (const el of els) { if (el.getAttribute('data-key') === key) { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); break; } }
+};
+
+const setupSectionObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (sectionObserver) sectionObserver.disconnect();
+    const root = selectionContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-key]');
+    if (!els.length) return;
+    sectionObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) { if (entry.isIntersecting) activeSection.value = entry.target.getAttribute('data-key'); }
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => sectionObserver.observe(el));
+};
+
+watch(selectionSections, (sections) => {
+    if (!sections.length) return;
+    if (!sections.some((sec) => sec.key === activeSection.value)) activeSection.value = sections[0].key;
+}, { immediate: true });
+
+watch([loading, activeTab, selectionSections], () => {
+    if (!loading.value && activeTab.value === 'films') nextTick(() => setupSectionObserver());
+    else if (sectionObserver) sectionObserver.disconnect();
+}, { flush: 'post' });
+
+
+const FESTIVAL_TZ = 'America/Argentina/Buenos_Aires';
+
+const formatDate = (dateStr) => {
+    const options = { weekday: 'long', month: 'long', day: 'numeric', timeZone: 'UTC' };
+    return new Date(`${dateStr}T00:00:00Z`).toLocaleDateString('en-US', options);
+};
+
+const formatTime = (timeStr, tz) => {
+    return new Date(timeStr).toLocaleTimeString('en-US', {
+        hour: '2-digit',
         minute: '2-digit',
-        timeZone: 'America/Argentina/Buenos_Aires'
+        timeZone: tz || FESTIVAL_TZ
     });
 };
 
@@ -387,17 +507,57 @@ const groupedScreenings = computed(() => {
 });
 
 const toggleDay = (date) => {
-    if (openDays.value.has(date)) {
-        openDays.value.delete(date);
-    } else {
-        openDays.value.add(date);
-    }
-}
+    if (openDays.value.has(date)) openDays.value.delete(date);
+    else openDays.value.add(date);
+};
 
 const isOpen = (date) => {
     if (scheduleSearchActiveQuery.value) return true;
     return openDays.value.has(date);
 };
+
+const scheduleDays = computed(() => Object.entries(groupedScreenings.value).map(([date, arr]) => ({ date, label: formatDate(date), count: arr.length })));
+const onDayHeaderClick = (date) => { if (!isMobile.value) return; toggleDay(date); };
+const scrollToDay = (date) => {
+    activeDay.value = date;
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-day]');
+    for (const el of els) { if (el.getAttribute('data-day') === date) { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); break; } }
+};
+const setupDayObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (dayObserver) dayObserver.disconnect();
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-day]');
+    if (!els.length) return;
+    dayObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) { if (entry.isIntersecting) activeDay.value = entry.target.getAttribute('data-day'); }
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => dayObserver.observe(el));
+};
+watch(scheduleDays, (days) => {
+    if (!days.length) return;
+    if (!days.some((d) => d.date === activeDay.value)) activeDay.value = days[0]?.date || '';
+}, { immediate: true });
+watch([loading, activeTab, scheduleDays], () => {
+    if (!loading.value && activeTab.value === 'schedule') nextTick(() => setupDayObserver());
+    else if (dayObserver) dayObserver.disconnect();
+}, { flush: 'post' });
+const updateIsMobile = (e) => { isMobile.value = e.matches; };
+onMounted(() => {
+    if (typeof window !== 'undefined' && window.matchMedia) {
+        mobileMql = window.matchMedia('(max-width: 900px)');
+        isMobile.value = mobileMql.matches;
+        mobileMql.addEventListener('change', updateIsMobile);
+    }
+});
+onBeforeUnmount(() => {
+    if (sectionObserver) sectionObserver.disconnect();
+    if (dayObserver) dayObserver.disconnect();
+    if (mobileMql) mobileMql.removeEventListener('change', updateIsMobile);
+});
 
 onMounted(async () => {
     try {
@@ -433,60 +593,156 @@ onMounted(async () => {
     font-size: 1.2rem;
 }
 
-.film-category {
-    margin-bottom: 2.5rem;
-}
-
-// Compact catalog cards (~25%+ smaller than global default).
-// Scoped to .films-grid so other listings (home, search, etc.) are untouched.
-// Uses :deep() because festival cards are child components (scoped CSS).
-.films-grid :deep(.listing__items > .card) {
-    width: 25%;
+// Poster sizing inside the Selection content column. The column is narrower than
+// the old full-bleed grid, so we use fewer columns / slightly larger posters.
+.selection :deep(.listing__items > .card) {
+    width: 33.3333%;
 
     @media (min-width: 640px) {
-        width: 20%;
+        width: 25%;
     }
     @media (min-width: 1024px) {
-        width: 14.2857143%;
+        width: 20%;
     }
     @media (min-width: 1500px) {
-        width: 12.5%;
+        width: 16.6666%;
     }
     @media (min-width: 1800px) {
-        width: 11.1111111%;
-    }
-    @media (min-width: 2500px) {
-        width: 10%;
+        width: 14.2857%;
     }
 }
 
 
 
-.category-header {
+/* ── Selection: sidebar scroll-spy + sections ───────────── */
+.selection-layout,
+.schedule-layout {
+    display: grid;
+    grid-template-columns: 330px minmax(0, 1fr);
+    gap: 2.5rem;
+    align-items: start;
+}
+
+/* Breathing room between the screenings search bar and the day list below it. */
+.schedule-layout {
+    margin-top: 1.75rem;
+}
+
+.selection-nav,
+.schedule-nav {
+    position: sticky;
+    top: 5.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-height: calc(100vh - 7rem);
+    overflow-y: auto;
+    padding: 1rem;
+    border: 1px solid transparent;
+    background:
+        linear-gradient(rgba(3, 6, 10, 0.85), rgba(3, 6, 10, 0.85)) padding-box,
+        linear-gradient(160deg, rgba(139, 233, 253, 0.55), rgba(31, 84, 103, 0.45) 60%, rgba(139, 233, 253, 0.16)) border-box;
+    border-radius: 14px;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
+}
+
+.nav-group-label {
+    font-size: 1rem;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    color: rgba(139, 233, 253, 0.9);
+    font-weight: 700;
+    margin: 1.2rem 0.4rem 0.55rem;
+
+    &:first-child {
+        margin-top: 0.2rem;
+    }
+}
+
+.nav-item {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 10px;
+    width: 100%;
+    background: none;
+    border: none;
+    border-left: 3px solid transparent;
+    border-radius: 0 8px 8px 0;
+    color: rgba(255, 255, 255, 0.88);
+    padding: 0.82rem 1rem;
+    font-size: 1.32rem;
+    font-family: inherit;
+    text-align: left;
     cursor: pointer;
-    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
-    padding-bottom: 5px;
-    margin-bottom: 15px;
-    transition: border-color 0.2s;
-    user-select: none;
-    
+    transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+
     &:hover {
-        border-color: rgba(139, 233, 253, 0.6);
+        background: rgba(139, 233, 253, 0.08);
+        color: #eafbff;
+    }
+
+    &.active {
+        background: rgba(139, 233, 253, 0.12);
+        color: #8BE9FD;
+        border-left-color: #8BE9FD;
+        font-weight: 600;
     }
 }
 
-.category-title {
-    margin: 0 !important;
+.nav-item-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
-.category-count {
-    font-size: 1.1rem;
-    color: rgba(255, 255, 255, 0.6);
-    margin-left: 10px;
-    font-weight: normal;
+.nav-item-count {
+    font-size: 1.12rem;
+    color: rgba(255, 255, 255, 0.62);
+    flex-shrink: 0;
+}
+
+.nav-item.active .nav-item-count {
+    color: rgba(139, 233, 253, 0.85);
+}
+
+.sel-section {
+    scroll-margin-top: 6.5rem;
+    margin-bottom: 3rem;
+}
+
+.sel-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
+    padding-bottom: 6px;
+    margin-bottom: 1.25rem;
+}
+
+.sel-section-title {
+    margin: 0;
+    font-size: 1.7rem;
+    font-weight: 700;
+    color: #fff;
+}
+
+.sel-section-meta {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-shrink: 0;
+}
+
+.sel-section-count {
+    font-size: 1.05rem;
+    color: rgba(255, 255, 255, 0.5);
+    white-space: nowrap;
+    flex-shrink: 0;
 }
 
 .expand-btn {
@@ -502,7 +758,7 @@ onMounted(async () => {
     cursor: pointer;
     transition: all 0.2s ease;
     flex-shrink: 0;
-    
+
     &:hover {
         background: rgba(139, 233, 253, 0.15);
         color: #8BE9FD;
@@ -515,6 +771,42 @@ onMounted(async () => {
         min-width: 20px;
         min-height: 20px;
         display: block;
+    }
+}
+
+.parallel-band {
+    font-size: 0.85rem;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: #8BE9FD;
+    border-top: 1px solid rgba(139, 233, 253, 0.25);
+    padding-top: 1.4rem;
+    margin: 0.5rem 0 1.5rem;
+}
+
+@media (max-width: 900px) {
+    .selection-layout,
+    .schedule-layout {
+        display: block;
+    }
+
+    .selection-nav,
+    .schedule-nav {
+        display: none;
+    }
+
+    .sel-section-header {
+        cursor: pointer;
+        user-select: none;
+        transition: border-color 0.2s;
+    }
+
+    .sel-section-header:hover {
+        border-color: rgba(139, 233, 253, 0.6);
+    }
+
+    .day-header {
+        cursor: pointer;
     }
 }
 
@@ -537,12 +829,16 @@ onMounted(async () => {
 .segmented-control {
     position: relative;
     display: flex;
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 20px; 
+    background: rgba(3, 4, 6, 0.6);
+    border: 1px solid rgba(139, 233, 253, 0.18);
+    border-radius: 16px;
     padding: 4px;
     height: 48px;
     align-items: center;
     min-width: 420px;
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
 }
 
 .segmented-control input[type="radio"] {
@@ -565,7 +861,7 @@ onMounted(async () => {
 }
 
 .segmented-control input:checked + label {
-    color: #000;
+    color: #02080d;
 }
 
 .segmented-control .glider {
@@ -574,9 +870,10 @@ onMounted(async () => {
     left: 4px;
     height: calc(100% - 8px);
     width: calc((100% - 8px) / 3);
-    background: #8BE9FD; 
-    border-radius: 16px;
+    background: linear-gradient(135deg, #8BE9FD, #5cc4d8);
+    border-radius: 12px;
     z-index: 1;
+    box-shadow: 0 4px 14px rgba(139, 233, 253, 0.3);
     transition: transform 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
 }
 
@@ -590,12 +887,15 @@ onMounted(async () => {
     max-width: 1200px;
     margin: 0 auto;
     position: relative;
-    border-radius: 15px;
+    border-radius: 16px;
     overflow: hidden;
-    background-color: transparent;
     display: flex;
     justify-content: center;
-    border: 1px solid #8BE9FD;
+    border: 2px solid transparent;
+    background:
+        linear-gradient(#02080d, #02080d) padding-box,
+        linear-gradient(140deg, #8BE9FD 0%, #1F5467 45%, rgba(31, 84, 103, 0.35) 100%) border-box;
+    box-shadow: 0 14px 36px rgba(0, 0, 0, 0.5), 0 0 30px rgba(139, 233, 253, 0.12);
 }
 
 .back-link {
@@ -625,7 +925,7 @@ onMounted(async () => {
         box-shadow: 0 8px 25px rgba(0,0,0,0.4);
         border-color: #fff;
     }
-    
+
     svg {
         width: 24px;
         height: 24px;
@@ -636,7 +936,7 @@ onMounted(async () => {
         left: 20px;
         font-size: 0.9rem;
         padding: 8px 16px;
-        
+
         svg {
             width: 18px;
             height: 18px;
@@ -648,7 +948,7 @@ onMounted(async () => {
     width: 100%;
     height: auto;
     position: relative;
-    
+
     img {
         width: 100%;
         height: auto;
@@ -687,8 +987,184 @@ onMounted(async () => {
 }
 
 
+
 :deep(.winners-carousel) {
     max-width: 1200px;
+}
+
+.day-header {
+    font-size: 1.8rem;
+    color: #fff;
+    border-bottom: 1px solid #333;
+    padding-bottom: 0.5rem;
+    margin-top: 3rem;
+    margin-bottom: 1.5rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    cursor: default;
+    user-select: none;
+
+    h2 {
+        font-size: 1.8rem;
+        margin: 0;
+    }
+
+    .chevron {
+        transition: transform 0.3s ease;
+
+        &.closed {
+            transform: rotate(-90deg);
+        }
+    }
+}
+
+.schedule-day {
+    scroll-margin-top: 6.5rem;
+}
+
+.schedule-content > .schedule-day:first-child .day-header {
+    margin-top: 0;
+}
+
+.slide-enter-active,
+.slide-leave-active {
+  transition: all 0.3s ease-out;
+  max-height: 2000px;
+  opacity: 1;
+  overflow: hidden;
+}
+
+.slide-enter-from,
+.slide-leave-to {
+  max-height: 0;
+  opacity: 0;
+  margin-bottom: 0;
+}
+
+.screening-card {
+    display: flex;
+    border: 1px solid transparent;
+    background:
+        linear-gradient(#0a161b, #0a161b) padding-box,
+        linear-gradient(140deg, #8BE9FD, #1F5467 60%, rgba(31, 84, 103, 0.3)) border-box;
+    border-radius: 10px;
+    padding: 1.5rem;
+    margin-bottom: 1rem;
+    gap: 1.5rem;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.3);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.screening-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.4), 0 0 20px rgba(139, 233, 253, 0.1);
+}
+
+.time-block {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-width: 80px;
+    border-right: 1px solid #333;
+    padding-right: 1.5rem;
+
+    .time {
+        font-size: 1.2rem;
+        font-weight: 700;
+        color: #fff;
+    }
+    .timezone {
+        font-size: 0.92rem;
+        color: #888;
+    }
+}
+
+.film-info {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+
+    .film-title {
+        font-size: 1.6rem;
+        font-weight: 700;
+        color: #fff;
+        text-decoration: none;
+        margin-bottom: 0.5rem;
+
+        &:hover {
+            color: #8BE9FD;
+        }
+    }
+
+    .film-meta {
+        font-size: 1.05rem;
+        color: #aaa;
+        margin-bottom: 0.8rem;
+    }
+
+    .venue-info {
+        font-size: 1.25rem;
+        color: #ccc;
+        margin-bottom: 0.8rem;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+
+        svg {
+            min-width: 18px;
+        }
+    }
+}
+
+.tags {
+    display: flex;
+    gap: 0.5rem;
+
+    .tag {
+        font-size: 0.75rem;
+        padding: 4px 8px;
+        border-radius: 4px;
+        font-weight: 600;
+        text-transform: uppercase;
+
+        &.in-person { background: rgba(52, 152, 219, 0.2); }
+        &.online { background: rgba(46, 204, 113, 0.2); color: #2ecc71; }
+        &.sold-out { background: rgba(231, 76, 60, 0.2); color: #e74c3c; }
+    }
+}
+
+.poster-mini {
+    width: 60px;
+    height: 90px;
+
+    img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        border-radius: 4px;
+    }
+}
+
+@media (max-width: 600px) {
+    .screening-card {
+        flex-direction: column;
+        gap: 1rem;
+    }
+    .time-block {
+        border-right: none;
+        border-bottom: 1px solid #333;
+        padding-right: 0;
+        padding-bottom: 1rem;
+        flex-direction: row;
+        gap: 1rem;
+        width: 100%;
+    }
+    .poster-mini {
+        display: none;
+    }
 }
 
 /* ── Carousel ─────────────────────────────── */
@@ -707,14 +1183,33 @@ onMounted(async () => {
 }
 
 .carousel-card {
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(139, 233, 253, 0.18);
+  position: relative;
+  background: rgba(3, 4, 6, 0.85);
+  background-image:
+    radial-gradient(circle at 15% 20%, rgba(31, 84, 103, 0.18), transparent 35%),
+    radial-gradient(circle at 85% 80%, rgba(139, 233, 253, 0.08), transparent 30%);
+  border: 1px solid rgba(31, 84, 103, 0.5);
   border-radius: 20px;
   padding: 2.2rem 2.5rem;
-  backdrop-filter: blur(12px);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
   color: rgba(255, 255, 255, 0.88);
   line-height: 1.8;
   min-height: 300px;
+  overflow: hidden;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5), inset 0 0 24px rgba(139, 233, 253, 0.04);
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: linear-gradient(90deg, transparent, #8BE9FD, #1F5467, transparent);
+    opacity: 0.85;
+    pointer-events: none;
+  }
 
   strong { color: #fff; }
 }
@@ -748,19 +1243,21 @@ onMounted(async () => {
   justify-content: center;
   width: 44px;
   height: 44px;
-  border-radius: 50%;
-  border: 1px solid rgba(139, 233, 253, 0.25);
-  background: rgba(0, 0, 0, 0.4);
+  border-radius: 12px;
+  border: 1px solid rgba(139, 233, 253, 0.4);
+  background: rgba(3, 4, 6, 0.75);
   color: #8BE9FD;
   cursor: pointer;
-  transition: all 0.25s ease;
+  transition: all 0.2s ease;
   flex-shrink: 0;
-  backdrop-filter: blur(6px);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
 
   &:hover {
-    background: rgba(139, 233, 253, 0.15);
-    border-color: #8BE9FD;
-    transform: scale(1.1);
+    background: #ffffff;
+    border-color: #ffffff;
+    color: #000;
+    transform: scale(1.05);
   }
 }
 
@@ -792,7 +1289,6 @@ onMounted(async () => {
   }
 }
 
-/* Slide transitions */
 .carousel-next-enter-active,
 .carousel-next-leave-active,
 .carousel-prev-enter-active,
@@ -821,33 +1317,9 @@ onMounted(async () => {
   .price-value { color: #8BE9FD; font-weight: 700; font-size: 1.1rem; }
 }
 
-.promo-box {
-  background: rgba(139, 233, 253, 0.08);
-  border-left: 3px solid #8BE9FD;
-  border-radius: 8px;
-  padding: 1rem 1.2rem;
-  margin-top: 1rem;
-  position: relative;
-  .promo-tag { position: absolute; top: 0; right: 0; background: #8BE9FD; color: #000; font-size: 0.65rem; font-weight: 800; padding: 3px 10px; border-bottom-left-radius: 6px; }
-  p { margin: 0; font-size: 1rem; }
-}
-
-.activity-type {
-  display: flex; gap: 1rem; align-items: flex-start; margin-bottom: 1.2rem; &:last-child { margin-bottom: 0; }
-  .badge { padding: 4px 12px; border-radius: 6px; font-weight: 800; font-size: 0.8rem; flex-shrink: 0; margin-top: 3px;
-    &.gr { background: #8BE9FD; color: #000; }
-    &.gs { border: 1px solid #8BE9FD; color: #8BE9FD; }
-  }
-  p { margin: 0; font-size: 1.02rem; }
-}
-
 .venue-list {
-  display: grid; grid-template-columns: repeat(2, 1fr); gap: 0.9rem;
-  @media (max-width: 600px) { grid-template-columns: 1fr; }
-  .venue-item { font-size: 0.98rem; padding: 0.7rem 0.9rem; background: rgba(255,255,255,0.04); border-radius: 10px; border: 1px solid rgba(255,255,255,0.06);
-    strong { color: #8BE9FD; display: block; margin-bottom: 3px; font-size: 1.02rem; }
-    span { color: rgba(255,255,255,0.7); }
-  }
+  display: flex; flex-direction: column; gap: 0.5rem; margin: 0.5rem 0;
+  .venue-item { display: flex; justify-content: space-between; align-items: center; padding: 0.5rem 0; border-bottom: 1px solid rgba(255,255,255,0.05); span { color: rgba(255,255,255,0.5); font-size: 0.95rem; } strong { color: #fff; } }
 }
 
 .bullet-list {
@@ -860,162 +1332,55 @@ onMounted(async () => {
   &:hover { border-color: #8BE9FD; }
 }
 
-.day-header {
-    font-size: 1.8rem;
-    color: #fff;
-    border-bottom: 1px solid #333;
-    padding-bottom: 0.5rem;
-    margin-top: 3rem;
-    margin-bottom: 1.5rem;
+/* ── Initial-rollout banner (catalog/schedule placeholders) ─ */
+.rollout-banner {
     display: flex;
-    justify-content: space-between;
-    align-items: center;
-    cursor: pointer;
-    user-select: none;
-    
-    h2 {
-        font-size: 1.8rem;
-        margin: 0;
-    }
-    
-    .chevron {
-        transition: transform 0.3s ease;
-        
-        &.closed {
-            transform: rotate(-90deg);
-        }
-    }
+    gap: 1.25rem;
+    align-items: flex-start;
+    max-width: 720px;
+    margin: 2rem auto;
+    padding: 1.5rem 1.75rem;
+    background: rgba(16, 26, 35, 0.7);
+    border: 1px solid rgba(139, 233, 253, 0.22);
+    border-radius: 14px;
+    backdrop-filter: blur(8px);
 }
 
-.slide-enter-active,
-.slide-leave-active {
-  transition: all 0.3s ease-out;
-  max-height: 2000px;
-  opacity: 1;
-  overflow: hidden;
-}
-
-.slide-enter-from,
-.slide-leave-to {
-  max-height: 0;
-  opacity: 0;
-  margin-bottom: 0;
-}
-
-.screening-card {
+.rollout-banner__icon {
+    flex-shrink: 0;
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    background: rgba(139, 233, 253, 0.08);
     display: flex;
-    background: #0a161b;
-    border: 1px solid #8BE9FD;
-    border-radius: 8px;
-    padding: 1.5rem;
-    margin-bottom: 1rem;
-    gap: 1.5rem;
-    transition: transform 0.2s;
-}
-
-.time-block {
-    display: flex;
-    flex-direction: column;
     align-items: center;
     justify-content: center;
-    min-width: 80px;
-    border-right: 1px solid #333;
-    padding-right: 1.5rem;
-    
-    .time {
-        font-size: 1.2rem;
-        font-weight: 700;
-        color: #fff;
-    }
-    .timezone {
-        font-size: 0.92rem;
-        color: #888;
-    }
 }
 
-.film-info {
+.rollout-banner__copy {
     flex: 1;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    
-    .film-title {
-        font-size: 1.6rem;
+    color: rgba(255, 255, 255, 0.85);
+
+    h3 {
+        margin: 0 0 0.4rem;
+        font-size: 1.15rem;
         font-weight: 700;
-        color: #fff;
-        text-decoration: none;
-        margin-bottom: 0.5rem;
-        
-        &:hover {
-            color: #8BE9FD;
-        }
+        color: #8BE9FD;
+        letter-spacing: 0.3px;
     }
-    
-    .film-meta {
-        font-size: 1.05rem;
-        color: #aaa;
-        margin-bottom: 0.8rem;
-    }
-    
-    .venue-info {
-        font-size: 1.25rem;
-        color: #ccc;
-        margin-bottom: 0.8rem;
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-        
-        svg {
-            min-width: 18px;
-        }
-    }
-}
-
-.tags {
-    display: flex;
-    gap: 0.5rem;
-    
-    .tag {
-        font-size: 0.75rem;
-        padding: 4px 8px;
-        border-radius: 4px;
-        font-weight: 600;
-        text-transform: uppercase;
-        
-        &.in-person { background: rgba(52, 152, 219, 0.2); }
-        &.online { background: rgba(46, 204, 113, 0.2); color: #2ecc71; }
-        &.sold-out { background: rgba(231, 76, 60, 0.2); color: #e74c3c; }
-    }
-}
-
-.poster-mini {
-    width: 60px;
-    height: 90px;
-    
-    img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-        border-radius: 4px;
+    p {
+        margin: 0;
+        font-size: 1rem;
+        line-height: 1.6;
+        color: rgba(255, 255, 255, 0.7);
     }
 }
 
 @media (max-width: 600px) {
-    .screening-card {
-        flex-direction: column; 
-        gap: 1rem;
-    }
-    .time-block {
-        border-right: none;
-        border-bottom: 1px solid #333;
-        padding-right: 0;
-        padding-bottom: 1rem;
-        flex-direction: row;
-        gap: 1rem;
-        width: 100%;
-    }
-    .poster-mini {
-        display: none;
+    .rollout-banner {
+        flex-direction: column;
+        gap: 0.75rem;
+        padding: 1.25rem;
     }
 }
 

--- a/pages/festival/cuff-2026/index.vue
+++ b/pages/festival/cuff-2026/index.vue
@@ -51,54 +51,79 @@
       </div>
 
       <div v-else>
-        <div v-if="activeTab === 'films'" class="films-grid">
-            <div v-if="features.length > 0" class="film-category">
-                <div class="category-header" @click="featuresOpen = !featuresOpen">
-                    <h2 class="listing__title category-title">
-                        Features
-                        <span class="category-count">({{ features.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="featuresOpen ? 'Collapse' : 'Expand'">
-                        <svg v-if="featuresOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
-                    </button>
-                </div>
-                <transition name="slide">
-                    <div v-show="featuresOpen" class="listing__items">
-                        <CuffCard
-                            v-for="item in features"
-                            :key="`feature-${item.id}`"
-                            :item="item"
-                        />
-                    </div>
-                </transition>
+        <div v-if="activeTab === 'films'" class="selection">
+          <div v-if="orderedCategories.length === 0" class="rollout-banner">
+            <div class="rollout-banner__icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
             </div>
+            <div class="rollout-banner__copy">
+              <h3>Lineup updates in progress</h3>
+              <p>This festival lineup is currently being updated. New films, sections, and official selections will be added progressively as they are announced and verified.</p>
+            </div>
+          </div>
+          <div v-else class="selection-layout">
+            <aside class="selection-nav" aria-label="Jump to section">
+              <template v-if="officialNav.length">
+                <div class="nav-group-label">Catalog</div>
+                <button
+                  v-for="sec in officialNav"
+                  :key="sec.key"
+                  class="nav-item"
+                  :class="{ active: activeSection === sec.key }"
+                  @click="scrollToSection(sec.key)"
+                >
+                  <span class="nav-item-label">{{ sec.label }}</span>
+                  <span class="nav-item-count">{{ sec.count }}</span>
+                </button>
+              </template>
+            </aside>
 
-            <div v-if="shorts.length > 0" class="film-category">
-                <div class="category-header" @click="shortsOpen = !shortsOpen">
-                    <h2 class="listing__title category-title">
-                        Shorts
-                        <span class="category-count">({{ shorts.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="shortsOpen ? 'Collapse' : 'Expand'">
-                        <svg v-if="shortsOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
+            <div ref="selectionContentRef" class="selection-content">
+              <section
+                v-for="sec in selectionSections"
+                :key="sec.key"
+                :data-key="sec.key"
+                class="sel-section"
+              >
+                <div class="sel-section-header" @click="onSectionHeaderClick(sec.key)">
+                  <h2 class="sel-section-title">{{ sec.label }}</h2>
+                  <div class="sel-section-meta">
+                    <span class="sel-section-count">{{ sec.count }} {{ sec.count === 1 ? 'film' : 'films' }}</span>
+                    <button v-if="isMobile" class="expand-btn" :aria-label="isSectionOpen(sec.key) ? 'Collapse' : 'Expand'">
+                      <svg v-if="isSectionOpen(sec.key)" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
+                      <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
                     </button>
+                  </div>
                 </div>
                 <transition name="slide">
-                    <div v-show="shortsOpen" class="listing__items">
-                        <CuffCard
-                            v-for="item in shorts"
-                            :key="`short-${item.id}`"
-                            :item="item"
-                        />
+                  <div v-show="!isMobile || isSectionOpen(sec.key)" class="sel-section-body">
+                    <div class="listing__items">
+                      <CuffCard
+                        v-for="item in sec.films"
+                        :key="`${sec.key}-${item.id}`"
+                        :item="item"
+                      />
                     </div>
+                  </div>
                 </transition>
+              </section>
             </div>
+          </div>
         </div>
 
         <div v-if="activeTab === 'schedule'" class="schedule-container">
-          <div class="schedule-toolbar" :class="{ 'search-active': isScheduleSearchActive }">
+          <!-- Initial rollout banner: schedule pending official publication -->
+          <div v-if="schedule.length === 0" class="rollout-banner">
+            <div class="rollout-banner__icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+            </div>
+            <div class="rollout-banner__copy">
+              <h3>Schedule pending</h3>
+              <p>Official screening schedules have not yet been published by the festival. Screening information will appear here as soon as it becomes available.</p>
+            </div>
+          </div>
+
+          <div v-if="schedule.length > 0" class="schedule-toolbar" :class="{ 'search-active': isScheduleSearchActive }">
             <div class="schedule-toolbar-info">
               <span class="schedule-count" v-if="!loading">
                 <template v-if="scheduleSearchActiveQuery">
@@ -134,30 +159,48 @@
             <p>No screenings match "<strong>{{ scheduleSearch }}</strong>"</p>
           </div>
 
-          <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" class="schedule-day">
-            <div class="day-header" @click="toggleDay(date)">
+          <div v-if="scheduleDays.length" class="schedule-layout">
+            <aside class="schedule-nav" aria-label="Jump to day">
+              <div class="nav-group-label">Days</div>
+              <button
+                v-for="day in scheduleDays"
+                :key="day.date"
+                class="nav-item"
+                :class="{ active: activeDay === day.date }"
+                @click="scrollToDay(day.date)"
+              >
+                <span class="nav-item-label">{{ day.label }}</span>
+                <span class="nav-item-count">{{ day.count }}</span>
+              </button>
+            </aside>
+
+            <div ref="scheduleContentRef" class="schedule-content">
+              <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" :data-day="date" class="schedule-day">
+            <div class="day-header" @click="onDayHeaderClick(date)">
                 <h2>{{ formatDate(date) }}</h2>
-                <div class="chevron" :class="{ 'closed': !isOpen(date) }">
+                <div v-if="isMobile" class="chevron" :class="{ 'closed': !isOpen(date) }">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down"><path d="m6 9 6 6 6-6"/></svg>
                 </div>
             </div>
 
             <transition name="slide">
-                <div v-show="isOpen(date)" class="screenings-list">
+                <div v-show="!isMobile || isOpen(date)" class="screenings-list">
                   <div v-for="screening in dayScreenings" :key="screening.id" class="screening-card">
                      <div class="time-block">
-                        <span class="time">{{ formatTime(screening.start_time) }}</span>
+                        <span class="time">{{ formatTime(screening.start_time, screening.timezone) }}</span>
                         <span class="timezone">{{ screening.timezone }}</span>
                      </div>
 
                       <div class="film-info">
-                         <a
-                            :href="screening.film.source_url || 'https://www.calgaryundergroundfilm.org/2026/'"
-                            target="_blank"
+                         <component
+                            :is="screening.film.source_url ? 'a' : 'span'"
+                            :href="screening.film.source_url || ''"
+                            :target="screening.film.source_url ? '_blank' : ''"
                             class="film-title"
+                            :class="{'no-link': !screening.film.source_url}"
                          >
                             {{ screening.film.title }}
-                         </a>
+                         </component>
                          <div class="film-meta">
                              <span v-if="screening.film.director">Directed by {{ screening.film.director }}</span>
                              <span v-if="screening.film.director && screening.film.runtime"> • </span>
@@ -187,6 +230,8 @@
                   </div>
                 </div>
             </transition>
+          </div>
+            </div>
           </div>
         </div>
 
@@ -256,7 +301,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, nextTick } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount, nextTick, watch } from 'vue';
 import Loader from '~/components/Loader.vue';
 import FestivalDataDisclaimer from '~/components/FestivalDataDisclaimer.vue';
 import CuffCard from '~/components/CuffCard.vue';
@@ -306,29 +351,101 @@ const schedule = ref([]);
 const awards = ref([]);
 const openDays = ref(new Set());
 
-const featuresOpen = ref(true);
-const shortsOpen = ref(true);
+const CATEGORY_ORDER = [
+    'Features',
+    'Shorts',
+];
 
-const features = computed(() => {
-    return films.value?.results?.filter(f => !f.runtime || f.runtime >= 40) || [];
-});
-
-const shorts = computed(() => {
-    return films.value?.results?.filter(f => f.runtime > 0 && f.runtime < 40) || [];
-});
-
-const formatDate = (dateStr) => {
-    // Parse YYYY-MM-DD as local date to avoid UTC-induced day shift in negative-UTC timezones (Americas)
-    const [year, month, day] = dateStr.split('-').map(Number);
-    const localDate = new Date(year, month - 1, day);
-    const options = { weekday: 'long', month: 'long', day: 'numeric' };
-    return localDate.toLocaleDateString('en-US', options);
+const CATEGORY_LABELS = {
+    'Features': 'Features',
+    'Shorts': 'Shorts',
+    OTHER: 'Other',
 };
 
-const formatTime = (timeStr) => {
+const activeSection = ref('');
+const selectionContentRef = ref(null);
+let sectionObserver = null;
+const isMobile = ref(false);
+let mobileMql = null;
+const sectionOpen = ref({});
+const isSectionOpen = (key) => sectionOpen.value[key] !== false;
+const toggleSection = (key) => { sectionOpen.value = { ...sectionOpen.value, [key]: !isSectionOpen(key) }; };
+const onSectionHeaderClick = (key) => { if (!isMobile.value) return; toggleSection(key); };
+const activeDay = ref('');
+const scheduleContentRef = ref(null);
+let dayObserver = null;
+
+const filmsByCategory = computed(() => {
+    const map = Object.fromEntries(CATEGORY_ORDER.map((c) => [c, []]));
+    map.OTHER = [];
+    for (const f of films.value?.results || []) {
+        const key = String(f.category || f.section || '').trim();
+        if (key && map[key] !== undefined) map[key].push(f);
+        else map.OTHER.push(f);
+    }
+    return map;
+});
+
+const orderedCategories = computed(() => {
+    const out = CATEGORY_ORDER.filter((c) => (filmsByCategory.value[c] || []).length > 0);
+    if ((filmsByCategory.value.OTHER || []).length > 0) out.push('OTHER');
+    return out;
+});
+
+function categoryLabel (cat) {
+    return CATEGORY_LABELS[cat] || cat;
+}
+
+const selectionSections = computed(() => orderedCategories.value.map((cat) => {
+    const items = filmsByCategory.value[cat] || [];
+    return { key: cat, label: categoryLabel(cat), films: items, count: items.length };
+}));
+const officialNav = computed(() => selectionSections.value);
+
+const scrollToSection = (key) => {
+    activeSection.value = key;
+    const root = selectionContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-key]');
+    for (const el of els) { if (el.getAttribute('data-key') === key) { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); break; } }
+};
+
+const setupSectionObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (sectionObserver) sectionObserver.disconnect();
+    const root = selectionContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-key]');
+    if (!els.length) return;
+    sectionObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) { if (entry.isIntersecting) activeSection.value = entry.target.getAttribute('data-key'); }
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => sectionObserver.observe(el));
+};
+
+watch(selectionSections, (sections) => {
+    if (!sections.length) return;
+    if (!sections.some((sec) => sec.key === activeSection.value)) activeSection.value = sections[0].key;
+}, { immediate: true });
+
+watch([loading, activeTab, selectionSections], () => {
+    if (!loading.value && activeTab.value === 'films') nextTick(() => setupSectionObserver());
+    else if (sectionObserver) sectionObserver.disconnect();
+}, { flush: 'post' });
+
+
+const FESTIVAL_TZ = 'America/Edmonton';
+
+const formatDate = (dateStr) => {
+    const options = { weekday: 'long', month: 'long', day: 'numeric', timeZone: 'UTC' };
+    return new Date(`${dateStr}T00:00:00Z`).toLocaleDateString('en-US', options);
+};
+
+const formatTime = (timeStr, tz) => {
     return new Date(timeStr).toLocaleTimeString('en-US', {
         hour: '2-digit',
-        minute: '2-digit'
+        minute: '2-digit',
+        timeZone: tz || FESTIVAL_TZ
     });
 };
 
@@ -359,17 +476,57 @@ const groupedScreenings = computed(() => {
 });
 
 const toggleDay = (date) => {
-    if (openDays.value.has(date)) {
-        openDays.value.delete(date);
-    } else {
-        openDays.value.add(date);
-    }
+    if (openDays.value.has(date)) openDays.value.delete(date);
+    else openDays.value.add(date);
 };
 
 const isOpen = (date) => {
     if (scheduleSearchActiveQuery.value) return true;
     return openDays.value.has(date);
 };
+
+const scheduleDays = computed(() => Object.entries(groupedScreenings.value).map(([date, arr]) => ({ date, label: formatDate(date), count: arr.length })));
+const onDayHeaderClick = (date) => { if (!isMobile.value) return; toggleDay(date); };
+const scrollToDay = (date) => {
+    activeDay.value = date;
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-day]');
+    for (const el of els) { if (el.getAttribute('data-day') === date) { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); break; } }
+};
+const setupDayObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (dayObserver) dayObserver.disconnect();
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-day]');
+    if (!els.length) return;
+    dayObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) { if (entry.isIntersecting) activeDay.value = entry.target.getAttribute('data-day'); }
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => dayObserver.observe(el));
+};
+watch(scheduleDays, (days) => {
+    if (!days.length) return;
+    if (!days.some((d) => d.date === activeDay.value)) activeDay.value = days[0]?.date || '';
+}, { immediate: true });
+watch([loading, activeTab, scheduleDays], () => {
+    if (!loading.value && activeTab.value === 'schedule') nextTick(() => setupDayObserver());
+    else if (dayObserver) dayObserver.disconnect();
+}, { flush: 'post' });
+const updateIsMobile = (e) => { isMobile.value = e.matches; };
+onMounted(() => {
+    if (typeof window !== 'undefined' && window.matchMedia) {
+        mobileMql = window.matchMedia('(max-width: 900px)');
+        isMobile.value = mobileMql.matches;
+        mobileMql.addEventListener('change', updateIsMobile);
+    }
+});
+onBeforeUnmount(() => {
+    if (sectionObserver) sectionObserver.disconnect();
+    if (dayObserver) dayObserver.disconnect();
+    if (mobileMql) mobileMql.removeEventListener('change', updateIsMobile);
+});
 
 onMounted(async () => {
     try {
@@ -403,60 +560,156 @@ onMounted(async () => {
     font-size: 1.2rem;
 }
 
-.film-category {
-    margin-bottom: 2.5rem;
-}
-
-// Compact catalog cards (~25%+ smaller than global default).
-// Scoped to .films-grid so other listings (home, search, etc.) are untouched.
-// Uses :deep() because festival cards are child components (scoped CSS).
-.films-grid :deep(.listing__items > .card) {
-    width: 25%;
+// Poster sizing inside the Selection content column. The column is narrower than
+// the old full-bleed grid, so we use fewer columns / slightly larger posters.
+.selection :deep(.listing__items > .card) {
+    width: 33.3333%;
 
     @media (min-width: 640px) {
-        width: 20%;
+        width: 25%;
     }
     @media (min-width: 1024px) {
-        width: 14.2857143%;
+        width: 20%;
     }
     @media (min-width: 1500px) {
-        width: 12.5%;
+        width: 16.6666%;
     }
     @media (min-width: 1800px) {
-        width: 11.1111111%;
-    }
-    @media (min-width: 2500px) {
-        width: 10%;
+        width: 14.2857%;
     }
 }
 
 
 
-.category-header {
+/* ── Selection: sidebar scroll-spy + sections ───────────── */
+.selection-layout,
+.schedule-layout {
+    display: grid;
+    grid-template-columns: 330px minmax(0, 1fr);
+    gap: 2.5rem;
+    align-items: start;
+}
+
+/* Breathing room between the screenings search bar and the day list below it. */
+.schedule-layout {
+    margin-top: 1.75rem;
+}
+
+.selection-nav,
+.schedule-nav {
+    position: sticky;
+    top: 5.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-height: calc(100vh - 7rem);
+    overflow-y: auto;
+    padding: 1rem;
+    border: 1px solid transparent;
+    background:
+        linear-gradient(rgba(3, 6, 10, 0.85), rgba(3, 6, 10, 0.85)) padding-box,
+        linear-gradient(160deg, rgba(139, 233, 253, 0.55), rgba(31, 84, 103, 0.45) 60%, rgba(139, 233, 253, 0.16)) border-box;
+    border-radius: 14px;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
+}
+
+.nav-group-label {
+    font-size: 1rem;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    color: rgba(139, 233, 253, 0.9);
+    font-weight: 700;
+    margin: 1.2rem 0.4rem 0.55rem;
+
+    &:first-child {
+        margin-top: 0.2rem;
+    }
+}
+
+.nav-item {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 10px;
+    width: 100%;
+    background: none;
+    border: none;
+    border-left: 3px solid transparent;
+    border-radius: 0 8px 8px 0;
+    color: rgba(255, 255, 255, 0.88);
+    padding: 0.82rem 1rem;
+    font-size: 1.32rem;
+    font-family: inherit;
+    text-align: left;
     cursor: pointer;
-    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
-    padding-bottom: 5px;
-    margin-bottom: 15px;
-    transition: border-color 0.2s;
-    user-select: none;
+    transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
 
     &:hover {
-        border-color: rgba(139, 233, 253, 0.6);
+        background: rgba(139, 233, 253, 0.08);
+        color: #eafbff;
+    }
+
+    &.active {
+        background: rgba(139, 233, 253, 0.12);
+        color: #8BE9FD;
+        border-left-color: #8BE9FD;
+        font-weight: 600;
     }
 }
 
-.category-title {
-    margin: 0 !important;
+.nav-item-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
-.category-count {
-    font-size: 1.1rem;
-    color: rgba(255, 255, 255, 0.6);
-    margin-left: 10px;
-    font-weight: normal;
+.nav-item-count {
+    font-size: 1.12rem;
+    color: rgba(255, 255, 255, 0.62);
+    flex-shrink: 0;
+}
+
+.nav-item.active .nav-item-count {
+    color: rgba(139, 233, 253, 0.85);
+}
+
+.sel-section {
+    scroll-margin-top: 6.5rem;
+    margin-bottom: 3rem;
+}
+
+.sel-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
+    padding-bottom: 6px;
+    margin-bottom: 1.25rem;
+}
+
+.sel-section-title {
+    margin: 0;
+    font-size: 1.7rem;
+    font-weight: 700;
+    color: #fff;
+}
+
+.sel-section-meta {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-shrink: 0;
+}
+
+.sel-section-count {
+    font-size: 1.05rem;
+    color: rgba(255, 255, 255, 0.5);
+    white-space: nowrap;
+    flex-shrink: 0;
 }
 
 .expand-btn {
@@ -488,6 +741,42 @@ onMounted(async () => {
     }
 }
 
+.parallel-band {
+    font-size: 0.85rem;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: #8BE9FD;
+    border-top: 1px solid rgba(139, 233, 253, 0.25);
+    padding-top: 1.4rem;
+    margin: 0.5rem 0 1.5rem;
+}
+
+@media (max-width: 900px) {
+    .selection-layout,
+    .schedule-layout {
+        display: block;
+    }
+
+    .selection-nav,
+    .schedule-nav {
+        display: none;
+    }
+
+    .sel-section-header {
+        cursor: pointer;
+        user-select: none;
+        transition: border-color 0.2s;
+    }
+
+    .sel-section-header:hover {
+        border-color: rgba(139, 233, 253, 0.6);
+    }
+
+    .day-header {
+        cursor: pointer;
+    }
+}
+
 .header-container {
     display: flex;
     flex-direction: column;
@@ -507,12 +796,16 @@ onMounted(async () => {
 .segmented-control {
     position: relative;
     display: flex;
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 20px;
+    background: rgba(3, 4, 6, 0.6);
+    border: 1px solid rgba(139, 233, 253, 0.18);
+    border-radius: 16px;
     padding: 4px;
     height: 48px;
     align-items: center;
     min-width: 420px;
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
 }
 
 .segmented-control input[type="radio"] {
@@ -535,7 +828,7 @@ onMounted(async () => {
 }
 
 .segmented-control input:checked + label {
-    color: #000;
+    color: #02080d;
 }
 
 .segmented-control .glider {
@@ -544,9 +837,10 @@ onMounted(async () => {
     left: 4px;
     height: calc(100% - 8px);
     width: calc((100% - 8px) / 3);
-    background: #8BE9FD;
-    border-radius: 16px;
+    background: linear-gradient(135deg, #8BE9FD, #5cc4d8);
+    border-radius: 12px;
     z-index: 1;
+    box-shadow: 0 4px 14px rgba(139, 233, 253, 0.3);
     transition: transform 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
 }
 
@@ -560,12 +854,15 @@ onMounted(async () => {
     max-width: 1200px;
     margin: 0 auto;
     position: relative;
-    border-radius: 15px;
+    border-radius: 16px;
     overflow: hidden;
-    background-color: transparent;
     display: flex;
     justify-content: center;
-    border: 1px solid #8BE9FD;
+    border: 2px solid transparent;
+    background:
+        linear-gradient(#02080d, #02080d) padding-box,
+        linear-gradient(140deg, #8BE9FD 0%, #1F5467 45%, rgba(31, 84, 103, 0.35) 100%) border-box;
+    box-shadow: 0 14px 36px rgba(0, 0, 0, 0.5), 0 0 30px rgba(139, 233, 253, 0.12);
 }
 
 .back-link {
@@ -672,7 +969,7 @@ onMounted(async () => {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    cursor: pointer;
+    cursor: default;
     user-select: none;
 
     h2 {
@@ -687,6 +984,14 @@ onMounted(async () => {
             transform: rotate(-90deg);
         }
     }
+}
+
+.schedule-day {
+    scroll-margin-top: 6.5rem;
+}
+
+.schedule-content > .schedule-day:first-child .day-header {
+    margin-top: 0;
 }
 
 .slide-enter-active,
@@ -706,13 +1011,21 @@ onMounted(async () => {
 
 .screening-card {
     display: flex;
-    background: #0a161b;
-    border: 1px solid #8BE9FD;
-    border-radius: 8px;
+    border: 1px solid transparent;
+    background:
+        linear-gradient(#0a161b, #0a161b) padding-box,
+        linear-gradient(140deg, #8BE9FD, #1F5467 60%, rgba(31, 84, 103, 0.3)) border-box;
+    border-radius: 10px;
     padding: 1.5rem;
     margin-bottom: 1rem;
     gap: 1.5rem;
-    transition: transform 0.2s;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.3);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.screening-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.4), 0 0 20px rgba(139, 233, 253, 0.1);
 }
 
 .time-block {
@@ -837,14 +1150,33 @@ onMounted(async () => {
 }
 
 .carousel-card {
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(139, 233, 253, 0.18);
+  position: relative;
+  background: rgba(3, 4, 6, 0.85);
+  background-image:
+    radial-gradient(circle at 15% 20%, rgba(31, 84, 103, 0.18), transparent 35%),
+    radial-gradient(circle at 85% 80%, rgba(139, 233, 253, 0.08), transparent 30%);
+  border: 1px solid rgba(31, 84, 103, 0.5);
   border-radius: 20px;
   padding: 2.2rem 2.5rem;
-  backdrop-filter: blur(12px);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
   color: rgba(255, 255, 255, 0.88);
   line-height: 1.8;
   min-height: 300px;
+  overflow: hidden;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5), inset 0 0 24px rgba(139, 233, 253, 0.04);
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: linear-gradient(90deg, transparent, #8BE9FD, #1F5467, transparent);
+    opacity: 0.85;
+    pointer-events: none;
+  }
 
   strong { color: #fff; }
 }
@@ -878,19 +1210,21 @@ onMounted(async () => {
   justify-content: center;
   width: 44px;
   height: 44px;
-  border-radius: 50%;
-  border: 1px solid rgba(139, 233, 253, 0.25);
-  background: rgba(0, 0, 0, 0.4);
+  border-radius: 12px;
+  border: 1px solid rgba(139, 233, 253, 0.4);
+  background: rgba(3, 4, 6, 0.75);
   color: #8BE9FD;
   cursor: pointer;
-  transition: all 0.25s ease;
+  transition: all 0.2s ease;
   flex-shrink: 0;
-  backdrop-filter: blur(6px);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
 
   &:hover {
-    background: rgba(139, 233, 253, 0.15);
-    border-color: #8BE9FD;
-    transform: scale(1.1);
+    background: #ffffff;
+    border-color: #ffffff;
+    color: #000;
+    transform: scale(1.05);
   }
 }
 
@@ -963,6 +1297,58 @@ onMounted(async () => {
 .accent-link {
   color: #8BE9FD; text-decoration: none; font-weight: 600; border-bottom: 1px solid transparent; transition: border-color 0.2s;
   &:hover { border-color: #8BE9FD; }
+}
+
+/* ── Initial-rollout banner (catalog/schedule placeholders) ─ */
+.rollout-banner {
+    display: flex;
+    gap: 1.25rem;
+    align-items: flex-start;
+    max-width: 720px;
+    margin: 2rem auto;
+    padding: 1.5rem 1.75rem;
+    background: rgba(16, 26, 35, 0.7);
+    border: 1px solid rgba(139, 233, 253, 0.22);
+    border-radius: 14px;
+    backdrop-filter: blur(8px);
+}
+
+.rollout-banner__icon {
+    flex-shrink: 0;
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    background: rgba(139, 233, 253, 0.08);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.rollout-banner__copy {
+    flex: 1;
+    color: rgba(255, 255, 255, 0.85);
+
+    h3 {
+        margin: 0 0 0.4rem;
+        font-size: 1.15rem;
+        font-weight: 700;
+        color: #8BE9FD;
+        letter-spacing: 0.3px;
+    }
+    p {
+        margin: 0;
+        font-size: 1rem;
+        line-height: 1.6;
+        color: rgba(255, 255, 255, 0.7);
+    }
+}
+
+@media (max-width: 600px) {
+    .rollout-banner {
+        flex-direction: column;
+        gap: 0.75rem;
+        padding: 1.25rem;
+    }
 }
 
 /* ── Schedule search toolbar ─────────────── */


### PR DESCRIPTION
### Motivation
- Bring `cuff-2026` and `bafici-2026` festival pages in line with the layout, responsive behavior and visual language already applied to other migrated festivals (sidebar scroll‑spy, glassmorphism, updated grids and schedule UX). 
- Replace the older per‑category full‑bleed listing UI with the new selection layout so catalog, schedule and info sections behave consistently across festivals.

### Description
- Converted catalog templates to the shared `selection` layout with sidebar navigation, section counts, scroll targets and mobile collapsible sections in `pages/festival/cuff-2026/index.vue` and `pages/festival/bafici-2026/index.vue`.
- Added category grouping, `filmsByCategory` / `orderedCategories` / `selectionSections` computed state, and the scroll‑spy behavior using `IntersectionObserver` plus `scrollToSection` / `setupSectionObserver` helpers and mobile breakpoint tracking (`matchMedia`).
- Reworked schedules to the two‑column `schedule-layout` (sticky day sidebar + content column), added day grouping (`groupedScreenings` / `scheduleDays`), mobile day toggle behavior, search/filter integration, timezone‑aware `formatTime`, and componentized screening titles (link vs span) for both festivals.
- Replaced and extended CSS with the glassmorphism/border treatment, responsive poster grid rules, updated card styles and rollout placeholder banners; updated imports and lifecycle cleanup (`onBeforeUnmount`) to match the established pattern.

### Testing
- Ran `git diff --check` to validate whitespace / basic issues and address obvious problems; it reported no blocking errors.
- Built the project with `yarn build`; the build completed successfully and server+client artifacts were generated, though the build emitted warnings about missing Supabase environment variables and CSS nesting minifier warnings. All automated build steps finished without error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a14ca04b083268063c1d353a8d4ce)