### PR TITLE
Festival pages: new selection layout, schedule nav, timezone handling, and rollout banners

### DIFF
--- a/pages/festival/bafici-2026/index.vue
+++ b/pages/festival/bafici-2026/index.vue
@@ -48,54 +48,79 @@
       </div>
 
       <div v-else>
-        <div v-if="activeTab === 'films'" class="films-grid">
-            <div v-if="features.length > 0" class="film-category">
-                <div class="category-header" @click="featuresOpen = !featuresOpen">
-                    <h2 class="listing__title category-title">
-                        Features
-                        <span class="category-count">({{ features.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="featuresOpen ? 'Collapse' : 'Expand'">
-                        <svg v-if="featuresOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
-                    </button>
-                </div>
-                <transition name="slide">
-                    <div v-show="featuresOpen" class="listing__items">
-                        <BaficiCard 
-                            v-for="item in features"
-                            :key="`feature-${item.id}`"
-                            :item="item" 
-                        />
-                    </div>
-                </transition>
+        <div v-if="activeTab === 'films'" class="selection">
+          <div v-if="orderedCategories.length === 0" class="rollout-banner">
+            <div class="rollout-banner__icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
             </div>
+            <div class="rollout-banner__copy">
+              <h3>Lineup updates in progress</h3>
+              <p>This festival lineup is currently being updated. New films, sections, and official selections will be added progressively as they are announced and verified.</p>
+            </div>
+          </div>
+          <div v-else class="selection-layout">
+            <aside class="selection-nav" aria-label="Jump to section">
+              <template v-if="officialNav.length">
+                <div class="nav-group-label">Catalog</div>
+                <button
+                  v-for="sec in officialNav"
+                  :key="sec.key"
+                  class="nav-item"
+                  :class="{ active: activeSection === sec.key }"
+                  @click="scrollToSection(sec.key)"
+                >
+                  <span class="nav-item-label">{{ sec.label }}</span>
+                  <span class="nav-item-count">{{ sec.count }}</span>
+                </button>
+              </template>
+            </aside>
 
-            <div v-if="shorts.length > 0" class="film-category">
-                <div class="category-header" @click="shortsOpen = !shortsOpen">
-                    <h2 class="listing__title category-title">
-                        Shorts
-                        <span class="category-count">({{ shorts.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="shortsOpen ? 'Collapse' : 'Expand'">
-                        <svg v-if="shortsOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
+            <div ref="selectionContentRef" class="selection-content">
+              <section
+                v-for="sec in selectionSections"
+                :key="sec.key"
+                :data-key="sec.key"
+                class="sel-section"
+              >
+                <div class="sel-section-header" @click="onSectionHeaderClick(sec.key)">
+                  <h2 class="sel-section-title">{{ sec.label }}</h2>
+                  <div class="sel-section-meta">
+                    <span class="sel-section-count">{{ sec.count }} {{ sec.count === 1 ? 'film' : 'films' }}</span>
+                    <button v-if="isMobile" class="expand-btn" :aria-label="isSectionOpen(sec.key) ? 'Collapse' : 'Expand'">
+                      <svg v-if="isSectionOpen(sec.key)" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
+                      <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
                     </button>
+                  </div>
                 </div>
                 <transition name="slide">
-                    <div v-show="shortsOpen" class="listing__items">
-                        <BaficiCard 
-                            v-for="item in shorts"
-                            :key="`short-${item.id}`"
-                            :item="item" 
-                        />
+                  <div v-show="!isMobile || isSectionOpen(sec.key)" class="sel-section-body">
+                    <div class="listing__items">
+                      <BaficiCard
+                        v-for="item in sec.films"
+                        :key="`${sec.key}-${item.id}`"
+                        :item="item"
+                      />
                     </div>
+                  </div>
                 </transition>
+              </section>
             </div>
+          </div>
         </div>
 
         <div v-if="activeTab === 'schedule'" class="schedule-container">
-          <div class="schedule-toolbar" :class="{ 'search-active': isScheduleSearchActive }">
+          <!-- Initial rollout banner: schedule pending official publication -->
+          <div v-if="schedule.length === 0" class="rollout-banner">
+            <div class="rollout-banner__icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+            </div>
+            <div class="rollout-banner__copy">
+              <h3>Schedule pending</h3>
+              <p>Official screening schedules have not yet been published by the festival. Screening information will appear here as soon as it becomes available.</p>
+            </div>
+          </div>
+
+          <div v-if="schedule.length > 0" class="schedule-toolbar" :class="{ 'search-active': isScheduleSearchActive }">
             <div class="schedule-toolbar-info">
               <span class="schedule-count" v-if="!loading">
                 <template v-if="scheduleSearchActiveQuery">
@@ -131,30 +156,48 @@
             <p>No screenings match "<strong>{{ scheduleSearch }}</strong>"</p>
           </div>
 
-          <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" class="schedule-day">
-            <div class="day-header" @click="toggleDay(date)">
+          <div v-if="scheduleDays.length" class="schedule-layout">
+            <aside class="schedule-nav" aria-label="Jump to day">
+              <div class="nav-group-label">Days</div>
+              <button
+                v-for="day in scheduleDays"
+                :key="day.date"
+                class="nav-item"
+                :class="{ active: activeDay === day.date }"
+                @click="scrollToDay(day.date)"
+              >
+                <span class="nav-item-label">{{ day.label }}</span>
+                <span class="nav-item-count">{{ day.count }}</span>
+              </button>
+            </aside>
+
+            <div ref="scheduleContentRef" class="schedule-content">
+              <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" :data-day="date" class="schedule-day">
+            <div class="day-header" @click="onDayHeaderClick(date)">
                 <h2>{{ formatDate(date) }}</h2>
-                <div class="chevron" :class="{ 'closed': !isOpen(date) }">
+                <div v-if="isMobile" class="chevron" :class="{ 'closed': !isOpen(date) }">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down"><path d="m6 9 6 6 6-6"/></svg>
                 </div>
             </div>
-            
+
             <transition name="slide">
-                <div v-show="isOpen(date)" class="screenings-list">
+                <div v-show="!isMobile || isOpen(date)" class="screenings-list">
                   <div v-for="screening in dayScreenings" :key="screening.id" class="screening-card">
                      <div class="time-block">
-                        <span class="time">{{ formatTime(screening.start_time) }}</span>
+                        <span class="time">{{ formatTime(screening.start_time, screening.timezone) }}</span>
                         <span class="timezone">{{ screening.timezone }}</span>
                      </div>
-                     
+
                       <div class="film-info">
-                         <a 
-                            :href="screening.film.source_url || 'https://bafici.org'"
-                            target="_blank"
+                         <component
+                            :is="screening.film.source_url ? 'a' : 'span'"
+                            :href="screening.film.source_url || ''"
+                            :target="screening.film.source_url ? '_blank' : ''"
                             class="film-title"
+                            :class="{'no-link': !screening.film.source_url}"
                          >
                             {{ screening.film.title }}
-                         </a>
+                         </component>
                          <div class="film-meta">
                              <span v-if="screening.film.director">Directed by {{ screening.film.director }}</span>
                              <span v-if="screening.film.director && screening.film.runtime"> • </span>
@@ -170,13 +213,13 @@
                              <span v-if="screening.is_sold_out" class="tag sold-out">Sold Out</span>
                          </div>
                       </div>
-                      
+
                       <div class="poster-mini">
-                          <img 
-                            v-if="screening.film.poster_path" 
-                            :src="screening.film.poster_path" 
-                            alt="Poster" 
-                            loading="lazy" 
+                          <img
+                            v-if="screening.film.poster_path"
+                            :src="screening.film.poster_path"
+                            alt="Poster"
+                            loading="lazy"
                             @error="$event.target.src = '/placeholders/image_not_found_yet.webp'"
                           />
                           <img v-else src="/placeholders/image_not_found_yet.webp" alt="No Poster" />
@@ -184,6 +227,8 @@
                   </div>
                 </div>
             </transition>
+          </div>
+            </div>
           </div>
         </div>
 
@@ -284,7 +329,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, nextTick } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount, nextTick, watch } from 'vue';
 import Loader from '~/components/Loader.vue';
 import WinnersCarousel from '~/components/festival/WinnersCarousel.vue';
 import FestivalDataDisclaimer from '~/components/FestivalDataDisclaimer.vue';
@@ -335,28 +380,103 @@ const prevSlide = () => { slideDirection.value = 'carousel-prev'; infoSlide.valu
 const nextSlide = () => { slideDirection.value = 'carousel-next'; infoSlide.value = (infoSlide.value + 1) % 4; };
 const goToSlide = (i) => { slideDirection.value = i > infoSlide.value ? 'carousel-next' : 'carousel-prev'; infoSlide.value = i; };
 
-const featuresOpen = ref(true);
-const shortsOpen = ref(true);
+const CATEGORY_ORDER = [
+    'Official Selection',
+    'Argentine Competition',
+    'Shorts',
+];
 
-const features = computed(() => {
-    return films.value?.results?.filter(f => !f.runtime || f.runtime >= 40) || [];
-});
-
-const shorts = computed(() => {
-    return films.value?.results?.filter(f => f.runtime > 0 && f.runtime < 40) || [];
-});
-
-const formatDate = (dateStr) => {
-    const options = { weekday: 'long', month: 'long', day: 'numeric' };
-    const [year, month, day] = dateStr.split('-').map(Number);
-    return new Date(year, month - 1, day).toLocaleDateString('en-US', options);
+const CATEGORY_LABELS = {
+    'Official Selection': 'Official Selection',
+    'Argentine Competition': 'Argentine Competition',
+    'Shorts': 'Shorts',
+    OTHER: 'Other',
 };
 
-const formatTime = (timeStr) => {
-    return new Date(timeStr).toLocaleTimeString('en-US', { 
-        hour: '2-digit', 
+const activeSection = ref('');
+const selectionContentRef = ref(null);
+let sectionObserver = null;
+const isMobile = ref(false);
+let mobileMql = null;
+const sectionOpen = ref({});
+const isSectionOpen = (key) => sectionOpen.value[key] !== false;
+const toggleSection = (key) => { sectionOpen.value = { ...sectionOpen.value, [key]: !isSectionOpen(key) }; };
+const onSectionHeaderClick = (key) => { if (!isMobile.value) return; toggleSection(key); };
+const activeDay = ref('');
+const scheduleContentRef = ref(null);
+let dayObserver = null;
+
+const filmsByCategory = computed(() => {
+    const map = Object.fromEntries(CATEGORY_ORDER.map((c) => [c, []]));
+    map.OTHER = [];
+    for (const f of films.value?.results || []) {
+        const key = String(f.category || f.section || '').trim();
+        if (key && map[key] !== undefined) map[key].push(f);
+        else map.OTHER.push(f);
+    }
+    return map;
+});
+
+const orderedCategories = computed(() => {
+    const out = CATEGORY_ORDER.filter((c) => (filmsByCategory.value[c] || []).length > 0);
+    if ((filmsByCategory.value.OTHER || []).length > 0) out.push('OTHER');
+    return out;
+});
+
+function categoryLabel (cat) {
+    return CATEGORY_LABELS[cat] || cat;
+}
+
+const selectionSections = computed(() => orderedCategories.value.map((cat) => {
+    const items = filmsByCategory.value[cat] || [];
+    return { key: cat, label: categoryLabel(cat), films: items, count: items.length };
+}));
+const officialNav = computed(() => selectionSections.value);
+
+const scrollToSection = (key) => {
+    activeSection.value = key;
+    const root = selectionContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-key]');
+    for (const el of els) { if (el.getAttribute('data-key') === key) { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); break; } }
+};
+
+const setupSectionObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (sectionObserver) sectionObserver.disconnect();
+    const root = selectionContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-key]');
+    if (!els.length) return;
+    sectionObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) { if (entry.isIntersecting) activeSection.value = entry.target.getAttribute('data-key'); }
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => sectionObserver.observe(el));
+};
+
+watch(selectionSections, (sections) => {
+    if (!sections.length) return;
+    if (!sections.some((sec) => sec.key === activeSection.value)) activeSection.value = sections[0].key;
+}, { immediate: true });
+
+watch([loading, activeTab, selectionSections], () => {
+    if (!loading.value && activeTab.value === 'films') nextTick(() => setupSectionObserver());
+    else if (sectionObserver) sectionObserver.disconnect();
+}, { flush: 'post' });
+
+
+const FESTIVAL_TZ = 'America/Argentina/Buenos_Aires';
+
+const formatDate = (dateStr) => {
+    const options = { weekday: 'long', month: 'long', day: 'numeric', timeZone: 'UTC' };
+    return new Date(`${dateStr}T00:00:00Z`).toLocaleDateString('en-US', options);
+};
+
+const formatTime = (timeStr, tz) => {
+    return new Date(timeStr).toLocaleTimeString('en-US', {
+        hour: '2-digit',
         minute: '2-digit',
-        timeZone: 'America/Argentina/Buenos_Aires'
+        timeZone: tz || FESTIVAL_TZ
     });
 };
 
@@ -387,17 +507,57 @@ const groupedScreenings = computed(() => {
 });
 
 const toggleDay = (date) => {
-    if (openDays.value.has(date)) {
-        openDays.value.delete(date);
-    } else {
-        openDays.value.add(date);
-    }
-}
+    if (openDays.value.has(date)) openDays.value.delete(date);
+    else openDays.value.add(date);
+};
 
 const isOpen = (date) => {
     if (scheduleSearchActiveQuery.value) return true;
     return openDays.value.has(date);
 };
+
+const scheduleDays = computed(() => Object.entries(groupedScreenings.value).map(([date, arr]) => ({ date, label: formatDate(date), count: arr.length })));
+const onDayHeaderClick = (date) => { if (!isMobile.value) return; toggleDay(date); };
+const scrollToDay = (date) => {
+    activeDay.value = date;
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-day]');
+    for (const el of els) { if (el.getAttribute('data-day') === date) { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); break; } }
+};
+const setupDayObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (dayObserver) dayObserver.disconnect();
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-day]');
+    if (!els.length) return;
+    dayObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) { if (entry.isIntersecting) activeDay.value = entry.target.getAttribute('data-day'); }
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => dayObserver.observe(el));
+};
+watch(scheduleDays, (days) => {
+    if (!days.length) return;
+    if (!days.some((d) => d.date === activeDay.value)) activeDay.value = days[0]?.date || '';
+}, { immediate: true });
+watch([loading, activeTab, scheduleDays], () => {
+    if (!loading.value && activeTab.value === 'schedule') nextTick(() => setupDayObserver());
+    else if (dayObserver) dayObserver.disconnect();
+}, { flush: 'post' });
+const updateIsMobile = (e) => { isMobile.value = e.matches; };
+onMounted(() => {
+    if (typeof window !== 'undefined' && window.matchMedia) {
+        mobileMql = window.matchMedia('(max-width: 900px)');
+        isMobile.value = mobileMql.matches;
+        mobileMql.addEventListener('change', updateIsMobile);
+    }
+});
+onBeforeUnmount(() => {
+    if (sectionObserver) sectionObserver.disconnect();
+    if (dayObserver) dayObserver.disconnect();
+    if (mobileMql) mobileMql.removeEventListener('change', updateIsMobile);
+});
 
 onMounted(async () => {
     try {
@@ -433,60 +593,156 @@ onMounted(async () => {
     font-size: 1.2rem;
 }
 
-.film-category {
-    margin-bottom: 2.5rem;
-}
-
-// Compact catalog cards (~25%+ smaller than global default).
-// Scoped to .films-grid so other listings (home, search, etc.) are untouched.
-// Uses :deep() because festival cards are child components (scoped CSS).
-.films-grid :deep(.listing__items > .card) {
-    width: 25%;
+// Poster sizing inside the Selection content column. The column is narrower than
+// the old full-bleed grid, so we use fewer columns / slightly larger posters.
+.selection :deep(.listing__items > .card) {
+    width: 33.3333%;
 
     @media (min-width: 640px) {
-        width: 20%;
+        width: 25%;
     }
     @media (min-width: 1024px) {
-        width: 14.2857143%;
+        width: 20%;
     }
     @media (min-width: 1500px) {
-        width: 12.5%;
+        width: 16.6666%;
     }
     @media (min-width: 1800px) {
-        width: 11.1111111%;
-    }
-    @media (min-width: 2500px) {
-        width: 10%;
+        width: 14.2857%;
     }
 }
 
 
 
-.category-header {
+/* ── Selection: sidebar scroll-spy + sections ───────────── */
+.selection-layout,
+.schedule-layout {
+    display: grid;
+    grid-template-columns: 330px minmax(0, 1fr);
+    gap: 2.5rem;
+    align-items: start;
+}
+
+/* Breathing room between the screenings search bar and the day list below it. */
+.schedule-layout {
+    margin-top: 1.75rem;
+}
+
+.selection-nav,
+.schedule-nav {
+    position: sticky;
+    top: 5.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-height: calc(100vh - 7rem);
+    overflow-y: auto;
+    padding: 1rem;
+    border: 1px solid transparent;
+    background:
+        linear-gradient(rgba(3, 6, 10, 0.85), rgba(3, 6, 10, 0.85)) padding-box,
+        linear-gradient(160deg, rgba(139, 233, 253, 0.55), rgba(31, 84, 103, 0.45) 60%, rgba(139, 233, 253, 0.16)) border-box;
+    border-radius: 14px;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
+}
+
+.nav-group-label {
+    font-size: 1rem;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    color: rgba(139, 233, 253, 0.9);
+    font-weight: 700;
+    margin: 1.2rem 0.4rem 0.55rem;
+
+    &:first-child {
+        margin-top: 0.2rem;
+    }
+}
+
+.nav-item {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 10px;
+    width: 100%;
+    background: none;
+    border: none;
+    border-left: 3px solid transparent;
+    border-radius: 0 8px 8px 0;
+    color: rgba(255, 255, 255, 0.88);
+    padding: 0.82rem 1rem;
+    font-size: 1.32rem;
+    font-family: inherit;
+    text-align: left;
     cursor: pointer;
-    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
-    padding-bottom: 5px;
-    margin-bottom: 15px;
-    transition: border-color 0.2s;
-    user-select: none;
-    
+    transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+
     &:hover {
-        border-color: rgba(139, 233, 253, 0.6);
+        background: rgba(139, 233, 253, 0.08);
+        color: #eafbff;
+    }
+
+    &.active {
+        background: rgba(139, 233, 253, 0.12);
+        color: #8BE9FD;
+        border-left-color: #8BE9FD;
+        font-weight: 600;
     }
 }
 
-.category-title {
-    margin: 0 !important;
+.nav-item-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
-.category-count {
-    font-size: 1.1rem;
-    color: rgba(255, 255, 255, 0.6);
-    margin-left: 10px;
-    font-weight: normal;
+.nav-item-count {
+    font-size: 1.12rem;
+    color: rgba(255, 255, 255, 0.62);
+    flex-shrink: 0;
+}
+
+.nav-item.active .nav-item-count {
+    color: rgba(139, 233, 253, 0.85);
+}
+
+.sel-section {
+    scroll-margin-top: 6.5rem;
+    margin-bottom: 3rem;
+}
+
+.sel-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
+    padding-bottom: 6px;
+    margin-bottom: 1.25rem;
+}
+
+.sel-section-title {
+    margin: 0;
+    font-size: 1.7rem;
+    font-weight: 700;
+    color: #fff;
+}
+
+.sel-section-meta {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-shrink: 0;
+}
+
+.sel-section-count {
+    font-size: 1.05rem;
+    color: rgba(255, 255, 255, 0.5);
+    white-space: nowrap;
+    flex-shrink: 0;
 }
 
 .expand-btn {
@@ -502,7 +758,7 @@ onMounted(async () => {
     cursor: pointer;
     transition: all 0.2s ease;
     flex-shrink: 0;
-    
+
     &:hover {
         background: rgba(139, 233, 253, 0.15);
         color: #8BE9FD;
@@ -515,6 +771,42 @@ onMounted(async () => {
         min-width: 20px;
         min-height: 20px;
         display: block;
+    }
+}
+
+.parallel-band {
+    font-size: 0.85rem;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: #8BE9FD;
+    border-top: 1px solid rgba(139, 233, 253, 0.25);
+    padding-top: 1.4rem;
+    margin: 0.5rem 0 1.5rem;
+}
+
+@media (max-width: 900px) {
+    .selection-layout,
+    .schedule-layout {
+        display: block;
+    }
+
+    .selection-nav,
+    .schedule-nav {
+        display: none;
+    }
+
+    .sel-section-header {
+        cursor: pointer;
+        user-select: none;
+        transition: border-color 0.2s;
+    }
+
+    .sel-section-header:hover {
+        border-color: rgba(139, 233, 253, 0.6);
+    }
+
+    .day-header {
+        cursor: pointer;
     }
 }
 
@@ -537,12 +829,16 @@ onMounted(async () => {
 .segmented-control {
     position: relative;
     display: flex;
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 20px; 
+    background: rgba(3, 4, 6, 0.6);
+    border: 1px solid rgba(139, 233, 253, 0.18);
+    border-radius: 16px;
     padding: 4px;
     height: 48px;
     align-items: center;
     min-width: 420px;
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
 }
 
 .segmented-control input[type="radio"] {
@@ -565,7 +861,7 @@ onMounted(async () => {
 }
 
 .segmented-control input:checked + label {
-    color: #000;
+    color: #02080d;
 }
 
 .segmented-control .glider {
@@ -574,9 +870,10 @@ onMounted(async () => {
     left: 4px;
     height: calc(100% - 8px);
     width: calc((100% - 8px) / 3);
-    background: #8BE9FD; 
-    border-radius: 16px;
+    background: linear-gradient(135deg, #8BE9FD, #5cc4d8);
+    border-radius: 12px;
     z-index: 1;
+    box-shadow: 0 4px 14px rgba(139, 233, 253, 0.3);
     transition: transform 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
 }
 
@@ -590,12 +887,15 @@ onMounted(async () => {
     max-width: 1200px;
     margin: 0 auto;
     position: relative;
-    border-radius: 15px;
+    border-radius: 16px;
     overflow: hidden;
-    background-color: transparent;
     display: flex;
     justify-content: center;
-    border: 1px solid #8BE9FD;
+    border: 2px solid transparent;
+    background:
+        linear-gradient(#02080d, #02080d) padding-box,
+        linear-gradient(140deg, #8BE9FD 0%, #1F5467 45%, rgba(31, 84, 103, 0.35) 100%) border-box;
+    box-shadow: 0 14px 36px rgba(0, 0, 0, 0.5), 0 0 30px rgba(139, 233, 253, 0.12);
 }
 
 .back-link {
@@ -625,7 +925,7 @@ onMounted(async () => {
         box-shadow: 0 8px 25px rgba(0,0,0,0.4);
         border-color: #fff;
     }
-    
+
     svg {
         width: 24px;
         height: 24px;
@@ -636,7 +936,7 @@ onMounted(async () => {
         left: 20px;
         font-size: 0.9rem;
         padding: 8px 16px;
-        
+
         svg {
             width: 18px;
             height: 18px;
@@ -648,7 +948,7 @@ onMounted(async () => {
     width: 100%;
     height: auto;
     position: relative;
-    
+
     img {
         width: 100%;
         height: auto;
@@ -687,8 +987,184 @@ onMounted(async () => {
 }
 
 
+
 :deep(.winners-carousel) {
     max-width: 1200px;
+}
+
+.day-header {
+    font-size: 1.8rem;
+    color: #fff;
+    border-bottom: 1px solid #333;
+    padding-bottom: 0.5rem;
+    margin-top: 3rem;
+    margin-bottom: 1.5rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    cursor: default;
+    user-select: none;
+
+    h2 {
+        font-size: 1.8rem;
+        margin: 0;
+    }
+
+    .chevron {
+        transition: transform 0.3s ease;
+
+        &.closed {
+            transform: rotate(-90deg);
+        }
+    }
+}
+
+.schedule-day {
+    scroll-margin-top: 6.5rem;
+}
+
+.schedule-content > .schedule-day:first-child .day-header {
+    margin-top: 0;
+}
+
+.slide-enter-active,
+.slide-leave-active {
+  transition: all 0.3s ease-out;
+  max-height: 2000px;
+  opacity: 1;
+  overflow: hidden;
+}
+
+.slide-enter-from,
+.slide-leave-to {
+  max-height: 0;
+  opacity: 0;
+  margin-bottom: 0;
+}
+
+.screening-card {
+    display: flex;
+    border: 1px solid transparent;
+    background:
+        linear-gradient(#0a161b, #0a161b) padding-box,
+        linear-gradient(140deg, #8BE9FD, #1F5467 60%, rgba(31, 84, 103, 0.3)) border-box;
+    border-radius: 10px;
+    padding: 1.5rem;
+    margin-bottom: 1rem;
+    gap: 1.5rem;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.3);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.screening-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.4), 0 0 20px rgba(139, 233, 253, 0.1);
+}
+
+.time-block {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-width: 80px;
+    border-right: 1px solid #333;
+    padding-right: 1.5rem;
+
+    .time {
+        font-size: 1.2rem;
+        font-weight: 700;
+        color: #fff;
+    }
+    .timezone {
+        font-size: 0.92rem;
+        color: #888;
+    }
+}
+
+.film-info {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+
+    .film-title {
+        font-size: 1.6rem;
+        font-weight: 700;
+        color: #fff;
+        text-decoration: none;
+        margin-bottom: 0.5rem;
+
+        &:hover {
+            color: #8BE9FD;
+        }
+    }
+
+    .film-meta {
+        font-size: 1.05rem;
+        color: #aaa;
+        margin-bottom: 0.8rem;
+    }
+
+    .venue-info {
+        font-size: 1.25rem;
+        color: #ccc;
+        margin-bottom: 0.8rem;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+
+        svg {
+            min-width: 18px;
+        }
+    }
+}
+
+.tags {
+    display: flex;
+    gap: 0.5rem;
+
+    .tag {
+        font-size: 0.75rem;
+        padding: 4px 8px;
+        border-radius: 4px;
+        font-weight: 600;
+        text-transform: uppercase;
+
+        &.in-person { background: rgba(52, 152, 219, 0.2); }
+        &.online { background: rgba(46, 204, 113, 0.2); color: #2ecc71; }
+        &.sold-out { background: rgba(231, 76, 60, 0.2); color: #e74c3c; }
+    }
+}
+
+.poster-mini {
+    width: 60px;
+    height: 90px;
+
+    img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        border-radius: 4px;
+    }
+}
+
+@media (max-width: 600px) {
+    .screening-card {
+        flex-direction: column;
+        gap: 1rem;
+    }
+    .time-block {
+        border-right: none;
+        border-bottom: 1px solid #333;
+        padding-right: 0;
+        padding-bottom: 1rem;
+        flex-direction: row;
+        gap: 1rem;
+        width: 100%;
+    }
+    .poster-mini {
+        display: none;
+    }
 }
 
 /* ── Carousel ─────────────────────────────── */
@@ -707,14 +1183,33 @@ onMounted(async () => {
 }
 
 .carousel-card {
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(139, 233, 253, 0.18);
+  position: relative;
+  background: rgba(3, 4, 6, 0.85);
+  background-image:
+    radial-gradient(circle at 15% 20%, rgba(31, 84, 103, 0.18), transparent 35%),
+    radial-gradient(circle at 85% 80%, rgba(139, 233, 253, 0.08), transparent 30%);
+  border: 1px solid rgba(31, 84, 103, 0.5);
   border-radius: 20px;
   padding: 2.2rem 2.5rem;
-  backdrop-filter: blur(12px);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
   color: rgba(255, 255, 255, 0.88);
   line-height: 1.8;
   min-height: 300px;
+  overflow: hidden;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5), inset 0 0 24px rgba(139, 233, 253, 0.04);
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: linear-gradient(90deg, transparent, #8BE9FD, #1F5467, transparent);
+    opacity: 0.85;
+    pointer-events: none;
+  }
 
   strong { color: #fff; }
 }
@@ -748,19 +1243,21 @@ onMounted(async () => {
   justify-content: center;
   width: 44px;
   height: 44px;
-  border-radius: 50%;
-  border: 1px solid rgba(139, 233, 253, 0.25);
-  background: rgba(0, 0, 0, 0.4);
+  border-radius: 12px;
+  border: 1px solid rgba(139, 233, 253, 0.4);
+  background: rgba(3, 4, 6, 0.75);
   color: #8BE9FD;
   cursor: pointer;
-  transition: all 0.25s ease;
+  transition: all 0.2s ease;
   flex-shrink: 0;
-  backdrop-filter: blur(6px);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
 
   &:hover {
-    background: rgba(139, 233, 253, 0.15);
-    border-color: #8BE9FD;
-    transform: scale(1.1);
+    background: #ffffff;
+    border-color: #ffffff;
+    color: #000;
+    transform: scale(1.05);
   }
 }
 
@@ -792,7 +1289,6 @@ onMounted(async () => {
   }
 }
 
-/* Slide transitions */
 .carousel-next-enter-active,
 .carousel-next-leave-active,
 .carousel-prev-enter-active,
@@ -821,33 +1317,9 @@ onMounted(async () => {
   .price-value { color: #8BE9FD; font-weight: 700; font-size: 1.1rem; }
 }
 
-.promo-box {
-  background: rgba(139, 233, 253, 0.08);
-  border-left: 3px solid #8BE9FD;
-  border-radius: 8px;
-  padding: 1rem 1.2rem;
-  margin-top: 1rem;
-  position: relative;
-  .promo-tag { position: absolute; top: 0; right: 0; background: #8BE9FD; color: #000; font-size: 0.65rem; font-weight: 800; padding: 3px 10px; border-bottom-left-radius: 6px; }
-  p { margin: 0; font-size: 1rem; }
-}
-
-.activity-type {
-  display: flex; gap: 1rem; align-items: flex-start; margin-bottom: 1.2rem; &:last-child { margin-bottom: 0; }
-  .badge { padding: 4px 12px; border-radius: 6px; font-weight: 800; font-size: 0.8rem; flex-shrink: 0; margin-top: 3px;
-    &.gr { background: #8BE9FD; color: #000; }
-    &.gs { border: 1px solid #8BE9FD; color: #8BE9FD; }
-  }
-  p { margin: 0; font-size: 1.02rem; }
-}
-
 .venue-list {
-  display: grid; grid-template-columns: repeat(2, 1fr); gap: 0.9rem;
-  @media (max-width: 600px) { grid-template-columns: 1fr; }
-  .venue-item { font-size: 0.98rem; padding: 0.7rem 0.9rem; background: rgba(255,255,255,0.04); border-radius: 10px; border: 1px solid rgba(255,255,255,0.06);
-    strong { color: #8BE9FD; display: block; margin-bottom: 3px; font-size: 1.02rem; }
-    span { color: rgba(255,255,255,0.7); }
-  }
+  display: flex; flex-direction: column; gap: 0.5rem; margin: 0.5rem 0;
+  .venue-item { display: flex; justify-content: space-between; align-items: center; padding: 0.5rem 0; border-bottom: 1px solid rgba(255,255,255,0.05); span { color: rgba(255,255,255,0.5); font-size: 0.95rem; } strong { color: #fff; } }
 }
 
 .bullet-list {
@@ -860,162 +1332,55 @@ onMounted(async () => {
   &:hover { border-color: #8BE9FD; }
 }
 
-.day-header {
-    font-size: 1.8rem;
-    color: #fff;
-    border-bottom: 1px solid #333;
-    padding-bottom: 0.5rem;
-    margin-top: 3rem;
-    margin-bottom: 1.5rem;
+/* ── Initial-rollout banner (catalog/schedule placeholders) ─ */
+.rollout-banner {
     display: flex;
-    justify-content: space-between;
-    align-items: center;
-    cursor: pointer;
-    user-select: none;
-    
-    h2 {
-        font-size: 1.8rem;
-        margin: 0;
-    }
-    
-    .chevron {
-        transition: transform 0.3s ease;
-        
-        &.closed {
-            transform: rotate(-90deg);
-        }
-    }
+    gap: 1.25rem;
+    align-items: flex-start;
+    max-width: 720px;
+    margin: 2rem auto;
+    padding: 1.5rem 1.75rem;
+    background: rgba(16, 26, 35, 0.7);
+    border: 1px solid rgba(139, 233, 253, 0.22);
+    border-radius: 14px;
+    backdrop-filter: blur(8px);
 }
 
-.slide-enter-active,
-.slide-leave-active {
-  transition: all 0.3s ease-out;
-  max-height: 2000px;
-  opacity: 1;
-  overflow: hidden;
-}
-
-.slide-enter-from,
-.slide-leave-to {
-  max-height: 0;
-  opacity: 0;
-  margin-bottom: 0;
-}
-
-.screening-card {
+.rollout-banner__icon {
+    flex-shrink: 0;
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    background: rgba(139, 233, 253, 0.08);
     display: flex;
-    background: #0a161b;
-    border: 1px solid #8BE9FD;
-    border-radius: 8px;
-    padding: 1.5rem;
-    margin-bottom: 1rem;
-    gap: 1.5rem;
-    transition: transform 0.2s;
-}
-
-.time-block {
-    display: flex;
-    flex-direction: column;
     align-items: center;
     justify-content: center;
-    min-width: 80px;
-    border-right: 1px solid #333;
-    padding-right: 1.5rem;
-    
-    .time {
-        font-size: 1.2rem;
-        font-weight: 700;
-        color: #fff;
-    }
-    .timezone {
-        font-size: 0.92rem;
-        color: #888;
-    }
 }
 
-.film-info {
+.rollout-banner__copy {
     flex: 1;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    
-    .film-title {
-        font-size: 1.6rem;
+    color: rgba(255, 255, 255, 0.85);
+
+    h3 {
+        margin: 0 0 0.4rem;
+        font-size: 1.15rem;
         font-weight: 700;
-        color: #fff;
-        text-decoration: none;
-        margin-bottom: 0.5rem;
-        
-        &:hover {
-            color: #8BE9FD;
-        }
+        color: #8BE9FD;
+        letter-spacing: 0.3px;
     }
-    
-    .film-meta {
-        font-size: 1.05rem;
-        color: #aaa;
-        margin-bottom: 0.8rem;
-    }
-    
-    .venue-info {
-        font-size: 1.25rem;
-        color: #ccc;
-        margin-bottom: 0.8rem;
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-        
-        svg {
-            min-width: 18px;
-        }
-    }
-}
-
-.tags {
-    display: flex;
-    gap: 0.5rem;
-    
-    .tag {
-        font-size: 0.75rem;
-        padding: 4px 8px;
-        border-radius: 4px;
-        font-weight: 600;
-        text-transform: uppercase;
-        
-        &.in-person { background: rgba(52, 152, 219, 0.2); }
-        &.online { background: rgba(46, 204, 113, 0.2); color: #2ecc71; }
-        &.sold-out { background: rgba(231, 76, 60, 0.2); color: #e74c3c; }
-    }
-}
-
-.poster-mini {
-    width: 60px;
-    height: 90px;
-    
-    img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-        border-radius: 4px;
+    p {
+        margin: 0;
+        font-size: 1rem;
+        line-height: 1.6;
+        color: rgba(255, 255, 255, 0.7);
     }
 }
 
 @media (max-width: 600px) {
-    .screening-card {
-        flex-direction: column; 
-        gap: 1rem;
-    }
-    .time-block {
-        border-right: none;
-        border-bottom: 1px solid #333;
-        padding-right: 0;
-        padding-bottom: 1rem;
-        flex-direction: row;
-        gap: 1rem;
-        width: 100%;
-    }
-    .poster-mini {
-        display: none;
+    .rollout-banner {
+        flex-direction: column;
+        gap: 0.75rem;
+        padding: 1.25rem;
     }
 }
 

--- a/pages/festival/berlinale-2026/index.vue
+++ b/pages/festival/berlinale-2026/index.vue
@@ -50,54 +50,79 @@
       </div>
 
       <div v-else>
-        <div v-if="activeTab === 'films'" class="films-grid">
-            <div v-if="features.length > 0" class="film-category">
-                <div class="category-header" @click="featuresOpen = !featuresOpen">
-                    <h2 class="listing__title category-title">
-                        Features
-                        <span class="category-count">({{ features.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="featuresOpen ? 'Collapse' : 'Expand'">
-                        <svg v-if="featuresOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
-                    </button>
-                </div>
-                <transition name="slide">
-                    <div v-show="featuresOpen" class="listing__items">
-                        <BerlinaleCard 
-                            v-for="item in features"
-                            :key="`feature-${item.id}`"
-                            :item="item" 
-                        />
-                    </div>
-                </transition>
+        <div v-if="activeTab === 'films'" class="selection">
+          <div v-if="orderedCategories.length === 0" class="rollout-banner">
+            <div class="rollout-banner__icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
             </div>
+            <div class="rollout-banner__copy">
+              <h3>Lineup updates in progress</h3>
+              <p>This festival lineup is currently being updated. New films, sections, and official selections will be added progressively as they are announced and verified.</p>
+            </div>
+          </div>
+          <div v-else class="selection-layout">
+            <aside class="selection-nav" aria-label="Jump to section">
+              <template v-if="officialNav.length">
+                <div class="nav-group-label">Catalog</div>
+                <button
+                  v-for="sec in officialNav"
+                  :key="sec.key"
+                  class="nav-item"
+                  :class="{ active: activeSection === sec.key }"
+                  @click="scrollToSection(sec.key)"
+                >
+                  <span class="nav-item-label">{{ sec.label }}</span>
+                  <span class="nav-item-count">{{ sec.count }}</span>
+                </button>
+              </template>
+            </aside>
 
-            <div v-if="shorts.length > 0" class="film-category">
-                <div class="category-header" @click="shortsOpen = !shortsOpen">
-                    <h2 class="listing__title category-title">
-                        Shorts
-                        <span class="category-count">({{ shorts.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="shortsOpen ? 'Collapse' : 'Expand'">
-                        <svg v-if="shortsOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
+            <div ref="selectionContentRef" class="selection-content">
+              <section
+                v-for="sec in selectionSections"
+                :key="sec.key"
+                :data-key="sec.key"
+                class="sel-section"
+              >
+                <div class="sel-section-header" @click="onSectionHeaderClick(sec.key)">
+                  <h2 class="sel-section-title">{{ sec.label }}</h2>
+                  <div class="sel-section-meta">
+                    <span class="sel-section-count">{{ sec.count }} {{ sec.count === 1 ? 'film' : 'films' }}</span>
+                    <button v-if="isMobile" class="expand-btn" :aria-label="isSectionOpen(sec.key) ? 'Collapse' : 'Expand'">
+                      <svg v-if="isSectionOpen(sec.key)" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
+                      <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
                     </button>
+                  </div>
                 </div>
                 <transition name="slide">
-                    <div v-show="shortsOpen" class="listing__items">
-                        <BerlinaleCard 
-                            v-for="item in shorts"
-                            :key="`short-${item.id}`"
-                            :item="item" 
-                        />
+                  <div v-show="!isMobile || isSectionOpen(sec.key)" class="sel-section-body">
+                    <div class="listing__items">
+                      <BerlinaleCard
+                        v-for="item in sec.films"
+                        :key="`${sec.key}-${item.id}`"
+                        :item="item"
+                      />
                     </div>
+                  </div>
                 </transition>
+              </section>
             </div>
+          </div>
         </div>
 
         <div v-if="activeTab === 'schedule'" class="schedule-container">
-          <div class="schedule-toolbar" :class="{ 'search-active': isScheduleSearchActive }">
+          <!-- Initial rollout banner: schedule pending official publication -->
+          <div v-if="schedule.length === 0" class="rollout-banner">
+            <div class="rollout-banner__icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+            </div>
+            <div class="rollout-banner__copy">
+              <h3>Schedule pending</h3>
+              <p>Official screening schedules have not yet been published by the festival. Screening information will appear here as soon as it becomes available.</p>
+            </div>
+          </div>
+
+          <div v-if="schedule.length > 0" class="schedule-toolbar" :class="{ 'search-active': isScheduleSearchActive }">
             <div class="schedule-toolbar-info">
               <span class="schedule-count" v-if="!loading">
                 <template v-if="scheduleSearchActiveQuery">
@@ -133,24 +158,40 @@
             <p>No screenings match "<strong>{{ scheduleSearch }}</strong>"</p>
           </div>
 
-          <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" class="schedule-day">
-            <div class="day-header" @click="toggleDay(date)">
+          <div v-if="scheduleDays.length" class="schedule-layout">
+            <aside class="schedule-nav" aria-label="Jump to day">
+              <div class="nav-group-label">Days</div>
+              <button
+                v-for="day in scheduleDays"
+                :key="day.date"
+                class="nav-item"
+                :class="{ active: activeDay === day.date }"
+                @click="scrollToDay(day.date)"
+              >
+                <span class="nav-item-label">{{ day.label }}</span>
+                <span class="nav-item-count">{{ day.count }}</span>
+              </button>
+            </aside>
+
+            <div ref="scheduleContentRef" class="schedule-content">
+              <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" :data-day="date" class="schedule-day">
+            <div class="day-header" @click="onDayHeaderClick(date)">
                 <h2>{{ formatDate(date) }}</h2>
-                <div class="chevron" :class="{ 'closed': !isOpen(date) }">
+                <div v-if="isMobile" class="chevron" :class="{ 'closed': !isOpen(date) }">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down"><path d="m6 9 6 6 6-6"/></svg>
                 </div>
             </div>
-            
+
             <transition name="slide">
-                <div v-show="isOpen(date)" class="screenings-list">
+                <div v-show="!isMobile || isOpen(date)" class="screenings-list">
                   <div v-for="screening in dayScreenings" :key="screening.id" class="screening-card">
                      <div class="time-block">
-                        <span class="time">{{ formatTime(screening.start_time) }}</span>
+                        <span class="time">{{ formatTime(screening.start_time, screening.timezone) }}</span>
                         <span class="timezone">{{ screening.timezone }}</span>
                      </div>
-                     
+
                       <div class="film-info">
-                         <component 
+                         <component
                             :is="screening.film.source_url ? 'a' : 'span'"
                             :href="screening.film.source_url || ''"
                             :target="screening.film.source_url ? '_blank' : ''"
@@ -174,13 +215,13 @@
                              <span v-if="screening.is_sold_out" class="tag sold-out">Sold Out</span>
                          </div>
                       </div>
-                      
+
                       <div class="poster-mini">
-                          <img 
-                            v-if="screening.film.poster_path" 
-                            :src="screening.film.poster_path" 
-                            alt="Poster" 
-                            loading="lazy" 
+                          <img
+                            v-if="screening.film.poster_path"
+                            :src="screening.film.poster_path"
+                            alt="Poster"
+                            loading="lazy"
                             @error="$event.target.src = '/placeholders/image_not_found_yet.webp'"
                           />
                           <img v-else src="/placeholders/image_not_found_yet.webp" alt="No Poster" />
@@ -188,6 +229,8 @@
                   </div>
                 </div>
             </transition>
+          </div>
+            </div>
           </div>
         </div>
 
@@ -265,7 +308,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, nextTick } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount, nextTick, watch } from 'vue';
 import Loader from '~/components/Loader.vue';
 import WinnersCarousel from '~/components/festival/WinnersCarousel.vue';
 import FestivalDataDisclaimer from '~/components/FestivalDataDisclaimer.vue';
@@ -315,27 +358,107 @@ const awards = ref([]);
 const schedule = ref([]);
 const openDays = ref(new Set());
 
-const featuresOpen = ref(true);
-const shortsOpen = ref(true);
+const CATEGORY_ORDER = [
+    'Features',
+    'Shorts',
+];
 
-const features = computed(() => {
-    return films.value?.results?.filter(f => !f.runtime || f.runtime >= 40) || [];
-});
-
-const shorts = computed(() => {
-    return films.value?.results?.filter(f => f.runtime > 0 && f.runtime < 40) || [];
-});
-
-const formatDate = (dateStr) => {
-    const options = { weekday: 'long', month: 'long', day: 'numeric', timeZone: 'Europe/Berlin' };
-    return new Date(dateStr).toLocaleDateString('en-US', options);
+const CATEGORY_LABELS = {
+    Features: 'Features',
+    Shorts: 'Shorts',
+    OTHER: 'Other',
 };
 
-const formatTime = (timeStr) => {
-    return new Date(timeStr).toLocaleTimeString('en-US', { 
-        hour: '2-digit', 
+const categoryKeyForFilm = (film) => {
+    const explicit = String(film.category || film.section || '').trim();
+    if (CATEGORY_ORDER.includes(explicit)) return explicit;
+    if (film.runtime > 0 && film.runtime < 40) return 'Shorts';
+    return 'Features';
+};
+
+const activeSection = ref('');
+const selectionContentRef = ref(null);
+let sectionObserver = null;
+const isMobile = ref(false);
+let mobileMql = null;
+const sectionOpen = ref({});
+const isSectionOpen = (key) => sectionOpen.value[key] !== false;
+const toggleSection = (key) => { sectionOpen.value = { ...sectionOpen.value, [key]: !isSectionOpen(key) }; };
+const onSectionHeaderClick = (key) => { if (!isMobile.value) return; toggleSection(key); };
+const activeDay = ref('');
+const scheduleContentRef = ref(null);
+let dayObserver = null;
+
+const filmsByCategory = computed(() => {
+    const map = Object.fromEntries(CATEGORY_ORDER.map((c) => [c, []]));
+    map.OTHER = [];
+    for (const f of films.value?.results || []) {
+        const key = categoryKeyForFilm(f);
+        if (key && map[key] !== undefined) map[key].push(f);
+        else map.OTHER.push(f);
+    }
+    return map;
+});
+
+const orderedCategories = computed(() => {
+    const out = CATEGORY_ORDER.filter((c) => (filmsByCategory.value[c] || []).length > 0);
+    if ((filmsByCategory.value.OTHER || []).length > 0) out.push('OTHER');
+    return out;
+});
+
+function categoryLabel (cat) {
+    return CATEGORY_LABELS[cat] || cat;
+}
+
+const selectionSections = computed(() => orderedCategories.value.map((cat) => {
+    const items = filmsByCategory.value[cat] || [];
+    return { key: cat, label: categoryLabel(cat), films: items, count: items.length };
+}));
+const officialNav = computed(() => selectionSections.value);
+
+const scrollToSection = (key) => {
+    activeSection.value = key;
+    const root = selectionContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-key]');
+    for (const el of els) { if (el.getAttribute('data-key') === key) { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); break; } }
+};
+
+const setupSectionObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (sectionObserver) sectionObserver.disconnect();
+    const root = selectionContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-key]');
+    if (!els.length) return;
+    sectionObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) { if (entry.isIntersecting) activeSection.value = entry.target.getAttribute('data-key'); }
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => sectionObserver.observe(el));
+};
+
+watch(selectionSections, (sections) => {
+    if (!sections.length) return;
+    if (!sections.some((sec) => sec.key === activeSection.value)) activeSection.value = sections[0].key;
+}, { immediate: true });
+
+watch([loading, activeTab, selectionSections], () => {
+    if (!loading.value && activeTab.value === 'films') nextTick(() => setupSectionObserver());
+    else if (sectionObserver) sectionObserver.disconnect();
+}, { flush: 'post' });
+
+const FESTIVAL_TZ = 'Europe/Berlin';
+
+const formatDate = (dateStr) => {
+    const options = { weekday: 'long', month: 'long', day: 'numeric', timeZone: 'UTC' };
+    return new Date(`${dateStr}T00:00:00Z`).toLocaleDateString('en-US', options);
+};
+
+const formatTime = (timeStr, tz) => {
+    return new Date(timeStr).toLocaleTimeString('en-US', {
+        hour: '2-digit',
         minute: '2-digit',
-        timeZone: 'Europe/Berlin'
+        timeZone: tz || FESTIVAL_TZ
     });
 };
 
@@ -366,17 +489,57 @@ const groupedScreenings = computed(() => {
 });
 
 const toggleDay = (date) => {
-    if (openDays.value.has(date)) {
-        openDays.value.delete(date);
-    } else {
-        openDays.value.add(date);
-    }
-}
+    if (openDays.value.has(date)) openDays.value.delete(date);
+    else openDays.value.add(date);
+};
 
 const isOpen = (date) => {
     if (scheduleSearchActiveQuery.value) return true;
     return openDays.value.has(date);
 };
+
+const scheduleDays = computed(() => Object.entries(groupedScreenings.value).map(([date, arr]) => ({ date, label: formatDate(date), count: arr.length })));
+const onDayHeaderClick = (date) => { if (!isMobile.value) return; toggleDay(date); };
+const scrollToDay = (date) => {
+    activeDay.value = date;
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-day]');
+    for (const el of els) { if (el.getAttribute('data-day') === date) { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); break; } }
+};
+const setupDayObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (dayObserver) dayObserver.disconnect();
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-day]');
+    if (!els.length) return;
+    dayObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) { if (entry.isIntersecting) activeDay.value = entry.target.getAttribute('data-day'); }
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => dayObserver.observe(el));
+};
+watch(scheduleDays, (days) => {
+    if (!days.length) return;
+    if (!days.some((d) => d.date === activeDay.value)) activeDay.value = days[0]?.date || '';
+}, { immediate: true });
+watch([loading, activeTab, scheduleDays], () => {
+    if (!loading.value && activeTab.value === 'schedule') nextTick(() => setupDayObserver());
+    else if (dayObserver) dayObserver.disconnect();
+}, { flush: 'post' });
+const updateIsMobile = (e) => { isMobile.value = e.matches; };
+onMounted(() => {
+    if (typeof window !== 'undefined' && window.matchMedia) {
+        mobileMql = window.matchMedia('(max-width: 900px)');
+        isMobile.value = mobileMql.matches;
+        mobileMql.addEventListener('change', updateIsMobile);
+    }
+});
+onBeforeUnmount(() => {
+    if (sectionObserver) sectionObserver.disconnect();
+    if (dayObserver) dayObserver.disconnect();
+    if (mobileMql) mobileMql.removeEventListener('change', updateIsMobile);
+});
 
 onMounted(async () => {
     try {
@@ -410,60 +573,156 @@ onMounted(async () => {
     font-size: 1.2rem;
 }
 
-.film-category {
-    margin-bottom: 2.5rem;
-}
-
-// Compact catalog cards (~25%+ smaller than global default).
-// Scoped to .films-grid so other listings (home, search, etc.) are untouched.
-// Uses :deep() because festival cards are child components (scoped CSS).
-.films-grid :deep(.listing__items > .card) {
-    width: 25%;
+// Poster sizing inside the Selection content column. The column is narrower than
+// the old full-bleed grid, so we use fewer columns / slightly larger posters.
+.selection :deep(.listing__items > .card) {
+    width: 33.3333%;
 
     @media (min-width: 640px) {
-        width: 20%;
+        width: 25%;
     }
     @media (min-width: 1024px) {
-        width: 14.2857143%;
+        width: 20%;
     }
     @media (min-width: 1500px) {
-        width: 12.5%;
+        width: 16.6666%;
     }
     @media (min-width: 1800px) {
-        width: 11.1111111%;
-    }
-    @media (min-width: 2500px) {
-        width: 10%;
+        width: 14.2857%;
     }
 }
 
 
 
-.category-header {
+/* ── Selection: sidebar scroll-spy + sections ───────────── */
+.selection-layout,
+.schedule-layout {
+    display: grid;
+    grid-template-columns: 330px minmax(0, 1fr);
+    gap: 2.5rem;
+    align-items: start;
+}
+
+/* Breathing room between the screenings search bar and the day list below it. */
+.schedule-layout {
+    margin-top: 1.75rem;
+}
+
+.selection-nav,
+.schedule-nav {
+    position: sticky;
+    top: 5.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-height: calc(100vh - 7rem);
+    overflow-y: auto;
+    padding: 1rem;
+    border: 1px solid transparent;
+    background:
+        linear-gradient(rgba(3, 6, 10, 0.85), rgba(3, 6, 10, 0.85)) padding-box,
+        linear-gradient(160deg, rgba(139, 233, 253, 0.55), rgba(31, 84, 103, 0.45) 60%, rgba(139, 233, 253, 0.16)) border-box;
+    border-radius: 14px;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
+}
+
+.nav-group-label {
+    font-size: 1rem;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    color: rgba(139, 233, 253, 0.9);
+    font-weight: 700;
+    margin: 1.2rem 0.4rem 0.55rem;
+
+    &:first-child {
+        margin-top: 0.2rem;
+    }
+}
+
+.nav-item {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 10px;
+    width: 100%;
+    background: none;
+    border: none;
+    border-left: 3px solid transparent;
+    border-radius: 0 8px 8px 0;
+    color: rgba(255, 255, 255, 0.88);
+    padding: 0.82rem 1rem;
+    font-size: 1.32rem;
+    font-family: inherit;
+    text-align: left;
     cursor: pointer;
-    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
-    padding-bottom: 5px;
-    margin-bottom: 15px;
-    transition: border-color 0.2s;
-    user-select: none;
-    
+    transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+
     &:hover {
-        border-color: rgba(139, 233, 253, 0.6);
+        background: rgba(139, 233, 253, 0.08);
+        color: #eafbff;
+    }
+
+    &.active {
+        background: rgba(139, 233, 253, 0.12);
+        color: #8BE9FD;
+        border-left-color: #8BE9FD;
+        font-weight: 600;
     }
 }
 
-.category-title {
-    margin: 0 !important;
+.nav-item-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
-.category-count {
-    font-size: 1.1rem;
-    color: rgba(255, 255, 255, 0.6);
-    margin-left: 10px;
-    font-weight: normal;
+.nav-item-count {
+    font-size: 1.12rem;
+    color: rgba(255, 255, 255, 0.62);
+    flex-shrink: 0;
+}
+
+.nav-item.active .nav-item-count {
+    color: rgba(139, 233, 253, 0.85);
+}
+
+.sel-section {
+    scroll-margin-top: 6.5rem;
+    margin-bottom: 3rem;
+}
+
+.sel-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
+    padding-bottom: 6px;
+    margin-bottom: 1.25rem;
+}
+
+.sel-section-title {
+    margin: 0;
+    font-size: 1.7rem;
+    font-weight: 700;
+    color: #fff;
+}
+
+.sel-section-meta {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-shrink: 0;
+}
+
+.sel-section-count {
+    font-size: 1.05rem;
+    color: rgba(255, 255, 255, 0.5);
+    white-space: nowrap;
+    flex-shrink: 0;
 }
 
 .expand-btn {
@@ -479,7 +738,7 @@ onMounted(async () => {
     cursor: pointer;
     transition: all 0.2s ease;
     flex-shrink: 0;
-    
+
     &:hover {
         background: rgba(139, 233, 253, 0.15);
         color: #8BE9FD;
@@ -492,6 +751,42 @@ onMounted(async () => {
         min-width: 20px;
         min-height: 20px;
         display: block;
+    }
+}
+
+.parallel-band {
+    font-size: 0.85rem;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: #8BE9FD;
+    border-top: 1px solid rgba(139, 233, 253, 0.25);
+    padding-top: 1.4rem;
+    margin: 0.5rem 0 1.5rem;
+}
+
+@media (max-width: 900px) {
+    .selection-layout,
+    .schedule-layout {
+        display: block;
+    }
+
+    .selection-nav,
+    .schedule-nav {
+        display: none;
+    }
+
+    .sel-section-header {
+        cursor: pointer;
+        user-select: none;
+        transition: border-color 0.2s;
+    }
+
+    .sel-section-header:hover {
+        border-color: rgba(139, 233, 253, 0.6);
+    }
+
+    .day-header {
+        cursor: pointer;
     }
 }
 
@@ -514,12 +809,16 @@ onMounted(async () => {
 .segmented-control {
     position: relative;
     display: flex;
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 20px; 
+    background: rgba(3, 4, 6, 0.6);
+    border: 1px solid rgba(139, 233, 253, 0.18);
+    border-radius: 16px;
     padding: 4px;
     height: 48px;
     align-items: center;
     min-width: 420px;
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
 }
 
 .segmented-control input[type="radio"] {
@@ -542,7 +841,7 @@ onMounted(async () => {
 }
 
 .segmented-control input:checked + label {
-    color: #000;
+    color: #02080d;
 }
 
 .segmented-control .glider {
@@ -551,9 +850,10 @@ onMounted(async () => {
     left: 4px;
     height: calc(100% - 8px);
     width: calc((100% - 8px) / 3);
-    background: #8BE9FD;
-    border-radius: 16px;
+    background: linear-gradient(135deg, #8BE9FD, #5cc4d8);
+    border-radius: 12px;
     z-index: 1;
+    box-shadow: 0 4px 14px rgba(139, 233, 253, 0.3);
     transition: transform 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
 }
 
@@ -567,12 +867,15 @@ onMounted(async () => {
     max-width: 1200px;
     margin: 0 auto;
     position: relative;
-    border-radius: 15px;
+    border-radius: 16px;
     overflow: hidden;
-    background-color: transparent;
     display: flex;
     justify-content: center;
-    border: 1px solid #8BE9FD;
+    border: 2px solid transparent;
+    background:
+        linear-gradient(#02080d, #02080d) padding-box,
+        linear-gradient(140deg, #8BE9FD 0%, #1F5467 45%, rgba(31, 84, 103, 0.35) 100%) border-box;
+    box-shadow: 0 14px 36px rgba(0, 0, 0, 0.5), 0 0 30px rgba(139, 233, 253, 0.12);
 }
 
 .back-link {
@@ -602,7 +905,7 @@ onMounted(async () => {
         box-shadow: 0 8px 25px rgba(0,0,0,0.4);
         border-color: #fff;
     }
-    
+
     svg {
         width: 24px;
         height: 24px;
@@ -613,7 +916,7 @@ onMounted(async () => {
         left: 20px;
         font-size: 0.9rem;
         padding: 8px 16px;
-        
+
         svg {
             width: 18px;
             height: 18px;
@@ -625,7 +928,7 @@ onMounted(async () => {
     width: 100%;
     height: auto;
     position: relative;
-    
+
     img {
         width: 100%;
         height: auto;
@@ -679,21 +982,29 @@ onMounted(async () => {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    cursor: pointer;
+    cursor: default;
     user-select: none;
-    
+
     h2 {
         font-size: 1.8rem;
         margin: 0;
     }
-    
+
     .chevron {
         transition: transform 0.3s ease;
-        
+
         &.closed {
             transform: rotate(-90deg);
         }
     }
+}
+
+.schedule-day {
+    scroll-margin-top: 6.5rem;
+}
+
+.schedule-content > .schedule-day:first-child .day-header {
+    margin-top: 0;
 }
 
 .slide-enter-active,
@@ -713,13 +1024,21 @@ onMounted(async () => {
 
 .screening-card {
     display: flex;
-    background: #0a161b;
-    border: 1px solid #8BE9FD;
-    border-radius: 8px;
+    border: 1px solid transparent;
+    background:
+        linear-gradient(#0a161b, #0a161b) padding-box,
+        linear-gradient(140deg, #8BE9FD, #1F5467 60%, rgba(31, 84, 103, 0.3)) border-box;
+    border-radius: 10px;
     padding: 1.5rem;
     margin-bottom: 1rem;
     gap: 1.5rem;
-    transition: transform 0.2s;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.3);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.screening-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.4), 0 0 20px rgba(139, 233, 253, 0.1);
 }
 
 .time-block {
@@ -730,7 +1049,7 @@ onMounted(async () => {
     min-width: 80px;
     border-right: 1px solid #333;
     padding-right: 1.5rem;
-    
+
     .time {
         font-size: 1.2rem;
         font-weight: 700;
@@ -747,25 +1066,25 @@ onMounted(async () => {
     display: flex;
     flex-direction: column;
     justify-content: center;
-    
+
     .film-title {
         font-size: 1.6rem;
         font-weight: 700;
         color: #fff;
         text-decoration: none;
         margin-bottom: 0.5rem;
-        
+
         &:hover {
             color: #8BE9FD;
         }
     }
-    
+
     .film-meta {
         font-size: 1.05rem;
         color: #aaa;
         margin-bottom: 0.8rem;
     }
-    
+
     .venue-info {
         font-size: 1.25rem;
         color: #ccc;
@@ -773,7 +1092,7 @@ onMounted(async () => {
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        
+
         svg {
             min-width: 18px;
         }
@@ -783,14 +1102,14 @@ onMounted(async () => {
 .tags {
     display: flex;
     gap: 0.5rem;
-    
+
     .tag {
         font-size: 0.75rem;
         padding: 4px 8px;
         border-radius: 4px;
         font-weight: 600;
         text-transform: uppercase;
-        
+
         &.in-person { background: rgba(52, 152, 219, 0.2); }
         &.online { background: rgba(46, 204, 113, 0.2); color: #2ecc71; }
         &.sold-out { background: rgba(231, 76, 60, 0.2); color: #e74c3c; }
@@ -800,7 +1119,7 @@ onMounted(async () => {
 .poster-mini {
     width: 60px;
     height: 90px;
-    
+
     img {
         width: 100%;
         height: 100%;
@@ -811,7 +1130,7 @@ onMounted(async () => {
 
 @media (max-width: 600px) {
     .screening-card {
-        flex-direction: column; 
+        flex-direction: column;
         gap: 1rem;
     }
     .time-block {
@@ -844,14 +1163,33 @@ onMounted(async () => {
 }
 
 .carousel-card {
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(139, 233, 253, 0.18);
+  position: relative;
+  background: rgba(3, 4, 6, 0.85);
+  background-image:
+    radial-gradient(circle at 15% 20%, rgba(31, 84, 103, 0.18), transparent 35%),
+    radial-gradient(circle at 85% 80%, rgba(139, 233, 253, 0.08), transparent 30%);
+  border: 1px solid rgba(31, 84, 103, 0.5);
   border-radius: 20px;
   padding: 2.2rem 2.5rem;
-  backdrop-filter: blur(12px);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
   color: rgba(255, 255, 255, 0.88);
   line-height: 1.8;
   min-height: 300px;
+  overflow: hidden;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5), inset 0 0 24px rgba(139, 233, 253, 0.04);
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: linear-gradient(90deg, transparent, #8BE9FD, #1F5467, transparent);
+    opacity: 0.85;
+    pointer-events: none;
+  }
 
   strong { color: #fff; }
 }
@@ -885,19 +1223,21 @@ onMounted(async () => {
   justify-content: center;
   width: 44px;
   height: 44px;
-  border-radius: 50%;
-  border: 1px solid rgba(139, 233, 253, 0.25);
-  background: rgba(0, 0, 0, 0.4);
+  border-radius: 12px;
+  border: 1px solid rgba(139, 233, 253, 0.4);
+  background: rgba(3, 4, 6, 0.75);
   color: #8BE9FD;
   cursor: pointer;
-  transition: all 0.25s ease;
+  transition: all 0.2s ease;
   flex-shrink: 0;
-  backdrop-filter: blur(6px);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
 
   &:hover {
-    background: rgba(139, 233, 253, 0.15);
-    border-color: #8BE9FD;
-    transform: scale(1.1);
+    background: #ffffff;
+    border-color: #ffffff;
+    color: #000;
+    transform: scale(1.05);
   }
 }
 
@@ -929,7 +1269,6 @@ onMounted(async () => {
   }
 }
 
-/* Slide transitions */
 .carousel-next-enter-active,
 .carousel-next-leave-active,
 .carousel-prev-enter-active,
@@ -959,12 +1298,8 @@ onMounted(async () => {
 }
 
 .venue-list {
-  display: grid; grid-template-columns: repeat(2, 1fr); gap: 0.9rem;
-  @media (max-width: 600px) { grid-template-columns: 1fr; }
-  .venue-item { font-size: 0.98rem; padding: 0.7rem 0.9rem; background: rgba(255,255,255,0.04); border-radius: 10px; border: 1px solid rgba(255,255,255,0.06);
-    strong { color: #8BE9FD; display: block; margin-bottom: 3px; font-size: 1.02rem; }
-    span { color: rgba(255,255,255,0.7); }
-  }
+  display: flex; flex-direction: column; gap: 0.5rem; margin: 0.5rem 0;
+  .venue-item { display: flex; justify-content: space-between; align-items: center; padding: 0.5rem 0; border-bottom: 1px solid rgba(255,255,255,0.05); span { color: rgba(255,255,255,0.5); font-size: 0.95rem; } strong { color: #fff; } }
 }
 
 .bullet-list {
@@ -975,6 +1310,58 @@ onMounted(async () => {
 .accent-link {
   color: #8BE9FD; text-decoration: none; font-weight: 600; border-bottom: 1px solid transparent; transition: border-color 0.2s;
   &:hover { border-color: #8BE9FD; }
+}
+
+/* ── Initial-rollout banner (catalog/schedule placeholders) ─ */
+.rollout-banner {
+    display: flex;
+    gap: 1.25rem;
+    align-items: flex-start;
+    max-width: 720px;
+    margin: 2rem auto;
+    padding: 1.5rem 1.75rem;
+    background: rgba(16, 26, 35, 0.7);
+    border: 1px solid rgba(139, 233, 253, 0.22);
+    border-radius: 14px;
+    backdrop-filter: blur(8px);
+}
+
+.rollout-banner__icon {
+    flex-shrink: 0;
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    background: rgba(139, 233, 253, 0.08);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.rollout-banner__copy {
+    flex: 1;
+    color: rgba(255, 255, 255, 0.85);
+
+    h3 {
+        margin: 0 0 0.4rem;
+        font-size: 1.15rem;
+        font-weight: 700;
+        color: #8BE9FD;
+        letter-spacing: 0.3px;
+    }
+    p {
+        margin: 0;
+        font-size: 1rem;
+        line-height: 1.6;
+        color: rgba(255, 255, 255, 0.7);
+    }
+}
+
+@media (max-width: 600px) {
+    .rollout-banner {
+        flex-direction: column;
+        gap: 0.75rem;
+        padding: 1.25rem;
+    }
 }
 
 /* ── Schedule search toolbar ─────────────── */

--- a/pages/festival/bifff-2026/index.vue
+++ b/pages/festival/bifff-2026/index.vue
@@ -50,54 +50,79 @@
       </div>
 
       <div v-else>
-        <div v-if="activeTab === 'films'" class="films-grid">
-            <div v-if="features.length > 0" class="film-category">
-                <div class="category-header" @click="featuresOpen = !featuresOpen">
-                    <h2 class="listing__title category-title">
-                        Features
-                        <span class="category-count">({{ features.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="featuresOpen ? 'Collapse' : 'Expand'">
-                        <svg v-if="featuresOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
-                    </button>
-                </div>
-                <transition name="slide">
-                    <div v-show="featuresOpen" class="listing__items">
-                        <BifffCard 
-                            v-for="item in features"
-                            :key="`feature-${item.id}`"
-                            :item="item" 
-                        />
-                    </div>
-                </transition>
+        <div v-if="activeTab === 'films'" class="selection">
+          <div v-if="orderedCategories.length === 0" class="rollout-banner">
+            <div class="rollout-banner__icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
             </div>
+            <div class="rollout-banner__copy">
+              <h3>Lineup updates in progress</h3>
+              <p>This festival lineup is currently being updated. New films, sections, and official selections will be added progressively as they are announced and verified.</p>
+            </div>
+          </div>
+          <div v-else class="selection-layout">
+            <aside class="selection-nav" aria-label="Jump to section">
+              <template v-if="officialNav.length">
+                <div class="nav-group-label">Catalog</div>
+                <button
+                  v-for="sec in officialNav"
+                  :key="sec.key"
+                  class="nav-item"
+                  :class="{ active: activeSection === sec.key }"
+                  @click="scrollToSection(sec.key)"
+                >
+                  <span class="nav-item-label">{{ sec.label }}</span>
+                  <span class="nav-item-count">{{ sec.count }}</span>
+                </button>
+              </template>
+            </aside>
 
-            <div v-if="shorts.length > 0" class="film-category">
-                <div class="category-header" @click="shortsOpen = !shortsOpen">
-                    <h2 class="listing__title category-title">
-                        Shorts
-                        <span class="category-count">({{ shorts.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="shortsOpen ? 'Collapse' : 'Expand'">
-                        <svg v-if="shortsOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
+            <div ref="selectionContentRef" class="selection-content">
+              <section
+                v-for="sec in selectionSections"
+                :key="sec.key"
+                :data-key="sec.key"
+                class="sel-section"
+              >
+                <div class="sel-section-header" @click="onSectionHeaderClick(sec.key)">
+                  <h2 class="sel-section-title">{{ sec.label }}</h2>
+                  <div class="sel-section-meta">
+                    <span class="sel-section-count">{{ sec.count }} {{ sec.count === 1 ? 'film' : 'films' }}</span>
+                    <button v-if="isMobile" class="expand-btn" :aria-label="isSectionOpen(sec.key) ? 'Collapse' : 'Expand'">
+                      <svg v-if="isSectionOpen(sec.key)" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
+                      <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
                     </button>
+                  </div>
                 </div>
                 <transition name="slide">
-                    <div v-show="shortsOpen" class="listing__items">
-                        <BifffCard 
-                            v-for="item in shorts"
-                            :key="`short-${item.id}`"
-                            :item="item" 
-                        />
+                  <div v-show="!isMobile || isSectionOpen(sec.key)" class="sel-section-body">
+                    <div class="listing__items">
+                      <BifffCard
+                        v-for="item in sec.films"
+                        :key="`${sec.key}-${item.id}`"
+                        :item="item"
+                      />
                     </div>
+                  </div>
                 </transition>
+              </section>
             </div>
+          </div>
         </div>
 
         <div v-if="activeTab === 'schedule'" class="schedule-container">
-          <div class="schedule-toolbar" :class="{ 'search-active': isScheduleSearchActive }">
+          <!-- Initial rollout banner: schedule pending official publication -->
+          <div v-if="schedule.length === 0" class="rollout-banner">
+            <div class="rollout-banner__icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+            </div>
+            <div class="rollout-banner__copy">
+              <h3>Schedule pending</h3>
+              <p>Official screening schedules have not yet been published by the festival. Screening information will appear here as soon as it becomes available.</p>
+            </div>
+          </div>
+
+          <div v-if="schedule.length > 0" class="schedule-toolbar" :class="{ 'search-active': isScheduleSearchActive }">
             <div class="schedule-toolbar-info">
               <span class="schedule-count" v-if="!loading">
                 <template v-if="scheduleSearchActiveQuery">
@@ -133,30 +158,48 @@
             <p>No screenings match "<strong>{{ scheduleSearch }}</strong>"</p>
           </div>
 
-          <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" class="schedule-day">
-            <div class="day-header" @click="toggleDay(date)">
+          <div v-if="scheduleDays.length" class="schedule-layout">
+            <aside class="schedule-nav" aria-label="Jump to day">
+              <div class="nav-group-label">Days</div>
+              <button
+                v-for="day in scheduleDays"
+                :key="day.date"
+                class="nav-item"
+                :class="{ active: activeDay === day.date }"
+                @click="scrollToDay(day.date)"
+              >
+                <span class="nav-item-label">{{ day.label }}</span>
+                <span class="nav-item-count">{{ day.count }}</span>
+              </button>
+            </aside>
+
+            <div ref="scheduleContentRef" class="schedule-content">
+              <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" :data-day="date" class="schedule-day">
+            <div class="day-header" @click="onDayHeaderClick(date)">
                 <h2>{{ formatDate(date) }}</h2>
-                <div class="chevron" :class="{ 'closed': !isOpen(date) }">
+                <div v-if="isMobile" class="chevron" :class="{ 'closed': !isOpen(date) }">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down"><path d="m6 9 6 6 6-6"/></svg>
                 </div>
             </div>
-            
+
             <transition name="slide">
-                <div v-show="isOpen(date)" class="screenings-list">
+                <div v-show="!isMobile || isOpen(date)" class="screenings-list">
                   <div v-for="screening in dayScreenings" :key="screening.id" class="screening-card">
                      <div class="time-block">
-                        <span class="time">{{ formatTime(screening.start_time) }}</span>
+                        <span class="time">{{ formatTime(screening.start_time, screening.timezone) }}</span>
                         <span class="timezone">{{ screening.timezone }}</span>
                      </div>
-                     
+
                       <div class="film-info">
-                         <a 
-                            :href="screening.film.source_url || 'https://www.bifff.net'"
-                            target="_blank"
+                         <component
+                            :is="screening.film.source_url ? 'a' : 'span'"
+                            :href="screening.film.source_url || ''"
+                            :target="screening.film.source_url ? '_blank' : ''"
                             class="film-title"
+                            :class="{'no-link': !screening.film.source_url}"
                          >
                             {{ screening.film.title }}
-                         </a>
+                         </component>
                          <div class="film-meta">
                              <span v-if="screening.film.director">Directed by {{ screening.film.director }}</span>
                              <span v-if="screening.film.director && screening.film.runtime"> • </span>
@@ -172,13 +215,13 @@
                              <span v-if="screening.is_sold_out" class="tag sold-out">Sold Out</span>
                          </div>
                       </div>
-                      
+
                       <div class="poster-mini">
-                          <img 
-                            v-if="screening.film.poster_path" 
-                            :src="screening.film.poster_path" 
-                            alt="Poster" 
-                            loading="lazy" 
+                          <img
+                            v-if="screening.film.poster_path"
+                            :src="screening.film.poster_path"
+                            alt="Poster"
+                            loading="lazy"
                             @error="$event.target.src = '/placeholders/image_not_found_yet.webp'"
                           />
                           <img v-else src="/placeholders/image_not_found_yet.webp" alt="No Poster" />
@@ -186,6 +229,8 @@
                   </div>
                 </div>
             </transition>
+          </div>
+            </div>
           </div>
         </div>
 
@@ -267,7 +312,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, nextTick } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount, nextTick, watch } from 'vue';
 import Loader from '~/components/Loader.vue';
 import WinnersCarousel from '~/components/festival/WinnersCarousel.vue';
 import FestivalDataDisclaimer from '~/components/FestivalDataDisclaimer.vue';
@@ -317,27 +362,107 @@ const awards = ref([]);
 const schedule = ref([]);
 const openDays = ref(new Set());
 
-const featuresOpen = ref(true);
-const shortsOpen = ref(true);
+const CATEGORY_ORDER = [
+    'Features',
+    'Shorts',
+];
 
-const features = computed(() => {
-    return films.value?.results?.filter(f => !f.runtime || f.runtime >= 40) || [];
-});
-
-const shorts = computed(() => {
-    return films.value?.results?.filter(f => f.runtime > 0 && f.runtime < 40) || [];
-});
-
-const formatDate = (dateStr) => {
-    const options = { weekday: 'long', month: 'long', day: 'numeric' };
-    const [year, month, day] = dateStr.split('-').map(Number);
-    return new Date(year, month - 1, day).toLocaleDateString('en-US', options);
+const CATEGORY_LABELS = {
+    Features: 'Features',
+    Shorts: 'Shorts',
+    OTHER: 'Other',
 };
 
-const formatTime = (timeStr) => {
-    return new Date(timeStr).toLocaleTimeString('en-US', { 
-        hour: '2-digit', 
-        minute: '2-digit'
+const categoryKeyForFilm = (film) => {
+    const explicit = String(film.category || film.section || '').trim();
+    if (CATEGORY_ORDER.includes(explicit)) return explicit;
+    if (film.runtime > 0 && film.runtime < 40) return 'Shorts';
+    return 'Features';
+};
+
+const activeSection = ref('');
+const selectionContentRef = ref(null);
+let sectionObserver = null;
+const isMobile = ref(false);
+let mobileMql = null;
+const sectionOpen = ref({});
+const isSectionOpen = (key) => sectionOpen.value[key] !== false;
+const toggleSection = (key) => { sectionOpen.value = { ...sectionOpen.value, [key]: !isSectionOpen(key) }; };
+const onSectionHeaderClick = (key) => { if (!isMobile.value) return; toggleSection(key); };
+const activeDay = ref('');
+const scheduleContentRef = ref(null);
+let dayObserver = null;
+
+const filmsByCategory = computed(() => {
+    const map = Object.fromEntries(CATEGORY_ORDER.map((c) => [c, []]));
+    map.OTHER = [];
+    for (const f of films.value?.results || []) {
+        const key = categoryKeyForFilm(f);
+        if (key && map[key] !== undefined) map[key].push(f);
+        else map.OTHER.push(f);
+    }
+    return map;
+});
+
+const orderedCategories = computed(() => {
+    const out = CATEGORY_ORDER.filter((c) => (filmsByCategory.value[c] || []).length > 0);
+    if ((filmsByCategory.value.OTHER || []).length > 0) out.push('OTHER');
+    return out;
+});
+
+function categoryLabel (cat) {
+    return CATEGORY_LABELS[cat] || cat;
+}
+
+const selectionSections = computed(() => orderedCategories.value.map((cat) => {
+    const items = filmsByCategory.value[cat] || [];
+    return { key: cat, label: categoryLabel(cat), films: items, count: items.length };
+}));
+const officialNav = computed(() => selectionSections.value);
+
+const scrollToSection = (key) => {
+    activeSection.value = key;
+    const root = selectionContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-key]');
+    for (const el of els) { if (el.getAttribute('data-key') === key) { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); break; } }
+};
+
+const setupSectionObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (sectionObserver) sectionObserver.disconnect();
+    const root = selectionContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-key]');
+    if (!els.length) return;
+    sectionObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) { if (entry.isIntersecting) activeSection.value = entry.target.getAttribute('data-key'); }
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => sectionObserver.observe(el));
+};
+
+watch(selectionSections, (sections) => {
+    if (!sections.length) return;
+    if (!sections.some((sec) => sec.key === activeSection.value)) activeSection.value = sections[0].key;
+}, { immediate: true });
+
+watch([loading, activeTab, selectionSections], () => {
+    if (!loading.value && activeTab.value === 'films') nextTick(() => setupSectionObserver());
+    else if (sectionObserver) sectionObserver.disconnect();
+}, { flush: 'post' });
+
+const FESTIVAL_TZ = 'Europe/Brussels';
+
+const formatDate = (dateStr) => {
+    const options = { weekday: 'long', month: 'long', day: 'numeric', timeZone: 'UTC' };
+    return new Date(`${dateStr}T00:00:00Z`).toLocaleDateString('en-US', options);
+};
+
+const formatTime = (timeStr, tz) => {
+    return new Date(timeStr).toLocaleTimeString('en-US', {
+        hour: '2-digit',
+        minute: '2-digit',
+        timeZone: tz || FESTIVAL_TZ
     });
 };
 
@@ -368,17 +493,57 @@ const groupedScreenings = computed(() => {
 });
 
 const toggleDay = (date) => {
-    if (openDays.value.has(date)) {
-        openDays.value.delete(date);
-    } else {
-        openDays.value.add(date);
-    }
-}
+    if (openDays.value.has(date)) openDays.value.delete(date);
+    else openDays.value.add(date);
+};
 
 const isOpen = (date) => {
     if (scheduleSearchActiveQuery.value) return true;
     return openDays.value.has(date);
 };
+
+const scheduleDays = computed(() => Object.entries(groupedScreenings.value).map(([date, arr]) => ({ date, label: formatDate(date), count: arr.length })));
+const onDayHeaderClick = (date) => { if (!isMobile.value) return; toggleDay(date); };
+const scrollToDay = (date) => {
+    activeDay.value = date;
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-day]');
+    for (const el of els) { if (el.getAttribute('data-day') === date) { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); break; } }
+};
+const setupDayObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (dayObserver) dayObserver.disconnect();
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-day]');
+    if (!els.length) return;
+    dayObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) { if (entry.isIntersecting) activeDay.value = entry.target.getAttribute('data-day'); }
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => dayObserver.observe(el));
+};
+watch(scheduleDays, (days) => {
+    if (!days.length) return;
+    if (!days.some((d) => d.date === activeDay.value)) activeDay.value = days[0]?.date || '';
+}, { immediate: true });
+watch([loading, activeTab, scheduleDays], () => {
+    if (!loading.value && activeTab.value === 'schedule') nextTick(() => setupDayObserver());
+    else if (dayObserver) dayObserver.disconnect();
+}, { flush: 'post' });
+const updateIsMobile = (e) => { isMobile.value = e.matches; };
+onMounted(() => {
+    if (typeof window !== 'undefined' && window.matchMedia) {
+        mobileMql = window.matchMedia('(max-width: 900px)');
+        isMobile.value = mobileMql.matches;
+        mobileMql.addEventListener('change', updateIsMobile);
+    }
+});
+onBeforeUnmount(() => {
+    if (sectionObserver) sectionObserver.disconnect();
+    if (dayObserver) dayObserver.disconnect();
+    if (mobileMql) mobileMql.removeEventListener('change', updateIsMobile);
+});
 
 onMounted(async () => {
     try {
@@ -412,60 +577,156 @@ onMounted(async () => {
     font-size: 1.2rem;
 }
 
-.film-category {
-    margin-bottom: 2.5rem;
-}
-
-// Compact catalog cards (~25%+ smaller than global default).
-// Scoped to .films-grid so other listings (home, search, etc.) are untouched.
-// Uses :deep() because festival cards are child components (scoped CSS).
-.films-grid :deep(.listing__items > .card) {
-    width: 25%;
+// Poster sizing inside the Selection content column. The column is narrower than
+// the old full-bleed grid, so we use fewer columns / slightly larger posters.
+.selection :deep(.listing__items > .card) {
+    width: 33.3333%;
 
     @media (min-width: 640px) {
-        width: 20%;
+        width: 25%;
     }
     @media (min-width: 1024px) {
-        width: 14.2857143%;
+        width: 20%;
     }
     @media (min-width: 1500px) {
-        width: 12.5%;
+        width: 16.6666%;
     }
     @media (min-width: 1800px) {
-        width: 11.1111111%;
-    }
-    @media (min-width: 2500px) {
-        width: 10%;
+        width: 14.2857%;
     }
 }
 
 
 
-.category-header {
+/* ── Selection: sidebar scroll-spy + sections ───────────── */
+.selection-layout,
+.schedule-layout {
+    display: grid;
+    grid-template-columns: 330px minmax(0, 1fr);
+    gap: 2.5rem;
+    align-items: start;
+}
+
+/* Breathing room between the screenings search bar and the day list below it. */
+.schedule-layout {
+    margin-top: 1.75rem;
+}
+
+.selection-nav,
+.schedule-nav {
+    position: sticky;
+    top: 5.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-height: calc(100vh - 7rem);
+    overflow-y: auto;
+    padding: 1rem;
+    border: 1px solid transparent;
+    background:
+        linear-gradient(rgba(3, 6, 10, 0.85), rgba(3, 6, 10, 0.85)) padding-box,
+        linear-gradient(160deg, rgba(139, 233, 253, 0.55), rgba(31, 84, 103, 0.45) 60%, rgba(139, 233, 253, 0.16)) border-box;
+    border-radius: 14px;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
+}
+
+.nav-group-label {
+    font-size: 1rem;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    color: rgba(139, 233, 253, 0.9);
+    font-weight: 700;
+    margin: 1.2rem 0.4rem 0.55rem;
+
+    &:first-child {
+        margin-top: 0.2rem;
+    }
+}
+
+.nav-item {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 10px;
+    width: 100%;
+    background: none;
+    border: none;
+    border-left: 3px solid transparent;
+    border-radius: 0 8px 8px 0;
+    color: rgba(255, 255, 255, 0.88);
+    padding: 0.82rem 1rem;
+    font-size: 1.32rem;
+    font-family: inherit;
+    text-align: left;
     cursor: pointer;
-    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
-    padding-bottom: 5px;
-    margin-bottom: 15px;
-    transition: border-color 0.2s;
-    user-select: none;
-    
+    transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+
     &:hover {
-        border-color: rgba(139, 233, 253, 0.6);
+        background: rgba(139, 233, 253, 0.08);
+        color: #eafbff;
+    }
+
+    &.active {
+        background: rgba(139, 233, 253, 0.12);
+        color: #8BE9FD;
+        border-left-color: #8BE9FD;
+        font-weight: 600;
     }
 }
 
-.category-title {
-    margin: 0 !important;
+.nav-item-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
-.category-count {
-    font-size: 1.1rem;
-    color: rgba(255, 255, 255, 0.6);
-    margin-left: 10px;
-    font-weight: normal;
+.nav-item-count {
+    font-size: 1.12rem;
+    color: rgba(255, 255, 255, 0.62);
+    flex-shrink: 0;
+}
+
+.nav-item.active .nav-item-count {
+    color: rgba(139, 233, 253, 0.85);
+}
+
+.sel-section {
+    scroll-margin-top: 6.5rem;
+    margin-bottom: 3rem;
+}
+
+.sel-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
+    padding-bottom: 6px;
+    margin-bottom: 1.25rem;
+}
+
+.sel-section-title {
+    margin: 0;
+    font-size: 1.7rem;
+    font-weight: 700;
+    color: #fff;
+}
+
+.sel-section-meta {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-shrink: 0;
+}
+
+.sel-section-count {
+    font-size: 1.05rem;
+    color: rgba(255, 255, 255, 0.5);
+    white-space: nowrap;
+    flex-shrink: 0;
 }
 
 .expand-btn {
@@ -481,7 +742,7 @@ onMounted(async () => {
     cursor: pointer;
     transition: all 0.2s ease;
     flex-shrink: 0;
-    
+
     &:hover {
         background: rgba(139, 233, 253, 0.15);
         color: #8BE9FD;
@@ -494,6 +755,42 @@ onMounted(async () => {
         min-width: 20px;
         min-height: 20px;
         display: block;
+    }
+}
+
+.parallel-band {
+    font-size: 0.85rem;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: #8BE9FD;
+    border-top: 1px solid rgba(139, 233, 253, 0.25);
+    padding-top: 1.4rem;
+    margin: 0.5rem 0 1.5rem;
+}
+
+@media (max-width: 900px) {
+    .selection-layout,
+    .schedule-layout {
+        display: block;
+    }
+
+    .selection-nav,
+    .schedule-nav {
+        display: none;
+    }
+
+    .sel-section-header {
+        cursor: pointer;
+        user-select: none;
+        transition: border-color 0.2s;
+    }
+
+    .sel-section-header:hover {
+        border-color: rgba(139, 233, 253, 0.6);
+    }
+
+    .day-header {
+        cursor: pointer;
     }
 }
 
@@ -516,12 +813,16 @@ onMounted(async () => {
 .segmented-control {
     position: relative;
     display: flex;
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 20px; 
+    background: rgba(3, 4, 6, 0.6);
+    border: 1px solid rgba(139, 233, 253, 0.18);
+    border-radius: 16px;
     padding: 4px;
     height: 48px;
     align-items: center;
     min-width: 420px;
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
 }
 
 .segmented-control input[type="radio"] {
@@ -544,7 +845,7 @@ onMounted(async () => {
 }
 
 .segmented-control input:checked + label {
-    color: #000;
+    color: #02080d;
 }
 
 .segmented-control .glider {
@@ -553,9 +854,10 @@ onMounted(async () => {
     left: 4px;
     height: calc(100% - 8px);
     width: calc((100% - 8px) / 3);
-    background: #8BE9FD; 
-    border-radius: 16px;
+    background: linear-gradient(135deg, #8BE9FD, #5cc4d8);
+    border-radius: 12px;
     z-index: 1;
+    box-shadow: 0 4px 14px rgba(139, 233, 253, 0.3);
     transition: transform 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
 }
 
@@ -569,12 +871,15 @@ onMounted(async () => {
     max-width: 1200px;
     margin: 0 auto;
     position: relative;
-    border-radius: 15px;
+    border-radius: 16px;
     overflow: hidden;
-    background-color: transparent;
     display: flex;
     justify-content: center;
-    border: 1px solid #8BE9FD;
+    border: 2px solid transparent;
+    background:
+        linear-gradient(#02080d, #02080d) padding-box,
+        linear-gradient(140deg, #8BE9FD 0%, #1F5467 45%, rgba(31, 84, 103, 0.35) 100%) border-box;
+    box-shadow: 0 14px 36px rgba(0, 0, 0, 0.5), 0 0 30px rgba(139, 233, 253, 0.12);
 }
 
 .back-link {
@@ -604,7 +909,7 @@ onMounted(async () => {
         box-shadow: 0 8px 25px rgba(0,0,0,0.4);
         border-color: #fff;
     }
-    
+
     svg {
         width: 24px;
         height: 24px;
@@ -615,7 +920,7 @@ onMounted(async () => {
         left: 20px;
         font-size: 0.9rem;
         padding: 8px 16px;
-        
+
         svg {
             width: 18px;
             height: 18px;
@@ -623,58 +928,11 @@ onMounted(async () => {
     }
 }
 
-.buy-tickets-btn {
-    position: absolute;
-    top: 30px;
-    right: 30px;
-    z-index: 10;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    background: #8BE9FD;
-    color: #000;
-    padding: 12px 24px;
-    border-radius: 30px;
-    text-decoration: none;
-    font-weight: 700;
-    font-size: 1.1rem;
-    transition: transform 0.2s, opacity 0.2s;
-    backdrop-filter: blur(10px);
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    box-shadow: 0 4px 15px rgba(0,0,0,0.3);
-    
-    &:hover {
-        transform: translateY(-2px) scale(1.05);
-        box-shadow: 0 8px 25px rgba(0,0,0,0.4);
-        background: #fff;
-    }
-
-    &.sold-out {
-        background: rgba(100, 100, 100, 0.6);
-        color: #ddd;
-        border-color: #666;
-        cursor: not-allowed;
-        
-        &:hover {
-            transform: none;
-            background: rgba(100, 100, 100, 0.6);
-            box-shadow: 0 4px 15px rgba(0,0,0,0.3);
-        }
-    }
-    
-    @media (max-width: 768px) {
-        top: 20px;
-        right: 20px;
-        font-size: 0.9rem;
-        padding: 8px 16px;
-    }
-}
-
 .hero-backdrop {
     width: 100%;
     height: auto;
     position: relative;
-    
+
     img {
         width: 100%;
         height: auto;
@@ -705,11 +963,17 @@ onMounted(async () => {
     padding: 3rem;
 }
 
-.schedule-container {
+.schedule-container, .info-container {
     max-width: 1200px;
     margin: 0 auto;
     padding-left: 0.5rem;
     padding-right: 0.5rem;
+}
+
+
+
+:deep(.winners-carousel) {
+    max-width: 1200px;
 }
 
 .day-header {
@@ -722,21 +986,29 @@ onMounted(async () => {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    cursor: pointer;
+    cursor: default;
     user-select: none;
-    
+
     h2 {
         font-size: 1.8rem;
         margin: 0;
     }
-    
+
     .chevron {
         transition: transform 0.3s ease;
-        
+
         &.closed {
             transform: rotate(-90deg);
         }
     }
+}
+
+.schedule-day {
+    scroll-margin-top: 6.5rem;
+}
+
+.schedule-content > .schedule-day:first-child .day-header {
+    margin-top: 0;
 }
 
 .slide-enter-active,
@@ -756,13 +1028,21 @@ onMounted(async () => {
 
 .screening-card {
     display: flex;
-    background: #0a161b;
-    border: 1px solid #8BE9FD;
-    border-radius: 8px;
+    border: 1px solid transparent;
+    background:
+        linear-gradient(#0a161b, #0a161b) padding-box,
+        linear-gradient(140deg, #8BE9FD, #1F5467 60%, rgba(31, 84, 103, 0.3)) border-box;
+    border-radius: 10px;
     padding: 1.5rem;
     margin-bottom: 1rem;
     gap: 1.5rem;
-    transition: transform 0.2s;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.3);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.screening-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.4), 0 0 20px rgba(139, 233, 253, 0.1);
 }
 
 .time-block {
@@ -773,7 +1053,7 @@ onMounted(async () => {
     min-width: 80px;
     border-right: 1px solid #333;
     padding-right: 1.5rem;
-    
+
     .time {
         font-size: 1.2rem;
         font-weight: 700;
@@ -790,25 +1070,25 @@ onMounted(async () => {
     display: flex;
     flex-direction: column;
     justify-content: center;
-    
+
     .film-title {
         font-size: 1.6rem;
         font-weight: 700;
         color: #fff;
         text-decoration: none;
         margin-bottom: 0.5rem;
-        
+
         &:hover {
             color: #8BE9FD;
         }
     }
-    
+
     .film-meta {
         font-size: 1.05rem;
         color: #aaa;
         margin-bottom: 0.8rem;
     }
-    
+
     .venue-info {
         font-size: 1.25rem;
         color: #ccc;
@@ -816,7 +1096,7 @@ onMounted(async () => {
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        
+
         svg {
             min-width: 18px;
         }
@@ -826,14 +1106,14 @@ onMounted(async () => {
 .tags {
     display: flex;
     gap: 0.5rem;
-    
+
     .tag {
         font-size: 0.75rem;
         padding: 4px 8px;
         border-radius: 4px;
         font-weight: 600;
         text-transform: uppercase;
-        
+
         &.in-person { background: rgba(52, 152, 219, 0.2); }
         &.online { background: rgba(46, 204, 113, 0.2); color: #2ecc71; }
         &.sold-out { background: rgba(231, 76, 60, 0.2); color: #e74c3c; }
@@ -843,7 +1123,7 @@ onMounted(async () => {
 .poster-mini {
     width: 60px;
     height: 90px;
-    
+
     img {
         width: 100%;
         height: 100%;
@@ -854,7 +1134,7 @@ onMounted(async () => {
 
 @media (max-width: 600px) {
     .screening-card {
-        flex-direction: column; 
+        flex-direction: column;
         gap: 1rem;
     }
     .time-block {
@@ -872,19 +1152,6 @@ onMounted(async () => {
 }
 
 /* ── Carousel ─────────────────────────────── */
-.info-container {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
-}
-
-
-
-:deep(.winners-carousel) {
-    max-width: 1200px;
-}
-
 .carousel-wrapper {
   display: flex;
   align-items: center;
@@ -900,14 +1167,33 @@ onMounted(async () => {
 }
 
 .carousel-card {
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(139, 233, 253, 0.18);
+  position: relative;
+  background: rgba(3, 4, 6, 0.85);
+  background-image:
+    radial-gradient(circle at 15% 20%, rgba(31, 84, 103, 0.18), transparent 35%),
+    radial-gradient(circle at 85% 80%, rgba(139, 233, 253, 0.08), transparent 30%);
+  border: 1px solid rgba(31, 84, 103, 0.5);
   border-radius: 20px;
   padding: 2.2rem 2.5rem;
-  backdrop-filter: blur(12px);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
   color: rgba(255, 255, 255, 0.88);
   line-height: 1.8;
   min-height: 300px;
+  overflow: hidden;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5), inset 0 0 24px rgba(139, 233, 253, 0.04);
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: linear-gradient(90deg, transparent, #8BE9FD, #1F5467, transparent);
+    opacity: 0.85;
+    pointer-events: none;
+  }
 
   strong { color: #fff; }
 }
@@ -941,19 +1227,21 @@ onMounted(async () => {
   justify-content: center;
   width: 44px;
   height: 44px;
-  border-radius: 50%;
-  border: 1px solid rgba(139, 233, 253, 0.25);
-  background: rgba(0, 0, 0, 0.4);
+  border-radius: 12px;
+  border: 1px solid rgba(139, 233, 253, 0.4);
+  background: rgba(3, 4, 6, 0.75);
   color: #8BE9FD;
   cursor: pointer;
-  transition: all 0.25s ease;
+  transition: all 0.2s ease;
   flex-shrink: 0;
-  backdrop-filter: blur(6px);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
 
   &:hover {
-    background: rgba(139, 233, 253, 0.15);
-    border-color: #8BE9FD;
-    transform: scale(1.1);
+    background: #ffffff;
+    border-color: #ffffff;
+    color: #000;
+    transform: scale(1.05);
   }
 }
 
@@ -985,7 +1273,6 @@ onMounted(async () => {
   }
 }
 
-/* Slide transitions */
 .carousel-next-enter-active,
 .carousel-next-leave-active,
 .carousel-prev-enter-active,
@@ -1014,15 +1301,9 @@ onMounted(async () => {
   .price-value { color: #8BE9FD; font-weight: 700; font-size: 1.1rem; }
 }
 
-.promo-box {
-  background: rgba(139, 233, 253, 0.08);
-  border-left: 3px solid #8BE9FD;
-  border-radius: 8px;
-  padding: 1rem 1.2rem;
-  margin-top: 1rem;
-  position: relative;
-  .promo-tag { position: absolute; top: 0; right: 0; background: #8BE9FD; color: #000; font-size: 0.65rem; font-weight: 800; padding: 3px 10px; border-bottom-left-radius: 6px; }
-  p { margin: 0; font-size: 1rem; }
+.venue-list {
+  display: flex; flex-direction: column; gap: 0.5rem; margin: 0.5rem 0;
+  .venue-item { display: flex; justify-content: space-between; align-items: center; padding: 0.5rem 0; border-bottom: 1px solid rgba(255,255,255,0.05); span { color: rgba(255,255,255,0.5); font-size: 0.95rem; } strong { color: #fff; } }
 }
 
 .bullet-list {
@@ -1033,6 +1314,58 @@ onMounted(async () => {
 .accent-link {
   color: #8BE9FD; text-decoration: none; font-weight: 600; border-bottom: 1px solid transparent; transition: border-color 0.2s;
   &:hover { border-color: #8BE9FD; }
+}
+
+/* ── Initial-rollout banner (catalog/schedule placeholders) ─ */
+.rollout-banner {
+    display: flex;
+    gap: 1.25rem;
+    align-items: flex-start;
+    max-width: 720px;
+    margin: 2rem auto;
+    padding: 1.5rem 1.75rem;
+    background: rgba(16, 26, 35, 0.7);
+    border: 1px solid rgba(139, 233, 253, 0.22);
+    border-radius: 14px;
+    backdrop-filter: blur(8px);
+}
+
+.rollout-banner__icon {
+    flex-shrink: 0;
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    background: rgba(139, 233, 253, 0.08);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.rollout-banner__copy {
+    flex: 1;
+    color: rgba(255, 255, 255, 0.85);
+
+    h3 {
+        margin: 0 0 0.4rem;
+        font-size: 1.15rem;
+        font-weight: 700;
+        color: #8BE9FD;
+        letter-spacing: 0.3px;
+    }
+    p {
+        margin: 0;
+        font-size: 1rem;
+        line-height: 1.6;
+        color: rgba(255, 255, 255, 0.7);
+    }
+}
+
+@media (max-width: 600px) {
+    .rollout-banner {
+        flex-direction: column;
+        gap: 0.75rem;
+        padding: 1.25rem;
+    }
 }
 
 /* ── Schedule search toolbar ─────────────── */

--- a/pages/festival/cuff-2026/index.vue
+++ b/pages/festival/cuff-2026/index.vue
@@ -51,54 +51,79 @@
       </div>
 
       <div v-else>
-        <div v-if="activeTab === 'films'" class="films-grid">
-            <div v-if="features.length > 0" class="film-category">
-                <div class="category-header" @click="featuresOpen = !featuresOpen">
-                    <h2 class="listing__title category-title">
-                        Features
-                        <span class="category-count">({{ features.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="featuresOpen ? 'Collapse' : 'Expand'">
-                        <svg v-if="featuresOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
-                    </button>
-                </div>
-                <transition name="slide">
-                    <div v-show="featuresOpen" class="listing__items">
-                        <CuffCard
-                            v-for="item in features"
-                            :key="`feature-${item.id}`"
-                            :item="item"
-                        />
-                    </div>
-                </transition>
+        <div v-if="activeTab === 'films'" class="selection">
+          <div v-if="orderedCategories.length === 0" class="rollout-banner">
+            <div class="rollout-banner__icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
             </div>
+            <div class="rollout-banner__copy">
+              <h3>Lineup updates in progress</h3>
+              <p>This festival lineup is currently being updated. New films, sections, and official selections will be added progressively as they are announced and verified.</p>
+            </div>
+          </div>
+          <div v-else class="selection-layout">
+            <aside class="selection-nav" aria-label="Jump to section">
+              <template v-if="officialNav.length">
+                <div class="nav-group-label">Catalog</div>
+                <button
+                  v-for="sec in officialNav"
+                  :key="sec.key"
+                  class="nav-item"
+                  :class="{ active: activeSection === sec.key }"
+                  @click="scrollToSection(sec.key)"
+                >
+                  <span class="nav-item-label">{{ sec.label }}</span>
+                  <span class="nav-item-count">{{ sec.count }}</span>
+                </button>
+              </template>
+            </aside>
 
-            <div v-if="shorts.length > 0" class="film-category">
-                <div class="category-header" @click="shortsOpen = !shortsOpen">
-                    <h2 class="listing__title category-title">
-                        Shorts
-                        <span class="category-count">({{ shorts.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="shortsOpen ? 'Collapse' : 'Expand'">
-                        <svg v-if="shortsOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
+            <div ref="selectionContentRef" class="selection-content">
+              <section
+                v-for="sec in selectionSections"
+                :key="sec.key"
+                :data-key="sec.key"
+                class="sel-section"
+              >
+                <div class="sel-section-header" @click="onSectionHeaderClick(sec.key)">
+                  <h2 class="sel-section-title">{{ sec.label }}</h2>
+                  <div class="sel-section-meta">
+                    <span class="sel-section-count">{{ sec.count }} {{ sec.count === 1 ? 'film' : 'films' }}</span>
+                    <button v-if="isMobile" class="expand-btn" :aria-label="isSectionOpen(sec.key) ? 'Collapse' : 'Expand'">
+                      <svg v-if="isSectionOpen(sec.key)" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
+                      <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
                     </button>
+                  </div>
                 </div>
                 <transition name="slide">
-                    <div v-show="shortsOpen" class="listing__items">
-                        <CuffCard
-                            v-for="item in shorts"
-                            :key="`short-${item.id}`"
-                            :item="item"
-                        />
+                  <div v-show="!isMobile || isSectionOpen(sec.key)" class="sel-section-body">
+                    <div class="listing__items">
+                      <CuffCard
+                        v-for="item in sec.films"
+                        :key="`${sec.key}-${item.id}`"
+                        :item="item"
+                      />
                     </div>
+                  </div>
                 </transition>
+              </section>
             </div>
+          </div>
         </div>
 
         <div v-if="activeTab === 'schedule'" class="schedule-container">
-          <div class="schedule-toolbar" :class="{ 'search-active': isScheduleSearchActive }">
+          <!-- Initial rollout banner: schedule pending official publication -->
+          <div v-if="schedule.length === 0" class="rollout-banner">
+            <div class="rollout-banner__icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+            </div>
+            <div class="rollout-banner__copy">
+              <h3>Schedule pending</h3>
+              <p>Official screening schedules have not yet been published by the festival. Screening information will appear here as soon as it becomes available.</p>
+            </div>
+          </div>
+
+          <div v-if="schedule.length > 0" class="schedule-toolbar" :class="{ 'search-active': isScheduleSearchActive }">
             <div class="schedule-toolbar-info">
               <span class="schedule-count" v-if="!loading">
                 <template v-if="scheduleSearchActiveQuery">
@@ -134,30 +159,48 @@
             <p>No screenings match "<strong>{{ scheduleSearch }}</strong>"</p>
           </div>
 
-          <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" class="schedule-day">
-            <div class="day-header" @click="toggleDay(date)">
+          <div v-if="scheduleDays.length" class="schedule-layout">
+            <aside class="schedule-nav" aria-label="Jump to day">
+              <div class="nav-group-label">Days</div>
+              <button
+                v-for="day in scheduleDays"
+                :key="day.date"
+                class="nav-item"
+                :class="{ active: activeDay === day.date }"
+                @click="scrollToDay(day.date)"
+              >
+                <span class="nav-item-label">{{ day.label }}</span>
+                <span class="nav-item-count">{{ day.count }}</span>
+              </button>
+            </aside>
+
+            <div ref="scheduleContentRef" class="schedule-content">
+              <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" :data-day="date" class="schedule-day">
+            <div class="day-header" @click="onDayHeaderClick(date)">
                 <h2>{{ formatDate(date) }}</h2>
-                <div class="chevron" :class="{ 'closed': !isOpen(date) }">
+                <div v-if="isMobile" class="chevron" :class="{ 'closed': !isOpen(date) }">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down"><path d="m6 9 6 6 6-6"/></svg>
                 </div>
             </div>
 
             <transition name="slide">
-                <div v-show="isOpen(date)" class="screenings-list">
+                <div v-show="!isMobile || isOpen(date)" class="screenings-list">
                   <div v-for="screening in dayScreenings" :key="screening.id" class="screening-card">
                      <div class="time-block">
-                        <span class="time">{{ formatTime(screening.start_time) }}</span>
+                        <span class="time">{{ formatTime(screening.start_time, screening.timezone) }}</span>
                         <span class="timezone">{{ screening.timezone }}</span>
                      </div>
 
                       <div class="film-info">
-                         <a
-                            :href="screening.film.source_url || 'https://www.calgaryundergroundfilm.org/2026/'"
-                            target="_blank"
+                         <component
+                            :is="screening.film.source_url ? 'a' : 'span'"
+                            :href="screening.film.source_url || ''"
+                            :target="screening.film.source_url ? '_blank' : ''"
                             class="film-title"
+                            :class="{'no-link': !screening.film.source_url}"
                          >
                             {{ screening.film.title }}
-                         </a>
+                         </component>
                          <div class="film-meta">
                              <span v-if="screening.film.director">Directed by {{ screening.film.director }}</span>
                              <span v-if="screening.film.director && screening.film.runtime"> • </span>
@@ -187,6 +230,8 @@
                   </div>
                 </div>
             </transition>
+          </div>
+            </div>
           </div>
         </div>
 
@@ -256,7 +301,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, nextTick } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount, nextTick, watch } from 'vue';
 import Loader from '~/components/Loader.vue';
 import FestivalDataDisclaimer from '~/components/FestivalDataDisclaimer.vue';
 import CuffCard from '~/components/CuffCard.vue';
@@ -306,29 +351,101 @@ const schedule = ref([]);
 const awards = ref([]);
 const openDays = ref(new Set());
 
-const featuresOpen = ref(true);
-const shortsOpen = ref(true);
+const CATEGORY_ORDER = [
+    'Features',
+    'Shorts',
+];
 
-const features = computed(() => {
-    return films.value?.results?.filter(f => !f.runtime || f.runtime >= 40) || [];
-});
-
-const shorts = computed(() => {
-    return films.value?.results?.filter(f => f.runtime > 0 && f.runtime < 40) || [];
-});
-
-const formatDate = (dateStr) => {
-    // Parse YYYY-MM-DD as local date to avoid UTC-induced day shift in negative-UTC timezones (Americas)
-    const [year, month, day] = dateStr.split('-').map(Number);
-    const localDate = new Date(year, month - 1, day);
-    const options = { weekday: 'long', month: 'long', day: 'numeric' };
-    return localDate.toLocaleDateString('en-US', options);
+const CATEGORY_LABELS = {
+    'Features': 'Features',
+    'Shorts': 'Shorts',
+    OTHER: 'Other',
 };
 
-const formatTime = (timeStr) => {
+const activeSection = ref('');
+const selectionContentRef = ref(null);
+let sectionObserver = null;
+const isMobile = ref(false);
+let mobileMql = null;
+const sectionOpen = ref({});
+const isSectionOpen = (key) => sectionOpen.value[key] !== false;
+const toggleSection = (key) => { sectionOpen.value = { ...sectionOpen.value, [key]: !isSectionOpen(key) }; };
+const onSectionHeaderClick = (key) => { if (!isMobile.value) return; toggleSection(key); };
+const activeDay = ref('');
+const scheduleContentRef = ref(null);
+let dayObserver = null;
+
+const filmsByCategory = computed(() => {
+    const map = Object.fromEntries(CATEGORY_ORDER.map((c) => [c, []]));
+    map.OTHER = [];
+    for (const f of films.value?.results || []) {
+        const key = String(f.category || f.section || '').trim();
+        if (key && map[key] !== undefined) map[key].push(f);
+        else map.OTHER.push(f);
+    }
+    return map;
+});
+
+const orderedCategories = computed(() => {
+    const out = CATEGORY_ORDER.filter((c) => (filmsByCategory.value[c] || []).length > 0);
+    if ((filmsByCategory.value.OTHER || []).length > 0) out.push('OTHER');
+    return out;
+});
+
+function categoryLabel (cat) {
+    return CATEGORY_LABELS[cat] || cat;
+}
+
+const selectionSections = computed(() => orderedCategories.value.map((cat) => {
+    const items = filmsByCategory.value[cat] || [];
+    return { key: cat, label: categoryLabel(cat), films: items, count: items.length };
+}));
+const officialNav = computed(() => selectionSections.value);
+
+const scrollToSection = (key) => {
+    activeSection.value = key;
+    const root = selectionContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-key]');
+    for (const el of els) { if (el.getAttribute('data-key') === key) { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); break; } }
+};
+
+const setupSectionObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (sectionObserver) sectionObserver.disconnect();
+    const root = selectionContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-key]');
+    if (!els.length) return;
+    sectionObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) { if (entry.isIntersecting) activeSection.value = entry.target.getAttribute('data-key'); }
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => sectionObserver.observe(el));
+};
+
+watch(selectionSections, (sections) => {
+    if (!sections.length) return;
+    if (!sections.some((sec) => sec.key === activeSection.value)) activeSection.value = sections[0].key;
+}, { immediate: true });
+
+watch([loading, activeTab, selectionSections], () => {
+    if (!loading.value && activeTab.value === 'films') nextTick(() => setupSectionObserver());
+    else if (sectionObserver) sectionObserver.disconnect();
+}, { flush: 'post' });
+
+
+const FESTIVAL_TZ = 'America/Edmonton';
+
+const formatDate = (dateStr) => {
+    const options = { weekday: 'long', month: 'long', day: 'numeric', timeZone: 'UTC' };
+    return new Date(`${dateStr}T00:00:00Z`).toLocaleDateString('en-US', options);
+};
+
+const formatTime = (timeStr, tz) => {
     return new Date(timeStr).toLocaleTimeString('en-US', {
         hour: '2-digit',
-        minute: '2-digit'
+        minute: '2-digit',
+        timeZone: tz || FESTIVAL_TZ
     });
 };
 
@@ -359,17 +476,57 @@ const groupedScreenings = computed(() => {
 });
 
 const toggleDay = (date) => {
-    if (openDays.value.has(date)) {
-        openDays.value.delete(date);
-    } else {
-        openDays.value.add(date);
-    }
+    if (openDays.value.has(date)) openDays.value.delete(date);
+    else openDays.value.add(date);
 };
 
 const isOpen = (date) => {
     if (scheduleSearchActiveQuery.value) return true;
     return openDays.value.has(date);
 };
+
+const scheduleDays = computed(() => Object.entries(groupedScreenings.value).map(([date, arr]) => ({ date, label: formatDate(date), count: arr.length })));
+const onDayHeaderClick = (date) => { if (!isMobile.value) return; toggleDay(date); };
+const scrollToDay = (date) => {
+    activeDay.value = date;
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-day]');
+    for (const el of els) { if (el.getAttribute('data-day') === date) { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); break; } }
+};
+const setupDayObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (dayObserver) dayObserver.disconnect();
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-day]');
+    if (!els.length) return;
+    dayObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) { if (entry.isIntersecting) activeDay.value = entry.target.getAttribute('data-day'); }
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => dayObserver.observe(el));
+};
+watch(scheduleDays, (days) => {
+    if (!days.length) return;
+    if (!days.some((d) => d.date === activeDay.value)) activeDay.value = days[0]?.date || '';
+}, { immediate: true });
+watch([loading, activeTab, scheduleDays], () => {
+    if (!loading.value && activeTab.value === 'schedule') nextTick(() => setupDayObserver());
+    else if (dayObserver) dayObserver.disconnect();
+}, { flush: 'post' });
+const updateIsMobile = (e) => { isMobile.value = e.matches; };
+onMounted(() => {
+    if (typeof window !== 'undefined' && window.matchMedia) {
+        mobileMql = window.matchMedia('(max-width: 900px)');
+        isMobile.value = mobileMql.matches;
+        mobileMql.addEventListener('change', updateIsMobile);
+    }
+});
+onBeforeUnmount(() => {
+    if (sectionObserver) sectionObserver.disconnect();
+    if (dayObserver) dayObserver.disconnect();
+    if (mobileMql) mobileMql.removeEventListener('change', updateIsMobile);
+});
 
 onMounted(async () => {
     try {
@@ -403,60 +560,156 @@ onMounted(async () => {
     font-size: 1.2rem;
 }
 
-.film-category {
-    margin-bottom: 2.5rem;
-}
-
-// Compact catalog cards (~25%+ smaller than global default).
-// Scoped to .films-grid so other listings (home, search, etc.) are untouched.
-// Uses :deep() because festival cards are child components (scoped CSS).
-.films-grid :deep(.listing__items > .card) {
-    width: 25%;
+// Poster sizing inside the Selection content column. The column is narrower than
+// the old full-bleed grid, so we use fewer columns / slightly larger posters.
+.selection :deep(.listing__items > .card) {
+    width: 33.3333%;
 
     @media (min-width: 640px) {
-        width: 20%;
+        width: 25%;
     }
     @media (min-width: 1024px) {
-        width: 14.2857143%;
+        width: 20%;
     }
     @media (min-width: 1500px) {
-        width: 12.5%;
+        width: 16.6666%;
     }
     @media (min-width: 1800px) {
-        width: 11.1111111%;
-    }
-    @media (min-width: 2500px) {
-        width: 10%;
+        width: 14.2857%;
     }
 }
 
 
 
-.category-header {
+/* ── Selection: sidebar scroll-spy + sections ───────────── */
+.selection-layout,
+.schedule-layout {
+    display: grid;
+    grid-template-columns: 330px minmax(0, 1fr);
+    gap: 2.5rem;
+    align-items: start;
+}
+
+/* Breathing room between the screenings search bar and the day list below it. */
+.schedule-layout {
+    margin-top: 1.75rem;
+}
+
+.selection-nav,
+.schedule-nav {
+    position: sticky;
+    top: 5.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-height: calc(100vh - 7rem);
+    overflow-y: auto;
+    padding: 1rem;
+    border: 1px solid transparent;
+    background:
+        linear-gradient(rgba(3, 6, 10, 0.85), rgba(3, 6, 10, 0.85)) padding-box,
+        linear-gradient(160deg, rgba(139, 233, 253, 0.55), rgba(31, 84, 103, 0.45) 60%, rgba(139, 233, 253, 0.16)) border-box;
+    border-radius: 14px;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
+}
+
+.nav-group-label {
+    font-size: 1rem;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    color: rgba(139, 233, 253, 0.9);
+    font-weight: 700;
+    margin: 1.2rem 0.4rem 0.55rem;
+
+    &:first-child {
+        margin-top: 0.2rem;
+    }
+}
+
+.nav-item {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 10px;
+    width: 100%;
+    background: none;
+    border: none;
+    border-left: 3px solid transparent;
+    border-radius: 0 8px 8px 0;
+    color: rgba(255, 255, 255, 0.88);
+    padding: 0.82rem 1rem;
+    font-size: 1.32rem;
+    font-family: inherit;
+    text-align: left;
     cursor: pointer;
-    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
-    padding-bottom: 5px;
-    margin-bottom: 15px;
-    transition: border-color 0.2s;
-    user-select: none;
+    transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
 
     &:hover {
-        border-color: rgba(139, 233, 253, 0.6);
+        background: rgba(139, 233, 253, 0.08);
+        color: #eafbff;
+    }
+
+    &.active {
+        background: rgba(139, 233, 253, 0.12);
+        color: #8BE9FD;
+        border-left-color: #8BE9FD;
+        font-weight: 600;
     }
 }
 
-.category-title {
-    margin: 0 !important;
+.nav-item-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
-.category-count {
-    font-size: 1.1rem;
-    color: rgba(255, 255, 255, 0.6);
-    margin-left: 10px;
-    font-weight: normal;
+.nav-item-count {
+    font-size: 1.12rem;
+    color: rgba(255, 255, 255, 0.62);
+    flex-shrink: 0;
+}
+
+.nav-item.active .nav-item-count {
+    color: rgba(139, 233, 253, 0.85);
+}
+
+.sel-section {
+    scroll-margin-top: 6.5rem;
+    margin-bottom: 3rem;
+}
+
+.sel-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
+    padding-bottom: 6px;
+    margin-bottom: 1.25rem;
+}
+
+.sel-section-title {
+    margin: 0;
+    font-size: 1.7rem;
+    font-weight: 700;
+    color: #fff;
+}
+
+.sel-section-meta {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-shrink: 0;
+}
+
+.sel-section-count {
+    font-size: 1.05rem;
+    color: rgba(255, 255, 255, 0.5);
+    white-space: nowrap;
+    flex-shrink: 0;
 }
 
 .expand-btn {
@@ -488,6 +741,42 @@ onMounted(async () => {
     }
 }
 
+.parallel-band {
+    font-size: 0.85rem;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: #8BE9FD;
+    border-top: 1px solid rgba(139, 233, 253, 0.25);
+    padding-top: 1.4rem;
+    margin: 0.5rem 0 1.5rem;
+}
+
+@media (max-width: 900px) {
+    .selection-layout,
+    .schedule-layout {
+        display: block;
+    }
+
+    .selection-nav,
+    .schedule-nav {
+        display: none;
+    }
+
+    .sel-section-header {
+        cursor: pointer;
+        user-select: none;
+        transition: border-color 0.2s;
+    }
+
+    .sel-section-header:hover {
+        border-color: rgba(139, 233, 253, 0.6);
+    }
+
+    .day-header {
+        cursor: pointer;
+    }
+}
+
 .header-container {
     display: flex;
     flex-direction: column;
@@ -507,12 +796,16 @@ onMounted(async () => {
 .segmented-control {
     position: relative;
     display: flex;
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 20px;
+    background: rgba(3, 4, 6, 0.6);
+    border: 1px solid rgba(139, 233, 253, 0.18);
+    border-radius: 16px;
     padding: 4px;
     height: 48px;
     align-items: center;
     min-width: 420px;
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
 }
 
 .segmented-control input[type="radio"] {
@@ -535,7 +828,7 @@ onMounted(async () => {
 }
 
 .segmented-control input:checked + label {
-    color: #000;
+    color: #02080d;
 }
 
 .segmented-control .glider {
@@ -544,9 +837,10 @@ onMounted(async () => {
     left: 4px;
     height: calc(100% - 8px);
     width: calc((100% - 8px) / 3);
-    background: #8BE9FD;
-    border-radius: 16px;
+    background: linear-gradient(135deg, #8BE9FD, #5cc4d8);
+    border-radius: 12px;
     z-index: 1;
+    box-shadow: 0 4px 14px rgba(139, 233, 253, 0.3);
     transition: transform 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
 }
 
@@ -560,12 +854,15 @@ onMounted(async () => {
     max-width: 1200px;
     margin: 0 auto;
     position: relative;
-    border-radius: 15px;
+    border-radius: 16px;
     overflow: hidden;
-    background-color: transparent;
     display: flex;
     justify-content: center;
-    border: 1px solid #8BE9FD;
+    border: 2px solid transparent;
+    background:
+        linear-gradient(#02080d, #02080d) padding-box,
+        linear-gradient(140deg, #8BE9FD 0%, #1F5467 45%, rgba(31, 84, 103, 0.35) 100%) border-box;
+    box-shadow: 0 14px 36px rgba(0, 0, 0, 0.5), 0 0 30px rgba(139, 233, 253, 0.12);
 }
 
 .back-link {
@@ -672,7 +969,7 @@ onMounted(async () => {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    cursor: pointer;
+    cursor: default;
     user-select: none;
 
     h2 {
@@ -687,6 +984,14 @@ onMounted(async () => {
             transform: rotate(-90deg);
         }
     }
+}
+
+.schedule-day {
+    scroll-margin-top: 6.5rem;
+}
+
+.schedule-content > .schedule-day:first-child .day-header {
+    margin-top: 0;
 }
 
 .slide-enter-active,
@@ -706,13 +1011,21 @@ onMounted(async () => {
 
 .screening-card {
     display: flex;
-    background: #0a161b;
-    border: 1px solid #8BE9FD;
-    border-radius: 8px;
+    border: 1px solid transparent;
+    background:
+        linear-gradient(#0a161b, #0a161b) padding-box,
+        linear-gradient(140deg, #8BE9FD, #1F5467 60%, rgba(31, 84, 103, 0.3)) border-box;
+    border-radius: 10px;
     padding: 1.5rem;
     margin-bottom: 1rem;
     gap: 1.5rem;
-    transition: transform 0.2s;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.3);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.screening-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.4), 0 0 20px rgba(139, 233, 253, 0.1);
 }
 
 .time-block {
@@ -837,14 +1150,33 @@ onMounted(async () => {
 }
 
 .carousel-card {
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(139, 233, 253, 0.18);
+  position: relative;
+  background: rgba(3, 4, 6, 0.85);
+  background-image:
+    radial-gradient(circle at 15% 20%, rgba(31, 84, 103, 0.18), transparent 35%),
+    radial-gradient(circle at 85% 80%, rgba(139, 233, 253, 0.08), transparent 30%);
+  border: 1px solid rgba(31, 84, 103, 0.5);
   border-radius: 20px;
   padding: 2.2rem 2.5rem;
-  backdrop-filter: blur(12px);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
   color: rgba(255, 255, 255, 0.88);
   line-height: 1.8;
   min-height: 300px;
+  overflow: hidden;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5), inset 0 0 24px rgba(139, 233, 253, 0.04);
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: linear-gradient(90deg, transparent, #8BE9FD, #1F5467, transparent);
+    opacity: 0.85;
+    pointer-events: none;
+  }
 
   strong { color: #fff; }
 }
@@ -878,19 +1210,21 @@ onMounted(async () => {
   justify-content: center;
   width: 44px;
   height: 44px;
-  border-radius: 50%;
-  border: 1px solid rgba(139, 233, 253, 0.25);
-  background: rgba(0, 0, 0, 0.4);
+  border-radius: 12px;
+  border: 1px solid rgba(139, 233, 253, 0.4);
+  background: rgba(3, 4, 6, 0.75);
   color: #8BE9FD;
   cursor: pointer;
-  transition: all 0.25s ease;
+  transition: all 0.2s ease;
   flex-shrink: 0;
-  backdrop-filter: blur(6px);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
 
   &:hover {
-    background: rgba(139, 233, 253, 0.15);
-    border-color: #8BE9FD;
-    transform: scale(1.1);
+    background: #ffffff;
+    border-color: #ffffff;
+    color: #000;
+    transform: scale(1.05);
   }
 }
 
@@ -963,6 +1297,58 @@ onMounted(async () => {
 .accent-link {
   color: #8BE9FD; text-decoration: none; font-weight: 600; border-bottom: 1px solid transparent; transition: border-color 0.2s;
   &:hover { border-color: #8BE9FD; }
+}
+
+/* ── Initial-rollout banner (catalog/schedule placeholders) ─ */
+.rollout-banner {
+    display: flex;
+    gap: 1.25rem;
+    align-items: flex-start;
+    max-width: 720px;
+    margin: 2rem auto;
+    padding: 1.5rem 1.75rem;
+    background: rgba(16, 26, 35, 0.7);
+    border: 1px solid rgba(139, 233, 253, 0.22);
+    border-radius: 14px;
+    backdrop-filter: blur(8px);
+}
+
+.rollout-banner__icon {
+    flex-shrink: 0;
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    background: rgba(139, 233, 253, 0.08);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.rollout-banner__copy {
+    flex: 1;
+    color: rgba(255, 255, 255, 0.85);
+
+    h3 {
+        margin: 0 0 0.4rem;
+        font-size: 1.15rem;
+        font-weight: 700;
+        color: #8BE9FD;
+        letter-spacing: 0.3px;
+    }
+    p {
+        margin: 0;
+        font-size: 1rem;
+        line-height: 1.6;
+        color: rgba(255, 255, 255, 0.7);
+    }
+}
+
+@media (max-width: 600px) {
+    .rollout-banner {
+        flex-direction: column;
+        gap: 0.75rem;
+        padding: 1.25rem;
+    }
 }
 
 /* ── Schedule search toolbar ─────────────── */

--- a/pages/festival/romford-2026/index.vue
+++ b/pages/festival/romford-2026/index.vue
@@ -50,54 +50,79 @@
       </div>
 
       <div v-else>
-        <div v-if="activeTab === 'films'" class="films-grid">
-            <div v-if="features.length > 0" class="film-category">
-                <div class="category-header" @click="featuresOpen = !featuresOpen">
-                    <h2 class="listing__title category-title">
-                        Features
-                        <span class="category-count">({{ features.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="featuresOpen ? 'Collapse' : 'Expand'">
-                        <svg v-if="featuresOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
-                    </button>
-                </div>
-                <transition name="slide">
-                    <div v-show="featuresOpen" class="listing__items">
-                        <RomfordCard 
-                            v-for="item in features"
-                            :key="`feature-${item.id}`"
-                            :item="item" 
-                        />
-                    </div>
-                </transition>
+        <div v-if="activeTab === 'films'" class="selection">
+          <div v-if="orderedCategories.length === 0" class="rollout-banner">
+            <div class="rollout-banner__icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
             </div>
+            <div class="rollout-banner__copy">
+              <h3>Lineup updates in progress</h3>
+              <p>This festival lineup is currently being updated. New films, sections, and official selections will be added progressively as they are announced and verified.</p>
+            </div>
+          </div>
+          <div v-else class="selection-layout">
+            <aside class="selection-nav" aria-label="Jump to section">
+              <template v-if="officialNav.length">
+                <div class="nav-group-label">Catalog</div>
+                <button
+                  v-for="sec in officialNav"
+                  :key="sec.key"
+                  class="nav-item"
+                  :class="{ active: activeSection === sec.key }"
+                  @click="scrollToSection(sec.key)"
+                >
+                  <span class="nav-item-label">{{ sec.label }}</span>
+                  <span class="nav-item-count">{{ sec.count }}</span>
+                </button>
+              </template>
+            </aside>
 
-            <div v-if="shorts.length > 0" class="film-category">
-                <div class="category-header" @click="shortsOpen = !shortsOpen">
-                    <h2 class="listing__title category-title">
-                        Shorts
-                        <span class="category-count">({{ shorts.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="shortsOpen ? 'Collapse' : 'Expand'">
-                        <svg v-if="shortsOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
+            <div ref="selectionContentRef" class="selection-content">
+              <section
+                v-for="sec in selectionSections"
+                :key="sec.key"
+                :data-key="sec.key"
+                class="sel-section"
+              >
+                <div class="sel-section-header" @click="onSectionHeaderClick(sec.key)">
+                  <h2 class="sel-section-title">{{ sec.label }}</h2>
+                  <div class="sel-section-meta">
+                    <span class="sel-section-count">{{ sec.count }} {{ sec.count === 1 ? 'film' : 'films' }}</span>
+                    <button v-if="isMobile" class="expand-btn" :aria-label="isSectionOpen(sec.key) ? 'Collapse' : 'Expand'">
+                      <svg v-if="isSectionOpen(sec.key)" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
+                      <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
                     </button>
+                  </div>
                 </div>
                 <transition name="slide">
-                    <div v-show="shortsOpen" class="listing__items">
-                        <RomfordCard 
-                            v-for="item in shorts"
-                            :key="`short-${item.id}`"
-                            :item="item" 
-                        />
+                  <div v-show="!isMobile || isSectionOpen(sec.key)" class="sel-section-body">
+                    <div class="listing__items">
+                      <RomfordCard
+                        v-for="item in sec.films"
+                        :key="`${sec.key}-${item.id}`"
+                        :item="item"
+                      />
                     </div>
+                  </div>
                 </transition>
+              </section>
             </div>
+          </div>
         </div>
 
         <div v-if="activeTab === 'schedule'" class="schedule-container">
-          <div class="schedule-toolbar" :class="{ 'search-active': isScheduleSearchActive }">
+          <!-- Initial rollout banner: schedule pending official publication -->
+          <div v-if="schedule.length === 0" class="rollout-banner">
+            <div class="rollout-banner__icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+            </div>
+            <div class="rollout-banner__copy">
+              <h3>Schedule pending</h3>
+              <p>Official screening schedules have not yet been published by the festival. Screening information will appear here as soon as it becomes available.</p>
+            </div>
+          </div>
+
+          <div v-if="schedule.length > 0" class="schedule-toolbar" :class="{ 'search-active': isScheduleSearchActive }">
             <div class="schedule-toolbar-info">
               <span class="schedule-count" v-if="!loading">
                 <template v-if="scheduleSearchActiveQuery">
@@ -133,30 +158,48 @@
             <p>No screenings match "<strong>{{ scheduleSearch }}</strong>"</p>
           </div>
 
-          <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" class="schedule-day">
-            <div class="day-header" @click="toggleDay(date)">
+          <div v-if="scheduleDays.length" class="schedule-layout">
+            <aside class="schedule-nav" aria-label="Jump to day">
+              <div class="nav-group-label">Days</div>
+              <button
+                v-for="day in scheduleDays"
+                :key="day.date"
+                class="nav-item"
+                :class="{ active: activeDay === day.date }"
+                @click="scrollToDay(day.date)"
+              >
+                <span class="nav-item-label">{{ day.label }}</span>
+                <span class="nav-item-count">{{ day.count }}</span>
+              </button>
+            </aside>
+
+            <div ref="scheduleContentRef" class="schedule-content">
+              <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" :data-day="date" class="schedule-day">
+            <div class="day-header" @click="onDayHeaderClick(date)">
                 <h2>{{ formatDate(date) }}</h2>
-                <div class="chevron" :class="{ 'closed': !isOpen(date) }">
+                <div v-if="isMobile" class="chevron" :class="{ 'closed': !isOpen(date) }">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down"><path d="m6 9 6 6 6-6"/></svg>
                 </div>
             </div>
-            
+
             <transition name="slide">
-                <div v-show="isOpen(date)" class="screenings-list">
+                <div v-show="!isMobile || isOpen(date)" class="screenings-list">
                   <div v-for="screening in dayScreenings" :key="screening.id" class="screening-card">
                      <div class="time-block">
-                        <span class="time">{{ formatTime(screening.start_time) }}</span>
+                        <span class="time">{{ formatTime(screening.start_time, screening.timezone) }}</span>
                         <span class="timezone">{{ screening.timezone }}</span>
                      </div>
-                     
+
                       <div class="film-info">
-                         <a 
-                            href="https://www.romfordhorrorfestival.com"
-                            target="_blank"
+                         <component
+                            :is="screening.film.source_url ? 'a' : 'span'"
+                            :href="screening.film.source_url || ''"
+                            :target="screening.film.source_url ? '_blank' : ''"
                             class="film-title"
+                            :class="{'no-link': !screening.film.source_url}"
                          >
                             {{ screening.film.title }}
-                         </a>
+                         </component>
                          <div class="film-meta">
                              <span v-if="screening.film.director">Directed by {{ screening.film.director }}</span>
                              <span v-if="screening.film.director && screening.film.runtime"> • </span>
@@ -172,13 +215,13 @@
                              <span v-if="screening.is_sold_out" class="tag sold-out">Sold Out</span>
                          </div>
                       </div>
-                      
+
                       <div class="poster-mini">
-                          <img 
-                            v-if="screening.film.poster_path" 
-                            :src="screening.film.poster_path" 
-                            alt="Poster" 
-                            loading="lazy" 
+                          <img
+                            v-if="screening.film.poster_path"
+                            :src="screening.film.poster_path"
+                            alt="Poster"
+                            loading="lazy"
                             @error="$event.target.src = '/placeholders/image_not_found_yet.webp'"
                           />
                           <img v-else src="/placeholders/image_not_found_yet.webp" alt="No Poster" />
@@ -186,6 +229,8 @@
                   </div>
                 </div>
             </transition>
+          </div>
+            </div>
           </div>
         </div>
 
@@ -245,7 +290,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, nextTick } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount, nextTick, watch } from 'vue';
 import Loader from '~/components/Loader.vue';
 import WinnersCarousel from '~/components/festival/WinnersCarousel.vue';
 import FestivalDataDisclaimer from '~/components/FestivalDataDisclaimer.vue';
@@ -295,26 +340,107 @@ const awards = ref([]);
 const schedule = ref([]);
 const openDays = ref(new Set());
 
-const featuresOpen = ref(true);
-const shortsOpen = ref(true);
+const CATEGORY_ORDER = [
+    'Features',
+    'Shorts',
+];
 
-const features = computed(() => {
-    return films.value?.results?.filter(f => !f.runtime || f.runtime >= 40) || [];
-});
-
-const shorts = computed(() => {
-    return films.value?.results?.filter(f => f.runtime > 0 && f.runtime < 40) || [];
-});
-
-const formatDate = (dateStr) => {
-    const options = { weekday: 'long', month: 'long', day: 'numeric' };
-    return new Date(dateStr).toLocaleDateString('en-US', options);
+const CATEGORY_LABELS = {
+    Features: 'Features',
+    Shorts: 'Shorts',
+    OTHER: 'Other',
 };
 
-const formatTime = (timeStr) => {
-    return new Date(timeStr).toLocaleTimeString('en-US', { 
-        hour: '2-digit', 
-        minute: '2-digit'
+const categoryKeyForFilm = (film) => {
+    const explicit = String(film.category || film.section || '').trim();
+    if (CATEGORY_ORDER.includes(explicit)) return explicit;
+    if (film.runtime > 0 && film.runtime < 40) return 'Shorts';
+    return 'Features';
+};
+
+const activeSection = ref('');
+const selectionContentRef = ref(null);
+let sectionObserver = null;
+const isMobile = ref(false);
+let mobileMql = null;
+const sectionOpen = ref({});
+const isSectionOpen = (key) => sectionOpen.value[key] !== false;
+const toggleSection = (key) => { sectionOpen.value = { ...sectionOpen.value, [key]: !isSectionOpen(key) }; };
+const onSectionHeaderClick = (key) => { if (!isMobile.value) return; toggleSection(key); };
+const activeDay = ref('');
+const scheduleContentRef = ref(null);
+let dayObserver = null;
+
+const filmsByCategory = computed(() => {
+    const map = Object.fromEntries(CATEGORY_ORDER.map((c) => [c, []]));
+    map.OTHER = [];
+    for (const f of films.value?.results || []) {
+        const key = categoryKeyForFilm(f);
+        if (key && map[key] !== undefined) map[key].push(f);
+        else map.OTHER.push(f);
+    }
+    return map;
+});
+
+const orderedCategories = computed(() => {
+    const out = CATEGORY_ORDER.filter((c) => (filmsByCategory.value[c] || []).length > 0);
+    if ((filmsByCategory.value.OTHER || []).length > 0) out.push('OTHER');
+    return out;
+});
+
+function categoryLabel (cat) {
+    return CATEGORY_LABELS[cat] || cat;
+}
+
+const selectionSections = computed(() => orderedCategories.value.map((cat) => {
+    const items = filmsByCategory.value[cat] || [];
+    return { key: cat, label: categoryLabel(cat), films: items, count: items.length };
+}));
+const officialNav = computed(() => selectionSections.value);
+
+const scrollToSection = (key) => {
+    activeSection.value = key;
+    const root = selectionContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-key]');
+    for (const el of els) { if (el.getAttribute('data-key') === key) { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); break; } }
+};
+
+const setupSectionObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (sectionObserver) sectionObserver.disconnect();
+    const root = selectionContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-key]');
+    if (!els.length) return;
+    sectionObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) { if (entry.isIntersecting) activeSection.value = entry.target.getAttribute('data-key'); }
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => sectionObserver.observe(el));
+};
+
+watch(selectionSections, (sections) => {
+    if (!sections.length) return;
+    if (!sections.some((sec) => sec.key === activeSection.value)) activeSection.value = sections[0].key;
+}, { immediate: true });
+
+watch([loading, activeTab, selectionSections], () => {
+    if (!loading.value && activeTab.value === 'films') nextTick(() => setupSectionObserver());
+    else if (sectionObserver) sectionObserver.disconnect();
+}, { flush: 'post' });
+
+const FESTIVAL_TZ = 'Europe/London';
+
+const formatDate = (dateStr) => {
+    const options = { weekday: 'long', month: 'long', day: 'numeric', timeZone: 'UTC' };
+    return new Date(`${dateStr}T00:00:00Z`).toLocaleDateString('en-US', options);
+};
+
+const formatTime = (timeStr, tz) => {
+    return new Date(timeStr).toLocaleTimeString('en-US', {
+        hour: '2-digit',
+        minute: '2-digit',
+        timeZone: tz || FESTIVAL_TZ
     });
 };
 
@@ -345,17 +471,57 @@ const groupedScreenings = computed(() => {
 });
 
 const toggleDay = (date) => {
-    if (openDays.value.has(date)) {
-        openDays.value.delete(date);
-    } else {
-        openDays.value.add(date);
-    }
-}
+    if (openDays.value.has(date)) openDays.value.delete(date);
+    else openDays.value.add(date);
+};
 
 const isOpen = (date) => {
     if (scheduleSearchActiveQuery.value) return true;
     return openDays.value.has(date);
 };
+
+const scheduleDays = computed(() => Object.entries(groupedScreenings.value).map(([date, arr]) => ({ date, label: formatDate(date), count: arr.length })));
+const onDayHeaderClick = (date) => { if (!isMobile.value) return; toggleDay(date); };
+const scrollToDay = (date) => {
+    activeDay.value = date;
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-day]');
+    for (const el of els) { if (el.getAttribute('data-day') === date) { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); break; } }
+};
+const setupDayObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (dayObserver) dayObserver.disconnect();
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-day]');
+    if (!els.length) return;
+    dayObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) { if (entry.isIntersecting) activeDay.value = entry.target.getAttribute('data-day'); }
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => dayObserver.observe(el));
+};
+watch(scheduleDays, (days) => {
+    if (!days.length) return;
+    if (!days.some((d) => d.date === activeDay.value)) activeDay.value = days[0]?.date || '';
+}, { immediate: true });
+watch([loading, activeTab, scheduleDays], () => {
+    if (!loading.value && activeTab.value === 'schedule') nextTick(() => setupDayObserver());
+    else if (dayObserver) dayObserver.disconnect();
+}, { flush: 'post' });
+const updateIsMobile = (e) => { isMobile.value = e.matches; };
+onMounted(() => {
+    if (typeof window !== 'undefined' && window.matchMedia) {
+        mobileMql = window.matchMedia('(max-width: 900px)');
+        isMobile.value = mobileMql.matches;
+        mobileMql.addEventListener('change', updateIsMobile);
+    }
+});
+onBeforeUnmount(() => {
+    if (sectionObserver) sectionObserver.disconnect();
+    if (dayObserver) dayObserver.disconnect();
+    if (mobileMql) mobileMql.removeEventListener('change', updateIsMobile);
+});
 
 onMounted(async () => {
     try {
@@ -389,60 +555,156 @@ onMounted(async () => {
     font-size: 1.2rem;
 }
 
-.film-category {
-    margin-bottom: 2.5rem;
-}
-
-// Compact catalog cards (~25%+ smaller than global default).
-// Scoped to .films-grid so other listings (home, search, etc.) are untouched.
-// Uses :deep() because festival cards are child components (scoped CSS).
-.films-grid :deep(.listing__items > .card) {
-    width: 25%;
+// Poster sizing inside the Selection content column. The column is narrower than
+// the old full-bleed grid, so we use fewer columns / slightly larger posters.
+.selection :deep(.listing__items > .card) {
+    width: 33.3333%;
 
     @media (min-width: 640px) {
-        width: 20%;
+        width: 25%;
     }
     @media (min-width: 1024px) {
-        width: 14.2857143%;
+        width: 20%;
     }
     @media (min-width: 1500px) {
-        width: 12.5%;
+        width: 16.6666%;
     }
     @media (min-width: 1800px) {
-        width: 11.1111111%;
-    }
-    @media (min-width: 2500px) {
-        width: 10%;
+        width: 14.2857%;
     }
 }
 
 
 
-.category-header {
+/* ── Selection: sidebar scroll-spy + sections ───────────── */
+.selection-layout,
+.schedule-layout {
+    display: grid;
+    grid-template-columns: 330px minmax(0, 1fr);
+    gap: 2.5rem;
+    align-items: start;
+}
+
+/* Breathing room between the screenings search bar and the day list below it. */
+.schedule-layout {
+    margin-top: 1.75rem;
+}
+
+.selection-nav,
+.schedule-nav {
+    position: sticky;
+    top: 5.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-height: calc(100vh - 7rem);
+    overflow-y: auto;
+    padding: 1rem;
+    border: 1px solid transparent;
+    background:
+        linear-gradient(rgba(3, 6, 10, 0.85), rgba(3, 6, 10, 0.85)) padding-box,
+        linear-gradient(160deg, rgba(139, 233, 253, 0.55), rgba(31, 84, 103, 0.45) 60%, rgba(139, 233, 253, 0.16)) border-box;
+    border-radius: 14px;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
+}
+
+.nav-group-label {
+    font-size: 1rem;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    color: rgba(139, 233, 253, 0.9);
+    font-weight: 700;
+    margin: 1.2rem 0.4rem 0.55rem;
+
+    &:first-child {
+        margin-top: 0.2rem;
+    }
+}
+
+.nav-item {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 10px;
+    width: 100%;
+    background: none;
+    border: none;
+    border-left: 3px solid transparent;
+    border-radius: 0 8px 8px 0;
+    color: rgba(255, 255, 255, 0.88);
+    padding: 0.82rem 1rem;
+    font-size: 1.32rem;
+    font-family: inherit;
+    text-align: left;
     cursor: pointer;
-    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
-    padding-bottom: 5px;
-    margin-bottom: 15px;
-    transition: border-color 0.2s;
-    user-select: none;
-    
+    transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+
     &:hover {
-        border-color: rgba(139, 233, 253, 0.6);
+        background: rgba(139, 233, 253, 0.08);
+        color: #eafbff;
+    }
+
+    &.active {
+        background: rgba(139, 233, 253, 0.12);
+        color: #8BE9FD;
+        border-left-color: #8BE9FD;
+        font-weight: 600;
     }
 }
 
-.category-title {
-    margin: 0 !important;
+.nav-item-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
-.category-count {
-    font-size: 1.1rem;
-    color: rgba(255, 255, 255, 0.6);
-    margin-left: 10px;
-    font-weight: normal;
+.nav-item-count {
+    font-size: 1.12rem;
+    color: rgba(255, 255, 255, 0.62);
+    flex-shrink: 0;
+}
+
+.nav-item.active .nav-item-count {
+    color: rgba(139, 233, 253, 0.85);
+}
+
+.sel-section {
+    scroll-margin-top: 6.5rem;
+    margin-bottom: 3rem;
+}
+
+.sel-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
+    padding-bottom: 6px;
+    margin-bottom: 1.25rem;
+}
+
+.sel-section-title {
+    margin: 0;
+    font-size: 1.7rem;
+    font-weight: 700;
+    color: #fff;
+}
+
+.sel-section-meta {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-shrink: 0;
+}
+
+.sel-section-count {
+    font-size: 1.05rem;
+    color: rgba(255, 255, 255, 0.5);
+    white-space: nowrap;
+    flex-shrink: 0;
 }
 
 .expand-btn {
@@ -458,7 +720,7 @@ onMounted(async () => {
     cursor: pointer;
     transition: all 0.2s ease;
     flex-shrink: 0;
-    
+
     &:hover {
         background: rgba(139, 233, 253, 0.15);
         color: #8BE9FD;
@@ -471,6 +733,42 @@ onMounted(async () => {
         min-width: 20px;
         min-height: 20px;
         display: block;
+    }
+}
+
+.parallel-band {
+    font-size: 0.85rem;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: #8BE9FD;
+    border-top: 1px solid rgba(139, 233, 253, 0.25);
+    padding-top: 1.4rem;
+    margin: 0.5rem 0 1.5rem;
+}
+
+@media (max-width: 900px) {
+    .selection-layout,
+    .schedule-layout {
+        display: block;
+    }
+
+    .selection-nav,
+    .schedule-nav {
+        display: none;
+    }
+
+    .sel-section-header {
+        cursor: pointer;
+        user-select: none;
+        transition: border-color 0.2s;
+    }
+
+    .sel-section-header:hover {
+        border-color: rgba(139, 233, 253, 0.6);
+    }
+
+    .day-header {
+        cursor: pointer;
     }
 }
 
@@ -493,12 +791,16 @@ onMounted(async () => {
 .segmented-control {
     position: relative;
     display: flex;
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 20px; 
+    background: rgba(3, 4, 6, 0.6);
+    border: 1px solid rgba(139, 233, 253, 0.18);
+    border-radius: 16px;
     padding: 4px;
     height: 48px;
     align-items: center;
     min-width: 420px;
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
 }
 
 .segmented-control input[type="radio"] {
@@ -521,7 +823,7 @@ onMounted(async () => {
 }
 
 .segmented-control input:checked + label {
-    color: #000;
+    color: #02080d;
 }
 
 .segmented-control .glider {
@@ -530,9 +832,10 @@ onMounted(async () => {
     left: 4px;
     height: calc(100% - 8px);
     width: calc((100% - 8px) / 3);
-    background: #8BE9FD; 
-    border-radius: 16px;
+    background: linear-gradient(135deg, #8BE9FD, #5cc4d8);
+    border-radius: 12px;
     z-index: 1;
+    box-shadow: 0 4px 14px rgba(139, 233, 253, 0.3);
     transition: transform 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
 }
 
@@ -546,12 +849,15 @@ onMounted(async () => {
     max-width: 1200px;
     margin: 0 auto;
     position: relative;
-    border-radius: 15px;
+    border-radius: 16px;
     overflow: hidden;
-    background-color: transparent;
     display: flex;
     justify-content: center;
-    border: 1px solid #8BE9FD;
+    border: 2px solid transparent;
+    background:
+        linear-gradient(#02080d, #02080d) padding-box,
+        linear-gradient(140deg, #8BE9FD 0%, #1F5467 45%, rgba(31, 84, 103, 0.35) 100%) border-box;
+    box-shadow: 0 14px 36px rgba(0, 0, 0, 0.5), 0 0 30px rgba(139, 233, 253, 0.12);
 }
 
 .back-link {
@@ -581,7 +887,7 @@ onMounted(async () => {
         box-shadow: 0 8px 25px rgba(0,0,0,0.4);
         border-color: #fff;
     }
-    
+
     svg {
         width: 24px;
         height: 24px;
@@ -592,7 +898,7 @@ onMounted(async () => {
         left: 20px;
         font-size: 0.9rem;
         padding: 8px 16px;
-        
+
         svg {
             width: 18px;
             height: 18px;
@@ -604,7 +910,7 @@ onMounted(async () => {
     width: 100%;
     height: auto;
     position: relative;
-    
+
     img {
         width: 100%;
         height: auto;
@@ -658,21 +964,29 @@ onMounted(async () => {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    cursor: pointer;
+    cursor: default;
     user-select: none;
-    
+
     h2 {
         font-size: 1.8rem;
         margin: 0;
     }
-    
+
     .chevron {
         transition: transform 0.3s ease;
-        
+
         &.closed {
             transform: rotate(-90deg);
         }
     }
+}
+
+.schedule-day {
+    scroll-margin-top: 6.5rem;
+}
+
+.schedule-content > .schedule-day:first-child .day-header {
+    margin-top: 0;
 }
 
 .slide-enter-active,
@@ -692,13 +1006,21 @@ onMounted(async () => {
 
 .screening-card {
     display: flex;
-    background: #0a161b;
-    border: 1px solid #8BE9FD;
-    border-radius: 8px;
+    border: 1px solid transparent;
+    background:
+        linear-gradient(#0a161b, #0a161b) padding-box,
+        linear-gradient(140deg, #8BE9FD, #1F5467 60%, rgba(31, 84, 103, 0.3)) border-box;
+    border-radius: 10px;
     padding: 1.5rem;
     margin-bottom: 1rem;
     gap: 1.5rem;
-    transition: transform 0.2s;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.3);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.screening-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.4), 0 0 20px rgba(139, 233, 253, 0.1);
 }
 
 .time-block {
@@ -709,7 +1031,7 @@ onMounted(async () => {
     min-width: 80px;
     border-right: 1px solid #333;
     padding-right: 1.5rem;
-    
+
     .time {
         font-size: 1.2rem;
         font-weight: 700;
@@ -726,25 +1048,25 @@ onMounted(async () => {
     display: flex;
     flex-direction: column;
     justify-content: center;
-    
+
     .film-title {
         font-size: 1.6rem;
         font-weight: 700;
         color: #fff;
         text-decoration: none;
         margin-bottom: 0.5rem;
-        
+
         &:hover {
             color: #8BE9FD;
         }
     }
-    
+
     .film-meta {
         font-size: 1.05rem;
         color: #aaa;
         margin-bottom: 0.8rem;
     }
-    
+
     .venue-info {
         font-size: 1.25rem;
         color: #ccc;
@@ -752,7 +1074,7 @@ onMounted(async () => {
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        
+
         svg {
             min-width: 18px;
         }
@@ -762,14 +1084,14 @@ onMounted(async () => {
 .tags {
     display: flex;
     gap: 0.5rem;
-    
+
     .tag {
         font-size: 0.75rem;
         padding: 4px 8px;
         border-radius: 4px;
         font-weight: 600;
         text-transform: uppercase;
-        
+
         &.in-person { background: rgba(52, 152, 219, 0.2); }
         &.online { background: rgba(46, 204, 113, 0.2); color: #2ecc71; }
         &.sold-out { background: rgba(231, 76, 60, 0.2); color: #e74c3c; }
@@ -779,7 +1101,7 @@ onMounted(async () => {
 .poster-mini {
     width: 60px;
     height: 90px;
-    
+
     img {
         width: 100%;
         height: 100%;
@@ -790,7 +1112,7 @@ onMounted(async () => {
 
 @media (max-width: 600px) {
     .screening-card {
-        flex-direction: column; 
+        flex-direction: column;
         gap: 1rem;
     }
     .time-block {
@@ -823,14 +1145,33 @@ onMounted(async () => {
 }
 
 .carousel-card {
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(139, 233, 253, 0.18);
+  position: relative;
+  background: rgba(3, 4, 6, 0.85);
+  background-image:
+    radial-gradient(circle at 15% 20%, rgba(31, 84, 103, 0.18), transparent 35%),
+    radial-gradient(circle at 85% 80%, rgba(139, 233, 253, 0.08), transparent 30%);
+  border: 1px solid rgba(31, 84, 103, 0.5);
   border-radius: 20px;
   padding: 2.2rem 2.5rem;
-  backdrop-filter: blur(12px);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
   color: rgba(255, 255, 255, 0.88);
   line-height: 1.8;
   min-height: 300px;
+  overflow: hidden;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5), inset 0 0 24px rgba(139, 233, 253, 0.04);
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: linear-gradient(90deg, transparent, #8BE9FD, #1F5467, transparent);
+    opacity: 0.85;
+    pointer-events: none;
+  }
 
   strong { color: #fff; }
 }
@@ -864,19 +1205,21 @@ onMounted(async () => {
   justify-content: center;
   width: 44px;
   height: 44px;
-  border-radius: 50%;
-  border: 1px solid rgba(139, 233, 253, 0.25);
-  background: rgba(0, 0, 0, 0.4);
+  border-radius: 12px;
+  border: 1px solid rgba(139, 233, 253, 0.4);
+  background: rgba(3, 4, 6, 0.75);
   color: #8BE9FD;
   cursor: pointer;
-  transition: all 0.25s ease;
+  transition: all 0.2s ease;
   flex-shrink: 0;
-  backdrop-filter: blur(6px);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
 
   &:hover {
-    background: rgba(139, 233, 253, 0.15);
-    border-color: #8BE9FD;
-    transform: scale(1.1);
+    background: #ffffff;
+    border-color: #ffffff;
+    color: #000;
+    transform: scale(1.05);
   }
 }
 
@@ -928,6 +1271,7 @@ onMounted(async () => {
   .carousel-arrow svg { width: 18px; height: 18px; }
 }
 
+/* ── Shared card content styles ───────────── */
 .price-list {
   list-style: none; padding: 0; margin: 1rem 0;
   li { display: flex; justify-content: space-between; align-items: center; padding: 0.65rem 0; border-bottom: 1px dashed rgba(255,255,255,0.08); &:last-child { border: none; } }
@@ -936,12 +1280,8 @@ onMounted(async () => {
 }
 
 .venue-list {
-  display: grid; grid-template-columns: repeat(2, 1fr); gap: 0.9rem;
-  @media (max-width: 600px) { grid-template-columns: 1fr; }
-  .venue-item { font-size: 0.98rem; padding: 0.7rem 0.9rem; background: rgba(255,255,255,0.04); border-radius: 10px; border: 1px solid rgba(255,255,255,0.06);
-    strong { color: #8BE9FD; display: block; margin-bottom: 3px; font-size: 1.02rem; }
-    span { color: rgba(255,255,255,0.7); }
-  }
+  display: flex; flex-direction: column; gap: 0.5rem; margin: 0.5rem 0;
+  .venue-item { display: flex; justify-content: space-between; align-items: center; padding: 0.5rem 0; border-bottom: 1px solid rgba(255,255,255,0.05); span { color: rgba(255,255,255,0.5); font-size: 0.95rem; } strong { color: #fff; } }
 }
 
 .bullet-list {
@@ -952,6 +1292,58 @@ onMounted(async () => {
 .accent-link {
   color: #8BE9FD; text-decoration: none; font-weight: 600; border-bottom: 1px solid transparent; transition: border-color 0.2s;
   &:hover { border-color: #8BE9FD; }
+}
+
+/* ── Initial-rollout banner (catalog/schedule placeholders) ─ */
+.rollout-banner {
+    display: flex;
+    gap: 1.25rem;
+    align-items: flex-start;
+    max-width: 720px;
+    margin: 2rem auto;
+    padding: 1.5rem 1.75rem;
+    background: rgba(16, 26, 35, 0.7);
+    border: 1px solid rgba(139, 233, 253, 0.22);
+    border-radius: 14px;
+    backdrop-filter: blur(8px);
+}
+
+.rollout-banner__icon {
+    flex-shrink: 0;
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    background: rgba(139, 233, 253, 0.08);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.rollout-banner__copy {
+    flex: 1;
+    color: rgba(255, 255, 255, 0.85);
+
+    h3 {
+        margin: 0 0 0.4rem;
+        font-size: 1.15rem;
+        font-weight: 700;
+        color: #8BE9FD;
+        letter-spacing: 0.3px;
+    }
+    p {
+        margin: 0;
+        font-size: 1rem;
+        line-height: 1.6;
+        color: rgba(255, 255, 255, 0.7);
+    }
+}
+
+@media (max-width: 600px) {
+    .rollout-banner {
+        flex-direction: column;
+        gap: 0.75rem;
+        padding: 1.25rem;
+    }
 }
 
 /* ── Schedule search toolbar ─────────────── */

--- a/pages/festival/rotterdam-2026/index.vue
+++ b/pages/festival/rotterdam-2026/index.vue
@@ -50,54 +50,79 @@
       </div>
 
       <div v-else>
-        <div v-if="activeTab === 'films'" class="films-grid">
-            <div v-if="features.length > 0" class="film-category">
-                <div class="category-header" @click="featuresOpen = !featuresOpen">
-                    <h2 class="listing__title category-title">
-                        Features
-                        <span class="category-count">({{ features.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="featuresOpen ? 'Collapse' : 'Expand'">
-                        <svg v-if="featuresOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
-                    </button>
-                </div>
-                <transition name="slide">
-                    <div v-show="featuresOpen" class="listing__items">
-                        <RotterdamCard 
-                            v-for="item in features"
-                            :key="`feature-${item.id}`"
-                            :item="item" 
-                        />
-                    </div>
-                </transition>
+        <div v-if="activeTab === 'films'" class="selection">
+          <div v-if="orderedCategories.length === 0" class="rollout-banner">
+            <div class="rollout-banner__icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
             </div>
+            <div class="rollout-banner__copy">
+              <h3>Lineup updates in progress</h3>
+              <p>This festival lineup is currently being updated. New films, sections, and official selections will be added progressively as they are announced and verified.</p>
+            </div>
+          </div>
+          <div v-else class="selection-layout">
+            <aside class="selection-nav" aria-label="Jump to section">
+              <template v-if="officialNav.length">
+                <div class="nav-group-label">Catalog</div>
+                <button
+                  v-for="sec in officialNav"
+                  :key="sec.key"
+                  class="nav-item"
+                  :class="{ active: activeSection === sec.key }"
+                  @click="scrollToSection(sec.key)"
+                >
+                  <span class="nav-item-label">{{ sec.label }}</span>
+                  <span class="nav-item-count">{{ sec.count }}</span>
+                </button>
+              </template>
+            </aside>
 
-            <div v-if="shorts.length > 0" class="film-category">
-                <div class="category-header" @click="shortsOpen = !shortsOpen">
-                    <h2 class="listing__title category-title">
-                        Shorts
-                        <span class="category-count">({{ shorts.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="shortsOpen ? 'Collapse' : 'Expand'">
-                        <svg v-if="shortsOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
+            <div ref="selectionContentRef" class="selection-content">
+              <section
+                v-for="sec in selectionSections"
+                :key="sec.key"
+                :data-key="sec.key"
+                class="sel-section"
+              >
+                <div class="sel-section-header" @click="onSectionHeaderClick(sec.key)">
+                  <h2 class="sel-section-title">{{ sec.label }}</h2>
+                  <div class="sel-section-meta">
+                    <span class="sel-section-count">{{ sec.count }} {{ sec.count === 1 ? 'film' : 'films' }}</span>
+                    <button v-if="isMobile" class="expand-btn" :aria-label="isSectionOpen(sec.key) ? 'Collapse' : 'Expand'">
+                      <svg v-if="isSectionOpen(sec.key)" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
+                      <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
                     </button>
+                  </div>
                 </div>
                 <transition name="slide">
-                    <div v-show="shortsOpen" class="listing__items">
-                        <RotterdamCard 
-                            v-for="item in shorts"
-                            :key="`short-${item.id}`"
-                            :item="item" 
-                        />
+                  <div v-show="!isMobile || isSectionOpen(sec.key)" class="sel-section-body">
+                    <div class="listing__items">
+                      <RotterdamCard
+                        v-for="item in sec.films"
+                        :key="`${sec.key}-${item.id}`"
+                        :item="item"
+                      />
                     </div>
+                  </div>
                 </transition>
+              </section>
             </div>
+          </div>
         </div>
 
         <div v-if="activeTab === 'schedule'" class="schedule-container">
-          <div class="schedule-toolbar" :class="{ 'search-active': isScheduleSearchActive }">
+          <!-- Initial rollout banner: schedule pending official publication -->
+          <div v-if="schedule.length === 0" class="rollout-banner">
+            <div class="rollout-banner__icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+            </div>
+            <div class="rollout-banner__copy">
+              <h3>Schedule pending</h3>
+              <p>Official screening schedules have not yet been published by the festival. Screening information will appear here as soon as it becomes available.</p>
+            </div>
+          </div>
+
+          <div v-if="schedule.length > 0" class="schedule-toolbar" :class="{ 'search-active': isScheduleSearchActive }">
             <div class="schedule-toolbar-info">
               <span class="schedule-count" v-if="!loading">
                 <template v-if="scheduleSearchActiveQuery">
@@ -133,36 +158,56 @@
             <p>No screenings match "<strong>{{ scheduleSearch }}</strong>"</p>
           </div>
 
-          <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" class="schedule-day">
-            <div class="day-header" @click="toggleDay(date)">
+          <div v-if="scheduleDays.length" class="schedule-layout">
+            <aside class="schedule-nav" aria-label="Jump to day">
+              <div class="nav-group-label">Days</div>
+              <button
+                v-for="day in scheduleDays"
+                :key="day.date"
+                class="nav-item"
+                :class="{ active: activeDay === day.date }"
+                @click="scrollToDay(day.date)"
+              >
+                <span class="nav-item-label">{{ day.label }}</span>
+                <span class="nav-item-count">{{ day.count }}</span>
+              </button>
+            </aside>
+
+            <div ref="scheduleContentRef" class="schedule-content">
+              <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" :data-day="date" class="schedule-day">
+            <div class="day-header" @click="onDayHeaderClick(date)">
                 <h2>{{ formatDate(date) }}</h2>
-                <div class="chevron" :class="{ 'closed': !isOpen(date) }">
+                <div v-if="isMobile" class="chevron" :class="{ 'closed': !isOpen(date) }">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down"><path d="m6 9 6 6 6-6"/></svg>
                 </div>
             </div>
-            
+
             <transition name="slide">
-                <div v-show="isOpen(date)" class="screenings-list">
+                <div v-show="!isMobile || isOpen(date)" class="screenings-list">
                   <div v-for="screening in dayScreenings" :key="screening.id" class="screening-card">
                      <div class="time-block">
-                        <span class="time">{{ formatTime(screening.start_time) }}</span>
+                        <span class="time">{{ formatTime(screening.start_time, screening.timezone) }}</span>
                         <span class="timezone">{{ screening.timezone }}</span>
                      </div>
-                                           <div class="film-info">
-                          <component 
-                            :is="isSafeUrl(screening.film.source_url) ? 'a' : 'span'"
-                            :href="isSafeUrl(screening.film.source_url) ? screening.film.source_url : ''"
-                            :target="isSafeUrl(screening.film.source_url) ? '_blank' : ''"
+
+                      <div class="film-info">
+                         <component
+                            :is="screening.film.source_url ? 'a' : 'span'"
+                            :href="screening.film.source_url || ''"
+                            :target="screening.film.source_url ? '_blank' : ''"
                             class="film-title"
-                            :class="{'no-link': !isSafeUrl(screening.film.source_url)}"
-                          >
-                             {{ screening.film.title }}
-                          </component>
+                            :class="{'no-link': !screening.film.source_url}"
+                         >
+                            {{ screening.film.title }}
+                         </component>
                          <div class="film-meta">
                              <span v-if="screening.film.director">Directed by {{ screening.film.director }}</span>
                              <span v-if="screening.film.director && screening.film.runtime"> • </span>
                              <span v-if="screening.film.runtime">{{ screening.film.runtime }} min</span>
-                             <span v-if="screening.venue"> • {{ screening.venue }}</span>
+                         </div>
+                         <div v-if="screening.venue" class="venue-info">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-map-pin"><path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"/><circle cx="12" cy="10" r="3"/></svg>
+                            {{ screening.venue }}
                          </div>
                          <div class="tags">
                              <span v-if="screening.is_in_person" class="tag in-person">In Person</span>
@@ -170,13 +215,13 @@
                              <span v-if="screening.is_sold_out" class="tag sold-out">Sold Out</span>
                          </div>
                       </div>
-                      
+
                       <div class="poster-mini">
-                          <img 
-                            v-if="screening.film.poster_path" 
-                            :src="screening.film.poster_path" 
-                            alt="Poster" 
-                            loading="lazy" 
+                          <img
+                            v-if="screening.film.poster_path"
+                            :src="screening.film.poster_path"
+                            alt="Poster"
+                            loading="lazy"
                             @error="$event.target.src = '/placeholders/image_not_found_yet.webp'"
                           />
                           <img v-else src="/placeholders/image_not_found_yet.webp" alt="No Poster" />
@@ -184,6 +229,8 @@
                   </div>
                 </div>
             </transition>
+          </div>
+            </div>
           </div>
         </div>
 
@@ -263,7 +310,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, nextTick } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount, nextTick, watch } from 'vue';
 import Loader from '~/components/Loader.vue';
 import WinnersCarousel from '~/components/festival/WinnersCarousel.vue';
 import FestivalDataDisclaimer from '~/components/FestivalDataDisclaimer.vue';
@@ -326,24 +373,108 @@ const awards = ref([]);
 const schedule = ref([]);
 const openDays = ref(new Set());
 
-const featuresOpen = ref(true);
-const shortsOpen = ref(true);
+const CATEGORY_ORDER = [
+    'Features',
+    'Shorts',
+];
 
-const features = computed(() => {
-    return films.value?.results?.filter(f => !f.runtime || f.runtime >= 40) || [];
-});
-
-const shorts = computed(() => {
-    return films.value?.results?.filter(f => f.runtime > 0 && f.runtime < 40) || [];
-});
-
-const formatDate = (dateStr) => {
-    const options = { weekday: 'long', month: 'long', day: 'numeric' };
-    return new Date(dateStr).toLocaleDateString('en-US', options);
+const CATEGORY_LABELS = {
+    Features: 'Features',
+    Shorts: 'Shorts',
+    OTHER: 'Other',
 };
 
-const formatTime = (timeStr) => {
-    return new Date(timeStr).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
+const categoryKeyForFilm = (film) => {
+    const explicit = String(film.category || film.section || '').trim();
+    if (CATEGORY_ORDER.includes(explicit)) return explicit;
+    if (film.runtime > 0 && film.runtime < 40) return 'Shorts';
+    return 'Features';
+};
+
+const activeSection = ref('');
+const selectionContentRef = ref(null);
+let sectionObserver = null;
+const isMobile = ref(false);
+let mobileMql = null;
+const sectionOpen = ref({});
+const isSectionOpen = (key) => sectionOpen.value[key] !== false;
+const toggleSection = (key) => { sectionOpen.value = { ...sectionOpen.value, [key]: !isSectionOpen(key) }; };
+const onSectionHeaderClick = (key) => { if (!isMobile.value) return; toggleSection(key); };
+const activeDay = ref('');
+const scheduleContentRef = ref(null);
+let dayObserver = null;
+
+const filmsByCategory = computed(() => {
+    const map = Object.fromEntries(CATEGORY_ORDER.map((c) => [c, []]));
+    map.OTHER = [];
+    for (const f of films.value?.results || []) {
+        const key = categoryKeyForFilm(f);
+        if (key && map[key] !== undefined) map[key].push(f);
+        else map.OTHER.push(f);
+    }
+    return map;
+});
+
+const orderedCategories = computed(() => {
+    const out = CATEGORY_ORDER.filter((c) => (filmsByCategory.value[c] || []).length > 0);
+    if ((filmsByCategory.value.OTHER || []).length > 0) out.push('OTHER');
+    return out;
+});
+
+function categoryLabel (cat) {
+    return CATEGORY_LABELS[cat] || cat;
+}
+
+const selectionSections = computed(() => orderedCategories.value.map((cat) => {
+    const items = filmsByCategory.value[cat] || [];
+    return { key: cat, label: categoryLabel(cat), films: items, count: items.length };
+}));
+const officialNav = computed(() => selectionSections.value);
+
+const scrollToSection = (key) => {
+    activeSection.value = key;
+    const root = selectionContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-key]');
+    for (const el of els) { if (el.getAttribute('data-key') === key) { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); break; } }
+};
+
+const setupSectionObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (sectionObserver) sectionObserver.disconnect();
+    const root = selectionContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-key]');
+    if (!els.length) return;
+    sectionObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) { if (entry.isIntersecting) activeSection.value = entry.target.getAttribute('data-key'); }
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => sectionObserver.observe(el));
+};
+
+watch(selectionSections, (sections) => {
+    if (!sections.length) return;
+    if (!sections.some((sec) => sec.key === activeSection.value)) activeSection.value = sections[0].key;
+}, { immediate: true });
+
+watch([loading, activeTab, selectionSections], () => {
+    if (!loading.value && activeTab.value === 'films') nextTick(() => setupSectionObserver());
+    else if (sectionObserver) sectionObserver.disconnect();
+}, { flush: 'post' });
+
+const FESTIVAL_TZ = 'Europe/Amsterdam';
+
+const formatDate = (dateStr) => {
+    const options = { weekday: 'long', month: 'long', day: 'numeric', timeZone: 'UTC' };
+    return new Date(`${dateStr}T00:00:00Z`).toLocaleDateString('en-US', options);
+};
+
+const formatTime = (timeStr, tz) => {
+    return new Date(timeStr).toLocaleTimeString('en-US', {
+        hour: '2-digit',
+        minute: '2-digit',
+        timeZone: tz || FESTIVAL_TZ
+    });
 };
 
 const filteredSchedule = computed(() => {
@@ -373,17 +504,57 @@ const groupedScreenings = computed(() => {
 });
 
 const toggleDay = (date) => {
-    if (openDays.value.has(date)) {
-        openDays.value.delete(date);
-    } else {
-        openDays.value.add(date);
-    }
-}
+    if (openDays.value.has(date)) openDays.value.delete(date);
+    else openDays.value.add(date);
+};
 
 const isOpen = (date) => {
     if (scheduleSearchActiveQuery.value) return true;
     return openDays.value.has(date);
 };
+
+const scheduleDays = computed(() => Object.entries(groupedScreenings.value).map(([date, arr]) => ({ date, label: formatDate(date), count: arr.length })));
+const onDayHeaderClick = (date) => { if (!isMobile.value) return; toggleDay(date); };
+const scrollToDay = (date) => {
+    activeDay.value = date;
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-day]');
+    for (const el of els) { if (el.getAttribute('data-day') === date) { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); break; } }
+};
+const setupDayObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (dayObserver) dayObserver.disconnect();
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-day]');
+    if (!els.length) return;
+    dayObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) { if (entry.isIntersecting) activeDay.value = entry.target.getAttribute('data-day'); }
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => dayObserver.observe(el));
+};
+watch(scheduleDays, (days) => {
+    if (!days.length) return;
+    if (!days.some((d) => d.date === activeDay.value)) activeDay.value = days[0]?.date || '';
+}, { immediate: true });
+watch([loading, activeTab, scheduleDays], () => {
+    if (!loading.value && activeTab.value === 'schedule') nextTick(() => setupDayObserver());
+    else if (dayObserver) dayObserver.disconnect();
+}, { flush: 'post' });
+const updateIsMobile = (e) => { isMobile.value = e.matches; };
+onMounted(() => {
+    if (typeof window !== 'undefined' && window.matchMedia) {
+        mobileMql = window.matchMedia('(max-width: 900px)');
+        isMobile.value = mobileMql.matches;
+        mobileMql.addEventListener('change', updateIsMobile);
+    }
+});
+onBeforeUnmount(() => {
+    if (sectionObserver) sectionObserver.disconnect();
+    if (dayObserver) dayObserver.disconnect();
+    if (mobileMql) mobileMql.removeEventListener('change', updateIsMobile);
+});
 
 onMounted(async () => {
     try {
@@ -428,60 +599,156 @@ onMounted(async () => {
     font-size: 1.2rem;
 }
 
-.film-category {
-    margin-bottom: 2.5rem;
-}
-
-// Compact catalog cards (~25%+ smaller than global default).
-// Scoped to .films-grid so other listings (home, search, etc.) are untouched.
-// Uses :deep() because festival cards are child components (scoped CSS).
-.films-grid :deep(.listing__items > .card) {
-    width: 25%;
+// Poster sizing inside the Selection content column. The column is narrower than
+// the old full-bleed grid, so we use fewer columns / slightly larger posters.
+.selection :deep(.listing__items > .card) {
+    width: 33.3333%;
 
     @media (min-width: 640px) {
-        width: 20%;
+        width: 25%;
     }
     @media (min-width: 1024px) {
-        width: 14.2857143%;
+        width: 20%;
     }
     @media (min-width: 1500px) {
-        width: 12.5%;
+        width: 16.6666%;
     }
     @media (min-width: 1800px) {
-        width: 11.1111111%;
-    }
-    @media (min-width: 2500px) {
-        width: 10%;
+        width: 14.2857%;
     }
 }
 
 
 
-.category-header {
+/* ── Selection: sidebar scroll-spy + sections ───────────── */
+.selection-layout,
+.schedule-layout {
+    display: grid;
+    grid-template-columns: 330px minmax(0, 1fr);
+    gap: 2.5rem;
+    align-items: start;
+}
+
+/* Breathing room between the screenings search bar and the day list below it. */
+.schedule-layout {
+    margin-top: 1.75rem;
+}
+
+.selection-nav,
+.schedule-nav {
+    position: sticky;
+    top: 5.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-height: calc(100vh - 7rem);
+    overflow-y: auto;
+    padding: 1rem;
+    border: 1px solid transparent;
+    background:
+        linear-gradient(rgba(3, 6, 10, 0.85), rgba(3, 6, 10, 0.85)) padding-box,
+        linear-gradient(160deg, rgba(139, 233, 253, 0.55), rgba(31, 84, 103, 0.45) 60%, rgba(139, 233, 253, 0.16)) border-box;
+    border-radius: 14px;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
+}
+
+.nav-group-label {
+    font-size: 1rem;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    color: rgba(139, 233, 253, 0.9);
+    font-weight: 700;
+    margin: 1.2rem 0.4rem 0.55rem;
+
+    &:first-child {
+        margin-top: 0.2rem;
+    }
+}
+
+.nav-item {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 10px;
+    width: 100%;
+    background: none;
+    border: none;
+    border-left: 3px solid transparent;
+    border-radius: 0 8px 8px 0;
+    color: rgba(255, 255, 255, 0.88);
+    padding: 0.82rem 1rem;
+    font-size: 1.32rem;
+    font-family: inherit;
+    text-align: left;
     cursor: pointer;
-    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
-    padding-bottom: 5px;
-    margin-bottom: 15px;
-    transition: border-color 0.2s;
-    user-select: none;
-    
+    transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+
     &:hover {
-        border-color: rgba(139, 233, 253, 0.6);
+        background: rgba(139, 233, 253, 0.08);
+        color: #eafbff;
+    }
+
+    &.active {
+        background: rgba(139, 233, 253, 0.12);
+        color: #8BE9FD;
+        border-left-color: #8BE9FD;
+        font-weight: 600;
     }
 }
 
-.category-title {
-    margin: 0 !important;
+.nav-item-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
-.category-count {
-    font-size: 1.1rem;
-    color: rgba(255, 255, 255, 0.6);
-    margin-left: 10px;
-    font-weight: normal;
+.nav-item-count {
+    font-size: 1.12rem;
+    color: rgba(255, 255, 255, 0.62);
+    flex-shrink: 0;
+}
+
+.nav-item.active .nav-item-count {
+    color: rgba(139, 233, 253, 0.85);
+}
+
+.sel-section {
+    scroll-margin-top: 6.5rem;
+    margin-bottom: 3rem;
+}
+
+.sel-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
+    padding-bottom: 6px;
+    margin-bottom: 1.25rem;
+}
+
+.sel-section-title {
+    margin: 0;
+    font-size: 1.7rem;
+    font-weight: 700;
+    color: #fff;
+}
+
+.sel-section-meta {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-shrink: 0;
+}
+
+.sel-section-count {
+    font-size: 1.05rem;
+    color: rgba(255, 255, 255, 0.5);
+    white-space: nowrap;
+    flex-shrink: 0;
 }
 
 .expand-btn {
@@ -497,7 +764,7 @@ onMounted(async () => {
     cursor: pointer;
     transition: all 0.2s ease;
     flex-shrink: 0;
-    
+
     &:hover {
         background: rgba(139, 233, 253, 0.15);
         color: #8BE9FD;
@@ -510,6 +777,42 @@ onMounted(async () => {
         min-width: 20px;
         min-height: 20px;
         display: block;
+    }
+}
+
+.parallel-band {
+    font-size: 0.85rem;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: #8BE9FD;
+    border-top: 1px solid rgba(139, 233, 253, 0.25);
+    padding-top: 1.4rem;
+    margin: 0.5rem 0 1.5rem;
+}
+
+@media (max-width: 900px) {
+    .selection-layout,
+    .schedule-layout {
+        display: block;
+    }
+
+    .selection-nav,
+    .schedule-nav {
+        display: none;
+    }
+
+    .sel-section-header {
+        cursor: pointer;
+        user-select: none;
+        transition: border-color 0.2s;
+    }
+
+    .sel-section-header:hover {
+        border-color: rgba(139, 233, 253, 0.6);
+    }
+
+    .day-header {
+        cursor: pointer;
     }
 }
 
@@ -529,39 +832,19 @@ onMounted(async () => {
     align-items: center;
 }
 
-.buy-tickets-btn {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    background: #8BE9FD;
-    color: #000;
-    padding: 0 20px;
-    height: 40px;
-    border-radius: 16px;
-    text-decoration: none;
-    font-weight: 700;
-    font-size: 1.1rem;
-    transition: transform 0.2s, opacity 0.2s;
-    
-    &:hover {
-        transform: scale(1.05);
-        opacity: 0.9;
-    }
-    
-    span {
-        white-space: nowrap;
-    }
-}
-
 .segmented-control {
     position: relative;
     display: flex;
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 20px; 
+    background: rgba(3, 4, 6, 0.6);
+    border: 1px solid rgba(139, 233, 253, 0.18);
+    border-radius: 16px;
     padding: 4px;
     height: 48px;
     align-items: center;
     min-width: 420px;
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
 }
 
 .segmented-control input[type="radio"] {
@@ -584,7 +867,7 @@ onMounted(async () => {
 }
 
 .segmented-control input:checked + label {
-    color: #000;
+    color: #02080d;
 }
 
 .segmented-control .glider {
@@ -593,9 +876,10 @@ onMounted(async () => {
     left: 4px;
     height: calc(100% - 8px);
     width: calc((100% - 8px) / 3);
-    background: #8BE9FD;
-    border-radius: 16px;
+    background: linear-gradient(135deg, #8BE9FD, #5cc4d8);
+    border-radius: 12px;
     z-index: 1;
+    box-shadow: 0 4px 14px rgba(139, 233, 253, 0.3);
     transition: transform 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
 }
 
@@ -609,12 +893,15 @@ onMounted(async () => {
     max-width: 1200px;
     margin: 0 auto;
     position: relative;
-    border-radius: 15px;
+    border-radius: 16px;
     overflow: hidden;
-    background-color: transparent;
     display: flex;
     justify-content: center;
-    border: 1px solid #8BE9FD;
+    border: 2px solid transparent;
+    background:
+        linear-gradient(#02080d, #02080d) padding-box,
+        linear-gradient(140deg, #8BE9FD 0%, #1F5467 45%, rgba(31, 84, 103, 0.35) 100%) border-box;
+    box-shadow: 0 14px 36px rgba(0, 0, 0, 0.5), 0 0 30px rgba(139, 233, 253, 0.12);
 }
 
 .back-link {
@@ -644,7 +931,7 @@ onMounted(async () => {
         box-shadow: 0 8px 25px rgba(0,0,0,0.4);
         border-color: #fff;
     }
-    
+
     svg {
         width: 24px;
         height: 24px;
@@ -655,7 +942,7 @@ onMounted(async () => {
         left: 20px;
         font-size: 0.9rem;
         padding: 8px 16px;
-        
+
         svg {
             width: 18px;
             height: 18px;
@@ -667,7 +954,7 @@ onMounted(async () => {
     width: 100%;
     height: auto;
     position: relative;
-    
+
     img {
         width: 100%;
         height: auto;
@@ -721,21 +1008,29 @@ onMounted(async () => {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    cursor: pointer;
+    cursor: default;
     user-select: none;
-    
+
     h2 {
         font-size: 1.8rem;
         margin: 0;
     }
-    
+
     .chevron {
         transition: transform 0.3s ease;
-        
+
         &.closed {
             transform: rotate(-90deg);
         }
     }
+}
+
+.schedule-day {
+    scroll-margin-top: 6.5rem;
+}
+
+.schedule-content > .schedule-day:first-child .day-header {
+    margin-top: 0;
 }
 
 .slide-enter-active,
@@ -755,13 +1050,21 @@ onMounted(async () => {
 
 .screening-card {
     display: flex;
-    background: #0a161b;
-    border: 1px solid #8BE9FD;
-    border-radius: 8px;
+    border: 1px solid transparent;
+    background:
+        linear-gradient(#0a161b, #0a161b) padding-box,
+        linear-gradient(140deg, #8BE9FD, #1F5467 60%, rgba(31, 84, 103, 0.3)) border-box;
+    border-radius: 10px;
     padding: 1.5rem;
     margin-bottom: 1rem;
     gap: 1.5rem;
-    transition: transform 0.2s;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.3);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.screening-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.4), 0 0 20px rgba(139, 233, 253, 0.1);
 }
 
 .time-block {
@@ -772,7 +1075,7 @@ onMounted(async () => {
     min-width: 80px;
     border-right: 1px solid #333;
     padding-right: 1.5rem;
-    
+
     .time {
         font-size: 1.2rem;
         font-weight: 700;
@@ -789,37 +1092,50 @@ onMounted(async () => {
     display: flex;
     flex-direction: column;
     justify-content: center;
-    
+
     .film-title {
         font-size: 1.6rem;
         font-weight: 700;
         color: #fff;
         text-decoration: none;
         margin-bottom: 0.5rem;
-        
+
         &:hover {
             color: #8BE9FD;
         }
     }
-    
+
     .film-meta {
         font-size: 1.05rem;
         color: #aaa;
         margin-bottom: 0.8rem;
+    }
+
+    .venue-info {
+        font-size: 1.25rem;
+        color: #ccc;
+        margin-bottom: 0.8rem;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+
+        svg {
+            min-width: 18px;
+        }
     }
 }
 
 .tags {
     display: flex;
     gap: 0.5rem;
-    
+
     .tag {
         font-size: 0.75rem;
         padding: 4px 8px;
         border-radius: 4px;
         font-weight: 600;
         text-transform: uppercase;
-        
+
         &.in-person { background: rgba(52, 152, 219, 0.2); }
         &.online { background: rgba(46, 204, 113, 0.2); color: #2ecc71; }
         &.sold-out { background: rgba(231, 76, 60, 0.2); color: #e74c3c; }
@@ -829,7 +1145,7 @@ onMounted(async () => {
 .poster-mini {
     width: 60px;
     height: 90px;
-    
+
     img {
         width: 100%;
         height: 100%;
@@ -840,7 +1156,7 @@ onMounted(async () => {
 
 @media (max-width: 600px) {
     .screening-card {
-        flex-direction: column; 
+        flex-direction: column;
         gap: 1rem;
     }
     .time-block {
@@ -873,14 +1189,33 @@ onMounted(async () => {
 }
 
 .carousel-card {
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(139, 233, 253, 0.18);
+  position: relative;
+  background: rgba(3, 4, 6, 0.85);
+  background-image:
+    radial-gradient(circle at 15% 20%, rgba(31, 84, 103, 0.18), transparent 35%),
+    radial-gradient(circle at 85% 80%, rgba(139, 233, 253, 0.08), transparent 30%);
+  border: 1px solid rgba(31, 84, 103, 0.5);
   border-radius: 20px;
   padding: 2.2rem 2.5rem;
-  backdrop-filter: blur(12px);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
   color: rgba(255, 255, 255, 0.88);
   line-height: 1.8;
   min-height: 300px;
+  overflow: hidden;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5), inset 0 0 24px rgba(139, 233, 253, 0.04);
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: linear-gradient(90deg, transparent, #8BE9FD, #1F5467, transparent);
+    opacity: 0.85;
+    pointer-events: none;
+  }
 
   strong { color: #fff; }
 }
@@ -914,19 +1249,21 @@ onMounted(async () => {
   justify-content: center;
   width: 44px;
   height: 44px;
-  border-radius: 50%;
-  border: 1px solid rgba(139, 233, 253, 0.25);
-  background: rgba(0, 0, 0, 0.4);
+  border-radius: 12px;
+  border: 1px solid rgba(139, 233, 253, 0.4);
+  background: rgba(3, 4, 6, 0.75);
   color: #8BE9FD;
   cursor: pointer;
-  transition: all 0.25s ease;
+  transition: all 0.2s ease;
   flex-shrink: 0;
-  backdrop-filter: blur(6px);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
 
   &:hover {
-    background: rgba(139, 233, 253, 0.15);
-    border-color: #8BE9FD;
-    transform: scale(1.1);
+    background: #ffffff;
+    border-color: #ffffff;
+    color: #000;
+    transform: scale(1.05);
   }
 }
 
@@ -986,15 +1323,9 @@ onMounted(async () => {
   .price-value { color: #8BE9FD; font-weight: 700; font-size: 1.1rem; }
 }
 
-.promo-box {
-  background: rgba(139, 233, 253, 0.08);
-  border-left: 3px solid #8BE9FD;
-  border-radius: 8px;
-  padding: 1rem 1.2rem;
-  margin-top: 1rem;
-  position: relative;
-  .promo-tag { position: absolute; top: 0; right: 0; background: #8BE9FD; color: #000; font-size: 0.65rem; font-weight: 800; padding: 3px 10px; border-bottom-left-radius: 6px; }
-  p { margin: 0; font-size: 1rem; }
+.venue-list {
+  display: flex; flex-direction: column; gap: 0.5rem; margin: 0.5rem 0;
+  .venue-item { display: flex; justify-content: space-between; align-items: center; padding: 0.5rem 0; border-bottom: 1px solid rgba(255,255,255,0.05); span { color: rgba(255,255,255,0.5); font-size: 0.95rem; } strong { color: #fff; } }
 }
 
 .bullet-list {
@@ -1005,6 +1336,58 @@ onMounted(async () => {
 .accent-link {
   color: #8BE9FD; text-decoration: none; font-weight: 600; border-bottom: 1px solid transparent; transition: border-color 0.2s;
   &:hover { border-color: #8BE9FD; }
+}
+
+/* ── Initial-rollout banner (catalog/schedule placeholders) ─ */
+.rollout-banner {
+    display: flex;
+    gap: 1.25rem;
+    align-items: flex-start;
+    max-width: 720px;
+    margin: 2rem auto;
+    padding: 1.5rem 1.75rem;
+    background: rgba(16, 26, 35, 0.7);
+    border: 1px solid rgba(139, 233, 253, 0.22);
+    border-radius: 14px;
+    backdrop-filter: blur(8px);
+}
+
+.rollout-banner__icon {
+    flex-shrink: 0;
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    background: rgba(139, 233, 253, 0.08);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.rollout-banner__copy {
+    flex: 1;
+    color: rgba(255, 255, 255, 0.85);
+
+    h3 {
+        margin: 0 0 0.4rem;
+        font-size: 1.15rem;
+        font-weight: 700;
+        color: #8BE9FD;
+        letter-spacing: 0.3px;
+    }
+    p {
+        margin: 0;
+        font-size: 1rem;
+        line-height: 1.6;
+        color: rgba(255, 255, 255, 0.7);
+    }
+}
+
+@media (max-width: 600px) {
+    .rollout-banner {
+        flex-direction: column;
+        gap: 0.75rem;
+        padding: 1.25rem;
+    }
 }
 
 /* ── Schedule search toolbar ─────────────── */

--- a/pages/festival/slamdance-2026/index.vue
+++ b/pages/festival/slamdance-2026/index.vue
@@ -50,54 +50,79 @@
       </div>
 
       <div v-else>
-        <div v-if="activeTab === 'films'" class="films-grid">
-            <div v-if="features.length > 0" class="film-category">
-                <div class="category-header" @click="featuresOpen = !featuresOpen">
-                    <h2 class="listing__title category-title">
-                        Features
-                        <span class="category-count">({{ features.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="featuresOpen ? 'Collapse' : 'Expand'">
-                        <svg v-if="featuresOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
-                    </button>
-                </div>
-                <transition name="slide">
-                    <div v-show="featuresOpen" class="listing__items">
-                        <SlamdanceCard 
-                            v-for="item in features"
-                            :key="`feature-${item.id}`"
-                            :item="item" 
-                        />
-                    </div>
-                </transition>
+        <div v-if="activeTab === 'films'" class="selection">
+          <div v-if="orderedCategories.length === 0" class="rollout-banner">
+            <div class="rollout-banner__icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
             </div>
+            <div class="rollout-banner__copy">
+              <h3>Lineup updates in progress</h3>
+              <p>This festival lineup is currently being updated. New films, sections, and official selections will be added progressively as they are announced and verified.</p>
+            </div>
+          </div>
+          <div v-else class="selection-layout">
+            <aside class="selection-nav" aria-label="Jump to section">
+              <template v-if="officialNav.length">
+                <div class="nav-group-label">Catalog</div>
+                <button
+                  v-for="sec in officialNav"
+                  :key="sec.key"
+                  class="nav-item"
+                  :class="{ active: activeSection === sec.key }"
+                  @click="scrollToSection(sec.key)"
+                >
+                  <span class="nav-item-label">{{ sec.label }}</span>
+                  <span class="nav-item-count">{{ sec.count }}</span>
+                </button>
+              </template>
+            </aside>
 
-            <div v-if="shorts.length > 0" class="film-category">
-                <div class="category-header" @click="shortsOpen = !shortsOpen">
-                    <h2 class="listing__title category-title">
-                        Shorts
-                        <span class="category-count">({{ shorts.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="shortsOpen ? 'Collapse' : 'Expand'">
-                        <svg v-if="shortsOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
+            <div ref="selectionContentRef" class="selection-content">
+              <section
+                v-for="sec in selectionSections"
+                :key="sec.key"
+                :data-key="sec.key"
+                class="sel-section"
+              >
+                <div class="sel-section-header" @click="onSectionHeaderClick(sec.key)">
+                  <h2 class="sel-section-title">{{ sec.label }}</h2>
+                  <div class="sel-section-meta">
+                    <span class="sel-section-count">{{ sec.count }} {{ sec.count === 1 ? 'film' : 'films' }}</span>
+                    <button v-if="isMobile" class="expand-btn" :aria-label="isSectionOpen(sec.key) ? 'Collapse' : 'Expand'">
+                      <svg v-if="isSectionOpen(sec.key)" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
+                      <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
                     </button>
+                  </div>
                 </div>
                 <transition name="slide">
-                    <div v-show="shortsOpen" class="listing__items">
-                        <SlamdanceCard 
-                            v-for="item in shorts"
-                            :key="`short-${item.id}`"
-                            :item="item" 
-                        />
+                  <div v-show="!isMobile || isSectionOpen(sec.key)" class="sel-section-body">
+                    <div class="listing__items">
+                      <SlamdanceCard
+                        v-for="item in sec.films"
+                        :key="`${sec.key}-${item.id}`"
+                        :item="item"
+                      />
                     </div>
+                  </div>
                 </transition>
+              </section>
             </div>
+          </div>
         </div>
 
         <div v-if="activeTab === 'schedule'" class="schedule-container">
-          <div class="schedule-toolbar" :class="{ 'search-active': isScheduleSearchActive }">
+          <!-- Initial rollout banner: schedule pending official publication -->
+          <div v-if="schedule.length === 0" class="rollout-banner">
+            <div class="rollout-banner__icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+            </div>
+            <div class="rollout-banner__copy">
+              <h3>Schedule pending</h3>
+              <p>Official screening schedules have not yet been published by the festival. Screening information will appear here as soon as it becomes available.</p>
+            </div>
+          </div>
+
+          <div v-if="schedule.length > 0" class="schedule-toolbar" :class="{ 'search-active': isScheduleSearchActive }">
             <div class="schedule-toolbar-info">
               <span class="schedule-count" v-if="!loading">
                 <template v-if="scheduleSearchActiveQuery">
@@ -133,30 +158,48 @@
             <p>No screenings match "<strong>{{ scheduleSearch }}</strong>"</p>
           </div>
 
-          <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" class="schedule-day">
-            <div class="day-header" @click="toggleDay(date)">
+          <div v-if="scheduleDays.length" class="schedule-layout">
+            <aside class="schedule-nav" aria-label="Jump to day">
+              <div class="nav-group-label">Days</div>
+              <button
+                v-for="day in scheduleDays"
+                :key="day.date"
+                class="nav-item"
+                :class="{ active: activeDay === day.date }"
+                @click="scrollToDay(day.date)"
+              >
+                <span class="nav-item-label">{{ day.label }}</span>
+                <span class="nav-item-count">{{ day.count }}</span>
+              </button>
+            </aside>
+
+            <div ref="scheduleContentRef" class="schedule-content">
+              <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" :data-day="date" class="schedule-day">
+            <div class="day-header" @click="onDayHeaderClick(date)">
                 <h2>{{ formatDate(date) }}</h2>
-                <div class="chevron" :class="{ 'closed': !isOpen(date) }">
+                <div v-if="isMobile" class="chevron" :class="{ 'closed': !isOpen(date) }">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down"><path d="m6 9 6 6 6-6"/></svg>
                 </div>
             </div>
-            
+
             <transition name="slide">
-                <div v-show="isOpen(date)" class="screenings-list">
+                <div v-show="!isMobile || isOpen(date)" class="screenings-list">
                   <div v-for="screening in dayScreenings" :key="screening.id" class="screening-card">
                      <div class="time-block">
-                        <span class="time">{{ formatTime(screening.start_time) }}</span>
+                        <span class="time">{{ formatTime(screening.start_time, screening.timezone) }}</span>
                         <span class="timezone">{{ screening.timezone }}</span>
                      </div>
-                     
+
                       <div class="film-info">
-                         <a 
-                            href="https://slamdance.com/26-digital-program/"
-                            target="_blank"
+                         <component
+                            :is="screening.film.source_url ? 'a' : 'span'"
+                            :href="screening.film.source_url || ''"
+                            :target="screening.film.source_url ? '_blank' : ''"
                             class="film-title"
+                            :class="{'no-link': !screening.film.source_url}"
                          >
                             {{ screening.film.title }}
-                         </a>
+                         </component>
                          <div class="film-meta">
                              <span v-if="screening.film.director">Directed by {{ screening.film.director }}</span>
                              <span v-if="screening.film.director && screening.film.runtime"> • </span>
@@ -172,13 +215,13 @@
                              <span v-if="screening.is_sold_out" class="tag sold-out">Sold Out</span>
                          </div>
                       </div>
-                      
+
                       <div class="poster-mini">
-                          <img 
-                            v-if="screening.film.poster_path" 
-                            :src="screening.film.poster_path" 
-                            alt="Poster" 
-                            loading="lazy" 
+                          <img
+                            v-if="screening.film.poster_path"
+                            :src="screening.film.poster_path"
+                            alt="Poster"
+                            loading="lazy"
                             @error="$event.target.src = '/placeholders/image_not_found_yet.webp'"
                           />
                           <img v-else src="/placeholders/image_not_found_yet.webp" alt="No Poster" />
@@ -186,6 +229,8 @@
                   </div>
                 </div>
             </transition>
+          </div>
+            </div>
           </div>
         </div>
 
@@ -257,7 +302,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, nextTick } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount, nextTick, watch } from 'vue';
 import Loader from '~/components/Loader.vue';
 import WinnersCarousel from '~/components/festival/WinnersCarousel.vue';
 import FestivalDataDisclaimer from '~/components/FestivalDataDisclaimer.vue';
@@ -307,26 +352,107 @@ const awards = ref([]);
 const schedule = ref([]);
 const openDays = ref(new Set());
 
-const featuresOpen = ref(true);
-const shortsOpen = ref(true);
+const CATEGORY_ORDER = [
+    'Features',
+    'Shorts',
+];
 
-const features = computed(() => {
-    return films.value?.results?.filter(f => !f.runtime || f.runtime >= 40) || [];
-});
-
-const shorts = computed(() => {
-    return films.value?.results?.filter(f => f.runtime > 0 && f.runtime < 40) || [];
-});
-
-const formatDate = (dateStr) => {
-    const options = { weekday: 'long', month: 'long', day: 'numeric' };
-    return new Date(dateStr).toLocaleDateString('en-US', options);
+const CATEGORY_LABELS = {
+    Features: 'Features',
+    Shorts: 'Shorts',
+    OTHER: 'Other',
 };
 
-const formatTime = (timeStr) => {
-    return new Date(timeStr).toLocaleTimeString('en-US', { 
-        hour: '2-digit', 
-        minute: '2-digit'
+const categoryKeyForFilm = (film) => {
+    const explicit = String(film.category || film.section || '').trim();
+    if (CATEGORY_ORDER.includes(explicit)) return explicit;
+    if (film.runtime > 0 && film.runtime < 40) return 'Shorts';
+    return 'Features';
+};
+
+const activeSection = ref('');
+const selectionContentRef = ref(null);
+let sectionObserver = null;
+const isMobile = ref(false);
+let mobileMql = null;
+const sectionOpen = ref({});
+const isSectionOpen = (key) => sectionOpen.value[key] !== false;
+const toggleSection = (key) => { sectionOpen.value = { ...sectionOpen.value, [key]: !isSectionOpen(key) }; };
+const onSectionHeaderClick = (key) => { if (!isMobile.value) return; toggleSection(key); };
+const activeDay = ref('');
+const scheduleContentRef = ref(null);
+let dayObserver = null;
+
+const filmsByCategory = computed(() => {
+    const map = Object.fromEntries(CATEGORY_ORDER.map((c) => [c, []]));
+    map.OTHER = [];
+    for (const f of films.value?.results || []) {
+        const key = categoryKeyForFilm(f);
+        if (key && map[key] !== undefined) map[key].push(f);
+        else map.OTHER.push(f);
+    }
+    return map;
+});
+
+const orderedCategories = computed(() => {
+    const out = CATEGORY_ORDER.filter((c) => (filmsByCategory.value[c] || []).length > 0);
+    if ((filmsByCategory.value.OTHER || []).length > 0) out.push('OTHER');
+    return out;
+});
+
+function categoryLabel (cat) {
+    return CATEGORY_LABELS[cat] || cat;
+}
+
+const selectionSections = computed(() => orderedCategories.value.map((cat) => {
+    const items = filmsByCategory.value[cat] || [];
+    return { key: cat, label: categoryLabel(cat), films: items, count: items.length };
+}));
+const officialNav = computed(() => selectionSections.value);
+
+const scrollToSection = (key) => {
+    activeSection.value = key;
+    const root = selectionContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-key]');
+    for (const el of els) { if (el.getAttribute('data-key') === key) { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); break; } }
+};
+
+const setupSectionObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (sectionObserver) sectionObserver.disconnect();
+    const root = selectionContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-key]');
+    if (!els.length) return;
+    sectionObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) { if (entry.isIntersecting) activeSection.value = entry.target.getAttribute('data-key'); }
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => sectionObserver.observe(el));
+};
+
+watch(selectionSections, (sections) => {
+    if (!sections.length) return;
+    if (!sections.some((sec) => sec.key === activeSection.value)) activeSection.value = sections[0].key;
+}, { immediate: true });
+
+watch([loading, activeTab, selectionSections], () => {
+    if (!loading.value && activeTab.value === 'films') nextTick(() => setupSectionObserver());
+    else if (sectionObserver) sectionObserver.disconnect();
+}, { flush: 'post' });
+
+const FESTIVAL_TZ = 'America/Denver';
+
+const formatDate = (dateStr) => {
+    const options = { weekday: 'long', month: 'long', day: 'numeric', timeZone: 'UTC' };
+    return new Date(`${dateStr}T00:00:00Z`).toLocaleDateString('en-US', options);
+};
+
+const formatTime = (timeStr, tz) => {
+    return new Date(timeStr).toLocaleTimeString('en-US', {
+        hour: '2-digit',
+        minute: '2-digit',
+        timeZone: tz || FESTIVAL_TZ
     });
 };
 
@@ -357,17 +483,57 @@ const groupedScreenings = computed(() => {
 });
 
 const toggleDay = (date) => {
-    if (openDays.value.has(date)) {
-        openDays.value.delete(date);
-    } else {
-        openDays.value.add(date);
-    }
-}
+    if (openDays.value.has(date)) openDays.value.delete(date);
+    else openDays.value.add(date);
+};
 
 const isOpen = (date) => {
     if (scheduleSearchActiveQuery.value) return true;
     return openDays.value.has(date);
 };
+
+const scheduleDays = computed(() => Object.entries(groupedScreenings.value).map(([date, arr]) => ({ date, label: formatDate(date), count: arr.length })));
+const onDayHeaderClick = (date) => { if (!isMobile.value) return; toggleDay(date); };
+const scrollToDay = (date) => {
+    activeDay.value = date;
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-day]');
+    for (const el of els) { if (el.getAttribute('data-day') === date) { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); break; } }
+};
+const setupDayObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (dayObserver) dayObserver.disconnect();
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-day]');
+    if (!els.length) return;
+    dayObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) { if (entry.isIntersecting) activeDay.value = entry.target.getAttribute('data-day'); }
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => dayObserver.observe(el));
+};
+watch(scheduleDays, (days) => {
+    if (!days.length) return;
+    if (!days.some((d) => d.date === activeDay.value)) activeDay.value = days[0]?.date || '';
+}, { immediate: true });
+watch([loading, activeTab, scheduleDays], () => {
+    if (!loading.value && activeTab.value === 'schedule') nextTick(() => setupDayObserver());
+    else if (dayObserver) dayObserver.disconnect();
+}, { flush: 'post' });
+const updateIsMobile = (e) => { isMobile.value = e.matches; };
+onMounted(() => {
+    if (typeof window !== 'undefined' && window.matchMedia) {
+        mobileMql = window.matchMedia('(max-width: 900px)');
+        isMobile.value = mobileMql.matches;
+        mobileMql.addEventListener('change', updateIsMobile);
+    }
+});
+onBeforeUnmount(() => {
+    if (sectionObserver) sectionObserver.disconnect();
+    if (dayObserver) dayObserver.disconnect();
+    if (mobileMql) mobileMql.removeEventListener('change', updateIsMobile);
+});
 
 onMounted(async () => {
     try {
@@ -401,60 +567,156 @@ onMounted(async () => {
     font-size: 1.2rem;
 }
 
-.film-category {
-    margin-bottom: 2.5rem;
-}
-
-// Compact catalog cards (~25%+ smaller than global default).
-// Scoped to .films-grid so other listings (home, search, etc.) are untouched.
-// Uses :deep() because festival cards are child components (scoped CSS).
-.films-grid :deep(.listing__items > .card) {
-    width: 25%;
+// Poster sizing inside the Selection content column. The column is narrower than
+// the old full-bleed grid, so we use fewer columns / slightly larger posters.
+.selection :deep(.listing__items > .card) {
+    width: 33.3333%;
 
     @media (min-width: 640px) {
-        width: 20%;
+        width: 25%;
     }
     @media (min-width: 1024px) {
-        width: 14.2857143%;
+        width: 20%;
     }
     @media (min-width: 1500px) {
-        width: 12.5%;
+        width: 16.6666%;
     }
     @media (min-width: 1800px) {
-        width: 11.1111111%;
-    }
-    @media (min-width: 2500px) {
-        width: 10%;
+        width: 14.2857%;
     }
 }
 
 
 
-.category-header {
+/* ── Selection: sidebar scroll-spy + sections ───────────── */
+.selection-layout,
+.schedule-layout {
+    display: grid;
+    grid-template-columns: 330px minmax(0, 1fr);
+    gap: 2.5rem;
+    align-items: start;
+}
+
+/* Breathing room between the screenings search bar and the day list below it. */
+.schedule-layout {
+    margin-top: 1.75rem;
+}
+
+.selection-nav,
+.schedule-nav {
+    position: sticky;
+    top: 5.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-height: calc(100vh - 7rem);
+    overflow-y: auto;
+    padding: 1rem;
+    border: 1px solid transparent;
+    background:
+        linear-gradient(rgba(3, 6, 10, 0.85), rgba(3, 6, 10, 0.85)) padding-box,
+        linear-gradient(160deg, rgba(139, 233, 253, 0.55), rgba(31, 84, 103, 0.45) 60%, rgba(139, 233, 253, 0.16)) border-box;
+    border-radius: 14px;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
+}
+
+.nav-group-label {
+    font-size: 1rem;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    color: rgba(139, 233, 253, 0.9);
+    font-weight: 700;
+    margin: 1.2rem 0.4rem 0.55rem;
+
+    &:first-child {
+        margin-top: 0.2rem;
+    }
+}
+
+.nav-item {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 10px;
+    width: 100%;
+    background: none;
+    border: none;
+    border-left: 3px solid transparent;
+    border-radius: 0 8px 8px 0;
+    color: rgba(255, 255, 255, 0.88);
+    padding: 0.82rem 1rem;
+    font-size: 1.32rem;
+    font-family: inherit;
+    text-align: left;
     cursor: pointer;
-    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
-    padding-bottom: 5px;
-    margin-bottom: 15px;
-    transition: border-color 0.2s;
-    user-select: none;
-    
+    transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+
     &:hover {
-        border-color: rgba(139, 233, 253, 0.6);
+        background: rgba(139, 233, 253, 0.08);
+        color: #eafbff;
+    }
+
+    &.active {
+        background: rgba(139, 233, 253, 0.12);
+        color: #8BE9FD;
+        border-left-color: #8BE9FD;
+        font-weight: 600;
     }
 }
 
-.category-title {
-    margin: 0 !important;
+.nav-item-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
-.category-count {
-    font-size: 1.1rem;
-    color: rgba(255, 255, 255, 0.6);
-    margin-left: 10px;
-    font-weight: normal;
+.nav-item-count {
+    font-size: 1.12rem;
+    color: rgba(255, 255, 255, 0.62);
+    flex-shrink: 0;
+}
+
+.nav-item.active .nav-item-count {
+    color: rgba(139, 233, 253, 0.85);
+}
+
+.sel-section {
+    scroll-margin-top: 6.5rem;
+    margin-bottom: 3rem;
+}
+
+.sel-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
+    padding-bottom: 6px;
+    margin-bottom: 1.25rem;
+}
+
+.sel-section-title {
+    margin: 0;
+    font-size: 1.7rem;
+    font-weight: 700;
+    color: #fff;
+}
+
+.sel-section-meta {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-shrink: 0;
+}
+
+.sel-section-count {
+    font-size: 1.05rem;
+    color: rgba(255, 255, 255, 0.5);
+    white-space: nowrap;
+    flex-shrink: 0;
 }
 
 .expand-btn {
@@ -470,7 +732,7 @@ onMounted(async () => {
     cursor: pointer;
     transition: all 0.2s ease;
     flex-shrink: 0;
-    
+
     &:hover {
         background: rgba(139, 233, 253, 0.15);
         color: #8BE9FD;
@@ -483,6 +745,42 @@ onMounted(async () => {
         min-width: 20px;
         min-height: 20px;
         display: block;
+    }
+}
+
+.parallel-band {
+    font-size: 0.85rem;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: #8BE9FD;
+    border-top: 1px solid rgba(139, 233, 253, 0.25);
+    padding-top: 1.4rem;
+    margin: 0.5rem 0 1.5rem;
+}
+
+@media (max-width: 900px) {
+    .selection-layout,
+    .schedule-layout {
+        display: block;
+    }
+
+    .selection-nav,
+    .schedule-nav {
+        display: none;
+    }
+
+    .sel-section-header {
+        cursor: pointer;
+        user-select: none;
+        transition: border-color 0.2s;
+    }
+
+    .sel-section-header:hover {
+        border-color: rgba(139, 233, 253, 0.6);
+    }
+
+    .day-header {
+        cursor: pointer;
     }
 }
 
@@ -505,12 +803,16 @@ onMounted(async () => {
 .segmented-control {
     position: relative;
     display: flex;
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 20px; 
+    background: rgba(3, 4, 6, 0.6);
+    border: 1px solid rgba(139, 233, 253, 0.18);
+    border-radius: 16px;
     padding: 4px;
     height: 48px;
     align-items: center;
     min-width: 420px;
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
 }
 
 .segmented-control input[type="radio"] {
@@ -533,7 +835,7 @@ onMounted(async () => {
 }
 
 .segmented-control input:checked + label {
-    color: #000;
+    color: #02080d;
 }
 
 .segmented-control .glider {
@@ -542,9 +844,10 @@ onMounted(async () => {
     left: 4px;
     height: calc(100% - 8px);
     width: calc((100% - 8px) / 3);
-    background: #8BE9FD; 
-    border-radius: 16px;
+    background: linear-gradient(135deg, #8BE9FD, #5cc4d8);
+    border-radius: 12px;
     z-index: 1;
+    box-shadow: 0 4px 14px rgba(139, 233, 253, 0.3);
     transition: transform 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
 }
 
@@ -558,12 +861,15 @@ onMounted(async () => {
     max-width: 1200px;
     margin: 0 auto;
     position: relative;
-    border-radius: 15px;
+    border-radius: 16px;
     overflow: hidden;
-    background-color: transparent;
     display: flex;
     justify-content: center;
-    border: 1px solid #8BE9FD;
+    border: 2px solid transparent;
+    background:
+        linear-gradient(#02080d, #02080d) padding-box,
+        linear-gradient(140deg, #8BE9FD 0%, #1F5467 45%, rgba(31, 84, 103, 0.35) 100%) border-box;
+    box-shadow: 0 14px 36px rgba(0, 0, 0, 0.5), 0 0 30px rgba(139, 233, 253, 0.12);
 }
 
 .back-link {
@@ -593,7 +899,7 @@ onMounted(async () => {
         box-shadow: 0 8px 25px rgba(0,0,0,0.4);
         border-color: #fff;
     }
-    
+
     svg {
         width: 24px;
         height: 24px;
@@ -604,7 +910,7 @@ onMounted(async () => {
         left: 20px;
         font-size: 0.9rem;
         padding: 8px 16px;
-        
+
         svg {
             width: 18px;
             height: 18px;
@@ -612,58 +918,11 @@ onMounted(async () => {
     }
 }
 
-.buy-tickets-btn {
-    position: absolute;
-    top: 30px;
-    right: 30px;
-    z-index: 10;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    background: #8BE9FD;
-    color: #000;
-    padding: 12px 24px;
-    border-radius: 30px;
-    text-decoration: none;
-    font-weight: 700;
-    font-size: 1.1rem;
-    transition: transform 0.2s, opacity 0.2s;
-    backdrop-filter: blur(10px);
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    box-shadow: 0 4px 15px rgba(0,0,0,0.3);
-    
-    &:hover {
-        transform: translateY(-2px) scale(1.05);
-        box-shadow: 0 8px 25px rgba(0,0,0,0.4);
-        background: #fff;
-    }
-
-    &.sold-out {
-        background: rgba(100, 100, 100, 0.6);
-        color: #ddd;
-        border-color: #666;
-        cursor: not-allowed;
-        
-        &:hover {
-            transform: none;
-            background: rgba(100, 100, 100, 0.6);
-            box-shadow: 0 4px 15px rgba(0,0,0,0.3);
-        }
-    }
-    
-    @media (max-width: 768px) {
-        top: 20px;
-        right: 20px;
-        font-size: 0.9rem;
-        padding: 8px 16px;
-    }
-}
-
 .hero-backdrop {
     width: 100%;
     height: auto;
     position: relative;
-    
+
     img {
         width: 100%;
         height: auto;
@@ -717,21 +976,29 @@ onMounted(async () => {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    cursor: pointer;
+    cursor: default;
     user-select: none;
-    
+
     h2 {
         font-size: 1.8rem;
         margin: 0;
     }
-    
+
     .chevron {
         transition: transform 0.3s ease;
-        
+
         &.closed {
             transform: rotate(-90deg);
         }
     }
+}
+
+.schedule-day {
+    scroll-margin-top: 6.5rem;
+}
+
+.schedule-content > .schedule-day:first-child .day-header {
+    margin-top: 0;
 }
 
 .slide-enter-active,
@@ -751,13 +1018,21 @@ onMounted(async () => {
 
 .screening-card {
     display: flex;
-    background: #0a161b;
-    border: 1px solid #8BE9FD;
-    border-radius: 8px;
+    border: 1px solid transparent;
+    background:
+        linear-gradient(#0a161b, #0a161b) padding-box,
+        linear-gradient(140deg, #8BE9FD, #1F5467 60%, rgba(31, 84, 103, 0.3)) border-box;
+    border-radius: 10px;
     padding: 1.5rem;
     margin-bottom: 1rem;
     gap: 1.5rem;
-    transition: transform 0.2s;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.3);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.screening-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.4), 0 0 20px rgba(139, 233, 253, 0.1);
 }
 
 .time-block {
@@ -768,7 +1043,7 @@ onMounted(async () => {
     min-width: 80px;
     border-right: 1px solid #333;
     padding-right: 1.5rem;
-    
+
     .time {
         font-size: 1.2rem;
         font-weight: 700;
@@ -785,25 +1060,25 @@ onMounted(async () => {
     display: flex;
     flex-direction: column;
     justify-content: center;
-    
+
     .film-title {
         font-size: 1.6rem;
         font-weight: 700;
         color: #fff;
         text-decoration: none;
         margin-bottom: 0.5rem;
-        
+
         &:hover {
             color: #8BE9FD;
         }
     }
-    
+
     .film-meta {
         font-size: 1.05rem;
         color: #aaa;
         margin-bottom: 0.8rem;
     }
-    
+
     .venue-info {
         font-size: 1.25rem;
         color: #ccc;
@@ -811,7 +1086,7 @@ onMounted(async () => {
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        
+
         svg {
             min-width: 18px;
         }
@@ -821,14 +1096,14 @@ onMounted(async () => {
 .tags {
     display: flex;
     gap: 0.5rem;
-    
+
     .tag {
         font-size: 0.75rem;
         padding: 4px 8px;
         border-radius: 4px;
         font-weight: 600;
         text-transform: uppercase;
-        
+
         &.in-person { background: rgba(52, 152, 219, 0.2); }
         &.online { background: rgba(46, 204, 113, 0.2); color: #2ecc71; }
         &.sold-out { background: rgba(231, 76, 60, 0.2); color: #e74c3c; }
@@ -838,7 +1113,7 @@ onMounted(async () => {
 .poster-mini {
     width: 60px;
     height: 90px;
-    
+
     img {
         width: 100%;
         height: 100%;
@@ -849,7 +1124,7 @@ onMounted(async () => {
 
 @media (max-width: 600px) {
     .screening-card {
-        flex-direction: column; 
+        flex-direction: column;
         gap: 1rem;
     }
     .time-block {
@@ -882,14 +1157,33 @@ onMounted(async () => {
 }
 
 .carousel-card {
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(139, 233, 253, 0.18);
+  position: relative;
+  background: rgba(3, 4, 6, 0.85);
+  background-image:
+    radial-gradient(circle at 15% 20%, rgba(31, 84, 103, 0.18), transparent 35%),
+    radial-gradient(circle at 85% 80%, rgba(139, 233, 253, 0.08), transparent 30%);
+  border: 1px solid rgba(31, 84, 103, 0.5);
   border-radius: 20px;
   padding: 2.2rem 2.5rem;
-  backdrop-filter: blur(12px);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
   color: rgba(255, 255, 255, 0.88);
   line-height: 1.8;
   min-height: 300px;
+  overflow: hidden;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5), inset 0 0 24px rgba(139, 233, 253, 0.04);
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: linear-gradient(90deg, transparent, #8BE9FD, #1F5467, transparent);
+    opacity: 0.85;
+    pointer-events: none;
+  }
 
   strong { color: #fff; }
 }
@@ -923,19 +1217,21 @@ onMounted(async () => {
   justify-content: center;
   width: 44px;
   height: 44px;
-  border-radius: 50%;
-  border: 1px solid rgba(139, 233, 253, 0.25);
-  background: rgba(0, 0, 0, 0.4);
+  border-radius: 12px;
+  border: 1px solid rgba(139, 233, 253, 0.4);
+  background: rgba(3, 4, 6, 0.75);
   color: #8BE9FD;
   cursor: pointer;
-  transition: all 0.25s ease;
+  transition: all 0.2s ease;
   flex-shrink: 0;
-  backdrop-filter: blur(6px);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
 
   &:hover {
-    background: rgba(139, 233, 253, 0.15);
-    border-color: #8BE9FD;
-    transform: scale(1.1);
+    background: #ffffff;
+    border-color: #ffffff;
+    color: #000;
+    transform: scale(1.05);
   }
 }
 
@@ -1008,6 +1304,58 @@ onMounted(async () => {
 .accent-link {
   color: #8BE9FD; text-decoration: none; font-weight: 600; border-bottom: 1px solid transparent; transition: border-color 0.2s;
   &:hover { border-color: #8BE9FD; }
+}
+
+/* ── Initial-rollout banner (catalog/schedule placeholders) ─ */
+.rollout-banner {
+    display: flex;
+    gap: 1.25rem;
+    align-items: flex-start;
+    max-width: 720px;
+    margin: 2rem auto;
+    padding: 1.5rem 1.75rem;
+    background: rgba(16, 26, 35, 0.7);
+    border: 1px solid rgba(139, 233, 253, 0.22);
+    border-radius: 14px;
+    backdrop-filter: blur(8px);
+}
+
+.rollout-banner__icon {
+    flex-shrink: 0;
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    background: rgba(139, 233, 253, 0.08);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.rollout-banner__copy {
+    flex: 1;
+    color: rgba(255, 255, 255, 0.85);
+
+    h3 {
+        margin: 0 0 0.4rem;
+        font-size: 1.15rem;
+        font-weight: 700;
+        color: #8BE9FD;
+        letter-spacing: 0.3px;
+    }
+    p {
+        margin: 0;
+        font-size: 1rem;
+        line-height: 1.6;
+        color: rgba(255, 255, 255, 0.7);
+    }
+}
+
+@media (max-width: 600px) {
+    .rollout-banner {
+        flex-direction: column;
+        gap: 0.75rem;
+        padding: 1.25rem;
+    }
 }
 
 /* ── Schedule search toolbar ─────────────── */

--- a/pages/festival/sundance-2026/index.vue
+++ b/pages/festival/sundance-2026/index.vue
@@ -50,54 +50,79 @@
       </div>
 
       <div v-else>
-        <div v-if="activeTab === 'films'" class="films-grid">
-            <div v-if="features.length > 0" class="film-category">
-                <div class="category-header" @click="featuresOpen = !featuresOpen">
-                    <h2 class="listing__title category-title">
-                        Features
-                        <span class="category-count">({{ features.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="featuresOpen ? 'Collapse' : 'Expand'">
-                        <svg v-if="featuresOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
-                    </button>
-                </div>
-                <transition name="slide">
-                    <div v-show="featuresOpen" class="listing__items">
-                        <SundanceCard 
-                            v-for="item in features"
-                            :key="`feature-${item.id}`"
-                            :item="item" 
-                        />
-                    </div>
-                </transition>
+        <div v-if="activeTab === 'films'" class="selection">
+          <div v-if="orderedCategories.length === 0" class="rollout-banner">
+            <div class="rollout-banner__icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
             </div>
+            <div class="rollout-banner__copy">
+              <h3>Lineup updates in progress</h3>
+              <p>This festival lineup is currently being updated. New films, sections, and official selections will be added progressively as they are announced and verified.</p>
+            </div>
+          </div>
+          <div v-else class="selection-layout">
+            <aside class="selection-nav" aria-label="Jump to section">
+              <template v-if="officialNav.length">
+                <div class="nav-group-label">Catalog</div>
+                <button
+                  v-for="sec in officialNav"
+                  :key="sec.key"
+                  class="nav-item"
+                  :class="{ active: activeSection === sec.key }"
+                  @click="scrollToSection(sec.key)"
+                >
+                  <span class="nav-item-label">{{ sec.label }}</span>
+                  <span class="nav-item-count">{{ sec.count }}</span>
+                </button>
+              </template>
+            </aside>
 
-            <div v-if="shorts.length > 0" class="film-category">
-                <div class="category-header" @click="shortsOpen = !shortsOpen">
-                    <h2 class="listing__title category-title">
-                        Shorts
-                        <span class="category-count">({{ shorts.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="shortsOpen ? 'Collapse' : 'Expand'">
-                        <svg v-if="shortsOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
+            <div ref="selectionContentRef" class="selection-content">
+              <section
+                v-for="sec in selectionSections"
+                :key="sec.key"
+                :data-key="sec.key"
+                class="sel-section"
+              >
+                <div class="sel-section-header" @click="onSectionHeaderClick(sec.key)">
+                  <h2 class="sel-section-title">{{ sec.label }}</h2>
+                  <div class="sel-section-meta">
+                    <span class="sel-section-count">{{ sec.count }} {{ sec.count === 1 ? 'film' : 'films' }}</span>
+                    <button v-if="isMobile" class="expand-btn" :aria-label="isSectionOpen(sec.key) ? 'Collapse' : 'Expand'">
+                      <svg v-if="isSectionOpen(sec.key)" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
+                      <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
                     </button>
+                  </div>
                 </div>
                 <transition name="slide">
-                    <div v-show="shortsOpen" class="listing__items">
-                        <SundanceCard 
-                            v-for="item in shorts"
-                            :key="`short-${item.id}`"
-                            :item="item" 
-                        />
+                  <div v-show="!isMobile || isSectionOpen(sec.key)" class="sel-section-body">
+                    <div class="listing__items">
+                      <SundanceCard
+                        v-for="item in sec.films"
+                        :key="`${sec.key}-${item.id}`"
+                        :item="item"
+                      />
                     </div>
+                  </div>
                 </transition>
+              </section>
             </div>
+          </div>
         </div>
 
         <div v-if="activeTab === 'schedule'" class="schedule-container">
-          <div class="schedule-toolbar" :class="{ 'search-active': isScheduleSearchActive }">
+          <!-- Initial rollout banner: schedule pending official publication -->
+          <div v-if="schedule.length === 0" class="rollout-banner">
+            <div class="rollout-banner__icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+            </div>
+            <div class="rollout-banner__copy">
+              <h3>Schedule pending</h3>
+              <p>Official screening schedules have not yet been published by the festival. Screening information will appear here as soon as it becomes available.</p>
+            </div>
+          </div>
+
+          <div v-if="schedule.length > 0" class="schedule-toolbar" :class="{ 'search-active': isScheduleSearchActive }">
             <div class="schedule-toolbar-info">
               <span class="schedule-count" v-if="!loading">
                 <template v-if="scheduleSearchActiveQuery">
@@ -133,24 +158,40 @@
             <p>No screenings match "<strong>{{ scheduleSearch }}</strong>"</p>
           </div>
 
-          <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" class="schedule-day">
-            <div class="day-header" @click="toggleDay(date)">
+          <div v-if="scheduleDays.length" class="schedule-layout">
+            <aside class="schedule-nav" aria-label="Jump to day">
+              <div class="nav-group-label">Days</div>
+              <button
+                v-for="day in scheduleDays"
+                :key="day.date"
+                class="nav-item"
+                :class="{ active: activeDay === day.date }"
+                @click="scrollToDay(day.date)"
+              >
+                <span class="nav-item-label">{{ day.label }}</span>
+                <span class="nav-item-count">{{ day.count }}</span>
+              </button>
+            </aside>
+
+            <div ref="scheduleContentRef" class="schedule-content">
+              <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" :data-day="date" class="schedule-day">
+            <div class="day-header" @click="onDayHeaderClick(date)">
                 <h2>{{ formatDate(date) }}</h2>
-                <div class="chevron" :class="{ 'closed': !isOpen(date) }">
+                <div v-if="isMobile" class="chevron" :class="{ 'closed': !isOpen(date) }">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down"><path d="m6 9 6 6 6-6"/></svg>
                 </div>
             </div>
-            
+
             <transition name="slide">
-                <div v-show="isOpen(date)" class="screenings-list">
+                <div v-show="!isMobile || isOpen(date)" class="screenings-list">
                   <div v-for="screening in dayScreenings" :key="screening.id" class="screening-card">
                      <div class="time-block">
-                        <span class="time">{{ formatTime(screening.start_time) }}</span>
+                        <span class="time">{{ formatTime(screening.start_time, screening.timezone) }}</span>
                         <span class="timezone">{{ screening.timezone }}</span>
                      </div>
-                     
+
                       <div class="film-info">
-                         <component 
+                         <component
                             :is="screening.film.source_url ? 'a' : 'span'"
                             :href="screening.film.source_url || ''"
                             :target="screening.film.source_url ? '_blank' : ''"
@@ -164,19 +205,23 @@
                              <span v-if="screening.film.director && screening.film.runtime"> • </span>
                              <span v-if="screening.film.runtime">{{ screening.film.runtime }} min</span>
                          </div>
+                         <div v-if="screening.venue" class="venue-info">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-map-pin"><path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"/><circle cx="12" cy="10" r="3"/></svg>
+                            {{ screening.venue }}
+                         </div>
                          <div class="tags">
                              <span v-if="screening.is_in_person" class="tag in-person">In Person</span>
                              <span v-if="screening.is_online" class="tag online">Online</span>
                              <span v-if="screening.is_sold_out" class="tag sold-out">Sold Out</span>
                          </div>
                       </div>
-                      
+
                       <div class="poster-mini">
-                          <img 
-                            v-if="screening.film.poster_path" 
-                            :src="screening.film.poster_path" 
-                            alt="Poster" 
-                            loading="lazy" 
+                          <img
+                            v-if="screening.film.poster_path"
+                            :src="screening.film.poster_path"
+                            alt="Poster"
+                            loading="lazy"
                             @error="$event.target.src = '/placeholders/image_not_found_yet.webp'"
                           />
                           <img v-else src="/placeholders/image_not_found_yet.webp" alt="No Poster" />
@@ -184,6 +229,8 @@
                   </div>
                 </div>
             </transition>
+          </div>
+            </div>
           </div>
         </div>
 
@@ -260,7 +307,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, nextTick } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount, nextTick, watch } from 'vue';
 import Loader from '~/components/Loader.vue';
 import WinnersCarousel from '~/components/festival/WinnersCarousel.vue';
 import FestivalDataDisclaimer from '~/components/FestivalDataDisclaimer.vue';
@@ -310,24 +357,108 @@ const awards = ref([]);
 const schedule = ref([]);
 const openDays = ref(new Set());
 
-const featuresOpen = ref(true);
-const shortsOpen = ref(true);
+const CATEGORY_ORDER = [
+    'Features',
+    'Shorts',
+];
 
-const features = computed(() => {
-    return films.value?.results?.filter(f => !f.runtime || f.runtime >= 40) || [];
-});
-
-const shorts = computed(() => {
-    return films.value?.results?.filter(f => f.runtime > 0 && f.runtime < 40) || [];
-});
-
-const formatDate = (dateStr) => {
-    const options = { weekday: 'long', month: 'long', day: 'numeric' };
-    return new Date(dateStr).toLocaleDateString('en-US', options);
+const CATEGORY_LABELS = {
+    Features: 'Features',
+    Shorts: 'Shorts',
+    OTHER: 'Other',
 };
 
-const formatTime = (timeStr) => {
-    return new Date(timeStr).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
+const categoryKeyForFilm = (film) => {
+    const explicit = String(film.category || film.section || '').trim();
+    if (CATEGORY_ORDER.includes(explicit)) return explicit;
+    if (film.runtime > 0 && film.runtime < 40) return 'Shorts';
+    return 'Features';
+};
+
+const activeSection = ref('');
+const selectionContentRef = ref(null);
+let sectionObserver = null;
+const isMobile = ref(false);
+let mobileMql = null;
+const sectionOpen = ref({});
+const isSectionOpen = (key) => sectionOpen.value[key] !== false;
+const toggleSection = (key) => { sectionOpen.value = { ...sectionOpen.value, [key]: !isSectionOpen(key) }; };
+const onSectionHeaderClick = (key) => { if (!isMobile.value) return; toggleSection(key); };
+const activeDay = ref('');
+const scheduleContentRef = ref(null);
+let dayObserver = null;
+
+const filmsByCategory = computed(() => {
+    const map = Object.fromEntries(CATEGORY_ORDER.map((c) => [c, []]));
+    map.OTHER = [];
+    for (const f of films.value?.results || []) {
+        const key = categoryKeyForFilm(f);
+        if (key && map[key] !== undefined) map[key].push(f);
+        else map.OTHER.push(f);
+    }
+    return map;
+});
+
+const orderedCategories = computed(() => {
+    const out = CATEGORY_ORDER.filter((c) => (filmsByCategory.value[c] || []).length > 0);
+    if ((filmsByCategory.value.OTHER || []).length > 0) out.push('OTHER');
+    return out;
+});
+
+function categoryLabel (cat) {
+    return CATEGORY_LABELS[cat] || cat;
+}
+
+const selectionSections = computed(() => orderedCategories.value.map((cat) => {
+    const items = filmsByCategory.value[cat] || [];
+    return { key: cat, label: categoryLabel(cat), films: items, count: items.length };
+}));
+const officialNav = computed(() => selectionSections.value);
+
+const scrollToSection = (key) => {
+    activeSection.value = key;
+    const root = selectionContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-key]');
+    for (const el of els) { if (el.getAttribute('data-key') === key) { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); break; } }
+};
+
+const setupSectionObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (sectionObserver) sectionObserver.disconnect();
+    const root = selectionContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-key]');
+    if (!els.length) return;
+    sectionObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) { if (entry.isIntersecting) activeSection.value = entry.target.getAttribute('data-key'); }
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => sectionObserver.observe(el));
+};
+
+watch(selectionSections, (sections) => {
+    if (!sections.length) return;
+    if (!sections.some((sec) => sec.key === activeSection.value)) activeSection.value = sections[0].key;
+}, { immediate: true });
+
+watch([loading, activeTab, selectionSections], () => {
+    if (!loading.value && activeTab.value === 'films') nextTick(() => setupSectionObserver());
+    else if (sectionObserver) sectionObserver.disconnect();
+}, { flush: 'post' });
+
+const FESTIVAL_TZ = 'America/Denver';
+
+const formatDate = (dateStr) => {
+    const options = { weekday: 'long', month: 'long', day: 'numeric', timeZone: 'UTC' };
+    return new Date(`${dateStr}T00:00:00Z`).toLocaleDateString('en-US', options);
+};
+
+const formatTime = (timeStr, tz) => {
+    return new Date(timeStr).toLocaleTimeString('en-US', {
+        hour: '2-digit',
+        minute: '2-digit',
+        timeZone: tz || FESTIVAL_TZ
+    });
 };
 
 const filteredSchedule = computed(() => {
@@ -357,17 +488,57 @@ const groupedScreenings = computed(() => {
 });
 
 const toggleDay = (date) => {
-    if (openDays.value.has(date)) {
-        openDays.value.delete(date);
-    } else {
-        openDays.value.add(date);
-    }
-}
+    if (openDays.value.has(date)) openDays.value.delete(date);
+    else openDays.value.add(date);
+};
 
 const isOpen = (date) => {
     if (scheduleSearchActiveQuery.value) return true;
     return openDays.value.has(date);
 };
+
+const scheduleDays = computed(() => Object.entries(groupedScreenings.value).map(([date, arr]) => ({ date, label: formatDate(date), count: arr.length })));
+const onDayHeaderClick = (date) => { if (!isMobile.value) return; toggleDay(date); };
+const scrollToDay = (date) => {
+    activeDay.value = date;
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-day]');
+    for (const el of els) { if (el.getAttribute('data-day') === date) { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); break; } }
+};
+const setupDayObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (dayObserver) dayObserver.disconnect();
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-day]');
+    if (!els.length) return;
+    dayObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) { if (entry.isIntersecting) activeDay.value = entry.target.getAttribute('data-day'); }
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => dayObserver.observe(el));
+};
+watch(scheduleDays, (days) => {
+    if (!days.length) return;
+    if (!days.some((d) => d.date === activeDay.value)) activeDay.value = days[0]?.date || '';
+}, { immediate: true });
+watch([loading, activeTab, scheduleDays], () => {
+    if (!loading.value && activeTab.value === 'schedule') nextTick(() => setupDayObserver());
+    else if (dayObserver) dayObserver.disconnect();
+}, { flush: 'post' });
+const updateIsMobile = (e) => { isMobile.value = e.matches; };
+onMounted(() => {
+    if (typeof window !== 'undefined' && window.matchMedia) {
+        mobileMql = window.matchMedia('(max-width: 900px)');
+        isMobile.value = mobileMql.matches;
+        mobileMql.addEventListener('change', updateIsMobile);
+    }
+});
+onBeforeUnmount(() => {
+    if (sectionObserver) sectionObserver.disconnect();
+    if (dayObserver) dayObserver.disconnect();
+    if (mobileMql) mobileMql.removeEventListener('change', updateIsMobile);
+});
 
 onMounted(async () => {
     try {
@@ -401,60 +572,156 @@ onMounted(async () => {
     font-size: 1.2rem;
 }
 
-.film-category {
-    margin-bottom: 2.5rem;
-}
-
-// Compact catalog cards (~25%+ smaller than global default).
-// Scoped to .films-grid so other listings (home, search, etc.) are untouched.
-// Uses :deep() because festival cards are child components (scoped CSS).
-.films-grid :deep(.listing__items > .card) {
-    width: 25%;
+// Poster sizing inside the Selection content column. The column is narrower than
+// the old full-bleed grid, so we use fewer columns / slightly larger posters.
+.selection :deep(.listing__items > .card) {
+    width: 33.3333%;
 
     @media (min-width: 640px) {
-        width: 20%;
+        width: 25%;
     }
     @media (min-width: 1024px) {
-        width: 14.2857143%;
+        width: 20%;
     }
     @media (min-width: 1500px) {
-        width: 12.5%;
+        width: 16.6666%;
     }
     @media (min-width: 1800px) {
-        width: 11.1111111%;
-    }
-    @media (min-width: 2500px) {
-        width: 10%;
+        width: 14.2857%;
     }
 }
 
 
 
-.category-header {
+/* ── Selection: sidebar scroll-spy + sections ───────────── */
+.selection-layout,
+.schedule-layout {
+    display: grid;
+    grid-template-columns: 330px minmax(0, 1fr);
+    gap: 2.5rem;
+    align-items: start;
+}
+
+/* Breathing room between the screenings search bar and the day list below it. */
+.schedule-layout {
+    margin-top: 1.75rem;
+}
+
+.selection-nav,
+.schedule-nav {
+    position: sticky;
+    top: 5.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-height: calc(100vh - 7rem);
+    overflow-y: auto;
+    padding: 1rem;
+    border: 1px solid transparent;
+    background:
+        linear-gradient(rgba(3, 6, 10, 0.85), rgba(3, 6, 10, 0.85)) padding-box,
+        linear-gradient(160deg, rgba(139, 233, 253, 0.55), rgba(31, 84, 103, 0.45) 60%, rgba(139, 233, 253, 0.16)) border-box;
+    border-radius: 14px;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
+}
+
+.nav-group-label {
+    font-size: 1rem;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    color: rgba(139, 233, 253, 0.9);
+    font-weight: 700;
+    margin: 1.2rem 0.4rem 0.55rem;
+
+    &:first-child {
+        margin-top: 0.2rem;
+    }
+}
+
+.nav-item {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 10px;
+    width: 100%;
+    background: none;
+    border: none;
+    border-left: 3px solid transparent;
+    border-radius: 0 8px 8px 0;
+    color: rgba(255, 255, 255, 0.88);
+    padding: 0.82rem 1rem;
+    font-size: 1.32rem;
+    font-family: inherit;
+    text-align: left;
     cursor: pointer;
-    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
-    padding-bottom: 5px;
-    margin-bottom: 15px;
-    transition: border-color 0.2s;
-    user-select: none;
-    
+    transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+
     &:hover {
-        border-color: rgba(139, 233, 253, 0.6);
+        background: rgba(139, 233, 253, 0.08);
+        color: #eafbff;
+    }
+
+    &.active {
+        background: rgba(139, 233, 253, 0.12);
+        color: #8BE9FD;
+        border-left-color: #8BE9FD;
+        font-weight: 600;
     }
 }
 
-.category-title {
-    margin: 0 !important;
+.nav-item-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
-.category-count {
-    font-size: 1.1rem;
-    color: rgba(255, 255, 255, 0.6);
-    margin-left: 10px;
-    font-weight: normal;
+.nav-item-count {
+    font-size: 1.12rem;
+    color: rgba(255, 255, 255, 0.62);
+    flex-shrink: 0;
+}
+
+.nav-item.active .nav-item-count {
+    color: rgba(139, 233, 253, 0.85);
+}
+
+.sel-section {
+    scroll-margin-top: 6.5rem;
+    margin-bottom: 3rem;
+}
+
+.sel-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
+    padding-bottom: 6px;
+    margin-bottom: 1.25rem;
+}
+
+.sel-section-title {
+    margin: 0;
+    font-size: 1.7rem;
+    font-weight: 700;
+    color: #fff;
+}
+
+.sel-section-meta {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-shrink: 0;
+}
+
+.sel-section-count {
+    font-size: 1.05rem;
+    color: rgba(255, 255, 255, 0.5);
+    white-space: nowrap;
+    flex-shrink: 0;
 }
 
 .expand-btn {
@@ -470,7 +737,7 @@ onMounted(async () => {
     cursor: pointer;
     transition: all 0.2s ease;
     flex-shrink: 0;
-    
+
     &:hover {
         background: rgba(139, 233, 253, 0.15);
         color: #8BE9FD;
@@ -483,6 +750,42 @@ onMounted(async () => {
         min-width: 20px;
         min-height: 20px;
         display: block;
+    }
+}
+
+.parallel-band {
+    font-size: 0.85rem;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: #8BE9FD;
+    border-top: 1px solid rgba(139, 233, 253, 0.25);
+    padding-top: 1.4rem;
+    margin: 0.5rem 0 1.5rem;
+}
+
+@media (max-width: 900px) {
+    .selection-layout,
+    .schedule-layout {
+        display: block;
+    }
+
+    .selection-nav,
+    .schedule-nav {
+        display: none;
+    }
+
+    .sel-section-header {
+        cursor: pointer;
+        user-select: none;
+        transition: border-color 0.2s;
+    }
+
+    .sel-section-header:hover {
+        border-color: rgba(139, 233, 253, 0.6);
+    }
+
+    .day-header {
+        cursor: pointer;
     }
 }
 
@@ -502,39 +805,19 @@ onMounted(async () => {
     align-items: center;
 }
 
-.buy-tickets-btn {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    background: #8BE9FD;
-    color: #000;
-    padding: 0 20px;
-    height: 40px;
-    border-radius: 16px;
-    text-decoration: none;
-    font-weight: 700;
-    font-size: 1.1rem;
-    transition: transform 0.2s, opacity 0.2s;
-    
-    &:hover {
-        transform: scale(1.05);
-        opacity: 0.9;
-    }
-    
-    span {
-        white-space: nowrap;
-    }
-}
-
 .segmented-control {
     position: relative;
     display: flex;
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 20px; 
+    background: rgba(3, 4, 6, 0.6);
+    border: 1px solid rgba(139, 233, 253, 0.18);
+    border-radius: 16px;
     padding: 4px;
     height: 48px;
     align-items: center;
     min-width: 420px;
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
 }
 
 .segmented-control input[type="radio"] {
@@ -557,7 +840,7 @@ onMounted(async () => {
 }
 
 .segmented-control input:checked + label {
-    color: #000;
+    color: #02080d;
 }
 
 .segmented-control .glider {
@@ -566,9 +849,10 @@ onMounted(async () => {
     left: 4px;
     height: calc(100% - 8px);
     width: calc((100% - 8px) / 3);
-    background: #8BE9FD;
-    border-radius: 16px;
+    background: linear-gradient(135deg, #8BE9FD, #5cc4d8);
+    border-radius: 12px;
     z-index: 1;
+    box-shadow: 0 4px 14px rgba(139, 233, 253, 0.3);
     transition: transform 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
 }
 
@@ -582,12 +866,15 @@ onMounted(async () => {
     max-width: 1200px;
     margin: 0 auto;
     position: relative;
-    border-radius: 15px;
+    border-radius: 16px;
     overflow: hidden;
-    background-color: transparent;
     display: flex;
     justify-content: center;
-    border: 1px solid #8BE9FD;
+    border: 2px solid transparent;
+    background:
+        linear-gradient(#02080d, #02080d) padding-box,
+        linear-gradient(140deg, #8BE9FD 0%, #1F5467 45%, rgba(31, 84, 103, 0.35) 100%) border-box;
+    box-shadow: 0 14px 36px rgba(0, 0, 0, 0.5), 0 0 30px rgba(139, 233, 253, 0.12);
 }
 
 .back-link {
@@ -617,7 +904,7 @@ onMounted(async () => {
         box-shadow: 0 8px 25px rgba(0,0,0,0.4);
         border-color: #fff;
     }
-    
+
     svg {
         width: 24px;
         height: 24px;
@@ -628,7 +915,7 @@ onMounted(async () => {
         left: 20px;
         font-size: 0.9rem;
         padding: 8px 16px;
-        
+
         svg {
             width: 18px;
             height: 18px;
@@ -640,7 +927,7 @@ onMounted(async () => {
     width: 100%;
     height: auto;
     position: relative;
-    
+
     img {
         width: 100%;
         height: auto;
@@ -694,21 +981,29 @@ onMounted(async () => {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    cursor: pointer;
+    cursor: default;
     user-select: none;
-    
+
     h2 {
         font-size: 1.8rem;
         margin: 0;
     }
-    
+
     .chevron {
         transition: transform 0.3s ease;
-        
+
         &.closed {
             transform: rotate(-90deg);
         }
     }
+}
+
+.schedule-day {
+    scroll-margin-top: 6.5rem;
+}
+
+.schedule-content > .schedule-day:first-child .day-header {
+    margin-top: 0;
 }
 
 .slide-enter-active,
@@ -728,13 +1023,21 @@ onMounted(async () => {
 
 .screening-card {
     display: flex;
-    background: #0a161b;
-    border: 1px solid #8BE9FD;
-    border-radius: 8px;
+    border: 1px solid transparent;
+    background:
+        linear-gradient(#0a161b, #0a161b) padding-box,
+        linear-gradient(140deg, #8BE9FD, #1F5467 60%, rgba(31, 84, 103, 0.3)) border-box;
+    border-radius: 10px;
     padding: 1.5rem;
     margin-bottom: 1rem;
     gap: 1.5rem;
-    transition: transform 0.2s;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.3);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.screening-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.4), 0 0 20px rgba(139, 233, 253, 0.1);
 }
 
 .time-block {
@@ -745,7 +1048,7 @@ onMounted(async () => {
     min-width: 80px;
     border-right: 1px solid #333;
     padding-right: 1.5rem;
-    
+
     .time {
         font-size: 1.2rem;
         font-weight: 700;
@@ -762,37 +1065,50 @@ onMounted(async () => {
     display: flex;
     flex-direction: column;
     justify-content: center;
-    
+
     .film-title {
         font-size: 1.6rem;
         font-weight: 700;
         color: #fff;
         text-decoration: none;
         margin-bottom: 0.5rem;
-        
+
         &:hover {
             color: #8BE9FD;
         }
     }
-    
+
     .film-meta {
         font-size: 1.05rem;
         color: #aaa;
         margin-bottom: 0.8rem;
+    }
+
+    .venue-info {
+        font-size: 1.25rem;
+        color: #ccc;
+        margin-bottom: 0.8rem;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+
+        svg {
+            min-width: 18px;
+        }
     }
 }
 
 .tags {
     display: flex;
     gap: 0.5rem;
-    
+
     .tag {
         font-size: 0.75rem;
         padding: 4px 8px;
         border-radius: 4px;
         font-weight: 600;
         text-transform: uppercase;
-        
+
         &.in-person { background: rgba(52, 152, 219, 0.2); }
         &.online { background: rgba(46, 204, 113, 0.2); color: #2ecc71; }
         &.sold-out { background: rgba(231, 76, 60, 0.2); color: #e74c3c; }
@@ -802,7 +1118,7 @@ onMounted(async () => {
 .poster-mini {
     width: 60px;
     height: 90px;
-    
+
     img {
         width: 100%;
         height: 100%;
@@ -813,7 +1129,7 @@ onMounted(async () => {
 
 @media (max-width: 600px) {
     .screening-card {
-        flex-direction: column; 
+        flex-direction: column;
         gap: 1rem;
     }
     .time-block {
@@ -846,14 +1162,33 @@ onMounted(async () => {
 }
 
 .carousel-card {
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(139, 233, 253, 0.18);
+  position: relative;
+  background: rgba(3, 4, 6, 0.85);
+  background-image:
+    radial-gradient(circle at 15% 20%, rgba(31, 84, 103, 0.18), transparent 35%),
+    radial-gradient(circle at 85% 80%, rgba(139, 233, 253, 0.08), transparent 30%);
+  border: 1px solid rgba(31, 84, 103, 0.5);
   border-radius: 20px;
   padding: 2.2rem 2.5rem;
-  backdrop-filter: blur(12px);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
   color: rgba(255, 255, 255, 0.88);
   line-height: 1.8;
   min-height: 300px;
+  overflow: hidden;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5), inset 0 0 24px rgba(139, 233, 253, 0.04);
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: linear-gradient(90deg, transparent, #8BE9FD, #1F5467, transparent);
+    opacity: 0.85;
+    pointer-events: none;
+  }
 
   strong { color: #fff; }
 }
@@ -887,19 +1222,21 @@ onMounted(async () => {
   justify-content: center;
   width: 44px;
   height: 44px;
-  border-radius: 50%;
-  border: 1px solid rgba(139, 233, 253, 0.25);
-  background: rgba(0, 0, 0, 0.4);
+  border-radius: 12px;
+  border: 1px solid rgba(139, 233, 253, 0.4);
+  background: rgba(3, 4, 6, 0.75);
   color: #8BE9FD;
   cursor: pointer;
-  transition: all 0.25s ease;
+  transition: all 0.2s ease;
   flex-shrink: 0;
-  backdrop-filter: blur(6px);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
 
   &:hover {
-    background: rgba(139, 233, 253, 0.15);
-    border-color: #8BE9FD;
-    transform: scale(1.1);
+    background: #ffffff;
+    border-color: #ffffff;
+    color: #000;
+    transform: scale(1.05);
   }
 }
 
@@ -951,6 +1288,7 @@ onMounted(async () => {
   .carousel-arrow svg { width: 18px; height: 18px; }
 }
 
+/* ── Shared card content styles ───────────── */
 .price-list {
   list-style: none; padding: 0; margin: 1rem 0;
   li { display: flex; justify-content: space-between; align-items: center; padding: 0.65rem 0; border-bottom: 1px dashed rgba(255,255,255,0.08); &:last-child { border: none; } }
@@ -959,12 +1297,8 @@ onMounted(async () => {
 }
 
 .venue-list {
-  display: grid; grid-template-columns: repeat(2, 1fr); gap: 0.9rem;
-  @media (max-width: 600px) { grid-template-columns: 1fr; }
-  .venue-item { font-size: 0.98rem; padding: 0.7rem 0.9rem; background: rgba(255,255,255,0.04); border-radius: 10px; border: 1px solid rgba(255,255,255,0.06);
-    strong { color: #8BE9FD; display: block; margin-bottom: 3px; font-size: 1.02rem; }
-    span { color: rgba(255,255,255,0.7); }
-  }
+  display: flex; flex-direction: column; gap: 0.5rem; margin: 0.5rem 0;
+  .venue-item { display: flex; justify-content: space-between; align-items: center; padding: 0.5rem 0; border-bottom: 1px solid rgba(255,255,255,0.05); span { color: rgba(255,255,255,0.5); font-size: 0.95rem; } strong { color: #fff; } }
 }
 
 .bullet-list {
@@ -975,6 +1309,58 @@ onMounted(async () => {
 .accent-link {
   color: #8BE9FD; text-decoration: none; font-weight: 600; border-bottom: 1px solid transparent; transition: border-color 0.2s;
   &:hover { border-color: #8BE9FD; }
+}
+
+/* ── Initial-rollout banner (catalog/schedule placeholders) ─ */
+.rollout-banner {
+    display: flex;
+    gap: 1.25rem;
+    align-items: flex-start;
+    max-width: 720px;
+    margin: 2rem auto;
+    padding: 1.5rem 1.75rem;
+    background: rgba(16, 26, 35, 0.7);
+    border: 1px solid rgba(139, 233, 253, 0.22);
+    border-radius: 14px;
+    backdrop-filter: blur(8px);
+}
+
+.rollout-banner__icon {
+    flex-shrink: 0;
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    background: rgba(139, 233, 253, 0.08);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.rollout-banner__copy {
+    flex: 1;
+    color: rgba(255, 255, 255, 0.85);
+
+    h3 {
+        margin: 0 0 0.4rem;
+        font-size: 1.15rem;
+        font-weight: 700;
+        color: #8BE9FD;
+        letter-spacing: 0.3px;
+    }
+    p {
+        margin: 0;
+        font-size: 1rem;
+        line-height: 1.6;
+        color: rgba(255, 255, 255, 0.7);
+    }
+}
+
+@media (max-width: 600px) {
+    .rollout-banner {
+        flex-direction: column;
+        gap: 0.75rem;
+        padding: 1.25rem;
+    }
 }
 
 /* ── Schedule search toolbar ─────────────── */

--- a/pages/festival/sxsw-2026/index.vue
+++ b/pages/festival/sxsw-2026/index.vue
@@ -48,54 +48,79 @@
       </div>
 
       <div v-else>
-        <div v-if="activeTab === 'films'" class="films-grid">
-            <div v-if="features.length > 0" class="film-category">
-                <div class="category-header" @click="featuresOpen = !featuresOpen">
-                    <h2 class="listing__title category-title">
-                        Features
-                        <span class="category-count">({{ features.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="featuresOpen ? 'Collapse' : 'Expand'">
-                        <svg v-if="featuresOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
-                    </button>
-                </div>
-                <transition name="slide">
-                    <div v-show="featuresOpen" class="listing__items">
-                        <SxswCard 
-                            v-for="item in features"
-                            :key="`feature-${item.id}`"
-                            :item="item" 
-                        />
-                    </div>
-                </transition>
+        <div v-if="activeTab === 'films'" class="selection">
+          <div v-if="orderedCategories.length === 0" class="rollout-banner">
+            <div class="rollout-banner__icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
             </div>
+            <div class="rollout-banner__copy">
+              <h3>Lineup updates in progress</h3>
+              <p>This festival lineup is currently being updated. New films, sections, and official selections will be added progressively as they are announced and verified.</p>
+            </div>
+          </div>
+          <div v-else class="selection-layout">
+            <aside class="selection-nav" aria-label="Jump to section">
+              <template v-if="officialNav.length">
+                <div class="nav-group-label">Catalog</div>
+                <button
+                  v-for="sec in officialNav"
+                  :key="sec.key"
+                  class="nav-item"
+                  :class="{ active: activeSection === sec.key }"
+                  @click="scrollToSection(sec.key)"
+                >
+                  <span class="nav-item-label">{{ sec.label }}</span>
+                  <span class="nav-item-count">{{ sec.count }}</span>
+                </button>
+              </template>
+            </aside>
 
-            <div v-if="shorts.length > 0" class="film-category">
-                <div class="category-header" @click="shortsOpen = !shortsOpen">
-                    <h2 class="listing__title category-title">
-                        Shorts
-                        <span class="category-count">({{ shorts.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="shortsOpen ? 'Collapse' : 'Expand'">
-                        <svg v-if="shortsOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
+            <div ref="selectionContentRef" class="selection-content">
+              <section
+                v-for="sec in selectionSections"
+                :key="sec.key"
+                :data-key="sec.key"
+                class="sel-section"
+              >
+                <div class="sel-section-header" @click="onSectionHeaderClick(sec.key)">
+                  <h2 class="sel-section-title">{{ sec.label }}</h2>
+                  <div class="sel-section-meta">
+                    <span class="sel-section-count">{{ sec.count }} {{ sec.count === 1 ? 'film' : 'films' }}</span>
+                    <button v-if="isMobile" class="expand-btn" :aria-label="isSectionOpen(sec.key) ? 'Collapse' : 'Expand'">
+                      <svg v-if="isSectionOpen(sec.key)" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
+                      <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
                     </button>
+                  </div>
                 </div>
                 <transition name="slide">
-                    <div v-show="shortsOpen" class="listing__items">
-                        <SxswCard 
-                            v-for="item in shorts"
-                            :key="`short-${item.id}`"
-                            :item="item" 
-                        />
+                  <div v-show="!isMobile || isSectionOpen(sec.key)" class="sel-section-body">
+                    <div class="listing__items">
+                      <SxswCard
+                        v-for="item in sec.films"
+                        :key="`${sec.key}-${item.id}`"
+                        :item="item"
+                      />
                     </div>
+                  </div>
                 </transition>
+              </section>
             </div>
+          </div>
         </div>
 
         <div v-if="activeTab === 'schedule'" class="schedule-container">
-          <div class="schedule-toolbar" :class="{ 'search-active': isScheduleSearchActive }">
+          <!-- Initial rollout banner: schedule pending official publication -->
+          <div v-if="schedule.length === 0" class="rollout-banner">
+            <div class="rollout-banner__icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+            </div>
+            <div class="rollout-banner__copy">
+              <h3>Schedule pending</h3>
+              <p>Official screening schedules have not yet been published by the festival. Screening information will appear here as soon as it becomes available.</p>
+            </div>
+          </div>
+
+          <div v-if="schedule.length > 0" class="schedule-toolbar" :class="{ 'search-active': isScheduleSearchActive }">
             <div class="schedule-toolbar-info">
               <span class="schedule-count" v-if="!loading">
                 <template v-if="scheduleSearchActiveQuery">
@@ -131,24 +156,40 @@
             <p>No screenings match "<strong>{{ scheduleSearch }}</strong>"</p>
           </div>
 
-          <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" class="schedule-day">
-            <div class="day-header" @click="toggleDay(date)">
+          <div v-if="scheduleDays.length" class="schedule-layout">
+            <aside class="schedule-nav" aria-label="Jump to day">
+              <div class="nav-group-label">Days</div>
+              <button
+                v-for="day in scheduleDays"
+                :key="day.date"
+                class="nav-item"
+                :class="{ active: activeDay === day.date }"
+                @click="scrollToDay(day.date)"
+              >
+                <span class="nav-item-label">{{ day.label }}</span>
+                <span class="nav-item-count">{{ day.count }}</span>
+              </button>
+            </aside>
+
+            <div ref="scheduleContentRef" class="schedule-content">
+              <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" :data-day="date" class="schedule-day">
+            <div class="day-header" @click="onDayHeaderClick(date)">
                 <h2>{{ formatDate(date) }}</h2>
-                <div class="chevron" :class="{ 'closed': !isOpen(date) }">
+                <div v-if="isMobile" class="chevron" :class="{ 'closed': !isOpen(date) }">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down"><path d="m6 9 6 6 6-6"/></svg>
                 </div>
             </div>
-            
+
             <transition name="slide">
-                <div v-show="isOpen(date)" class="screenings-list">
+                <div v-show="!isMobile || isOpen(date)" class="screenings-list">
                   <div v-for="screening in dayScreenings" :key="screening.id" class="screening-card">
                      <div class="time-block">
-                        <span class="time">{{ formatTime(screening.start_time) }}</span>
-                        <!-- <span class="timezone">{{ screening.timezone }}</span> -->
+                        <span class="time">{{ formatTime(screening.start_time, screening.timezone) }}</span>
+                        <span class="timezone">{{ screening.timezone }}</span>
                      </div>
-                     
+
                       <div class="film-info">
-                         <component 
+                         <component
                             :is="screening.film.source_url ? 'a' : 'span'"
                             :href="screening.film.source_url || ''"
                             :target="screening.film.source_url ? '_blank' : ''"
@@ -172,13 +213,13 @@
                              <span v-if="screening.is_sold_out" class="tag sold-out">Sold Out</span>
                          </div>
                       </div>
-                      
+
                       <div class="poster-mini">
-                          <img 
-                            v-if="screening.film.poster_path" 
-                            :src="screening.film.poster_path" 
-                            alt="Poster" 
-                            loading="lazy" 
+                          <img
+                            v-if="screening.film.poster_path"
+                            :src="screening.film.poster_path"
+                            alt="Poster"
+                            loading="lazy"
                             @error="$event.target.src = '/placeholders/image_not_found_yet.webp'"
                           />
                           <img v-else src="/placeholders/image_not_found_yet.webp" alt="No Poster" />
@@ -186,6 +227,8 @@
                   </div>
                 </div>
             </transition>
+          </div>
+            </div>
           </div>
         </div>
 
@@ -261,7 +304,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, nextTick } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount, nextTick, watch } from 'vue';
 import Loader from '~/components/Loader.vue';
 import WinnersCarousel from '~/components/festival/WinnersCarousel.vue';
 import FestivalDataDisclaimer from '~/components/FestivalDataDisclaimer.vue';
@@ -311,26 +354,107 @@ const awards = ref([]);
 const schedule = ref([]);
 const openDays = ref(new Set());
 
-const featuresOpen = ref(true);
-const shortsOpen = ref(true);
+const CATEGORY_ORDER = [
+    'Features',
+    'Shorts',
+];
 
-const features = computed(() => {
-    return films.value?.results?.filter(f => !f.runtime || f.runtime >= 40) || [];
-});
-
-const shorts = computed(() => {
-    return films.value?.results?.filter(f => f.runtime > 0 && f.runtime < 40) || [];
-});
-
-const formatDate = (dateStr) => {
-    const options = { weekday: 'long', month: 'long', day: 'numeric' };
-    return new Date(dateStr).toLocaleDateString('en-US', options);
+const CATEGORY_LABELS = {
+    Features: 'Features',
+    Shorts: 'Shorts',
+    OTHER: 'Other',
 };
 
-const formatTime = (timeStr) => {
-    return new Date(timeStr).toLocaleTimeString('en-US', { 
-        hour: '2-digit', 
-        minute: '2-digit'
+const categoryKeyForFilm = (film) => {
+    const explicit = String(film.category || film.section || '').trim();
+    if (CATEGORY_ORDER.includes(explicit)) return explicit;
+    if (film.runtime > 0 && film.runtime < 40) return 'Shorts';
+    return 'Features';
+};
+
+const activeSection = ref('');
+const selectionContentRef = ref(null);
+let sectionObserver = null;
+const isMobile = ref(false);
+let mobileMql = null;
+const sectionOpen = ref({});
+const isSectionOpen = (key) => sectionOpen.value[key] !== false;
+const toggleSection = (key) => { sectionOpen.value = { ...sectionOpen.value, [key]: !isSectionOpen(key) }; };
+const onSectionHeaderClick = (key) => { if (!isMobile.value) return; toggleSection(key); };
+const activeDay = ref('');
+const scheduleContentRef = ref(null);
+let dayObserver = null;
+
+const filmsByCategory = computed(() => {
+    const map = Object.fromEntries(CATEGORY_ORDER.map((c) => [c, []]));
+    map.OTHER = [];
+    for (const f of films.value?.results || []) {
+        const key = categoryKeyForFilm(f);
+        if (key && map[key] !== undefined) map[key].push(f);
+        else map.OTHER.push(f);
+    }
+    return map;
+});
+
+const orderedCategories = computed(() => {
+    const out = CATEGORY_ORDER.filter((c) => (filmsByCategory.value[c] || []).length > 0);
+    if ((filmsByCategory.value.OTHER || []).length > 0) out.push('OTHER');
+    return out;
+});
+
+function categoryLabel (cat) {
+    return CATEGORY_LABELS[cat] || cat;
+}
+
+const selectionSections = computed(() => orderedCategories.value.map((cat) => {
+    const items = filmsByCategory.value[cat] || [];
+    return { key: cat, label: categoryLabel(cat), films: items, count: items.length };
+}));
+const officialNav = computed(() => selectionSections.value);
+
+const scrollToSection = (key) => {
+    activeSection.value = key;
+    const root = selectionContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-key]');
+    for (const el of els) { if (el.getAttribute('data-key') === key) { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); break; } }
+};
+
+const setupSectionObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (sectionObserver) sectionObserver.disconnect();
+    const root = selectionContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-key]');
+    if (!els.length) return;
+    sectionObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) { if (entry.isIntersecting) activeSection.value = entry.target.getAttribute('data-key'); }
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => sectionObserver.observe(el));
+};
+
+watch(selectionSections, (sections) => {
+    if (!sections.length) return;
+    if (!sections.some((sec) => sec.key === activeSection.value)) activeSection.value = sections[0].key;
+}, { immediate: true });
+
+watch([loading, activeTab, selectionSections], () => {
+    if (!loading.value && activeTab.value === 'films') nextTick(() => setupSectionObserver());
+    else if (sectionObserver) sectionObserver.disconnect();
+}, { flush: 'post' });
+
+const FESTIVAL_TZ = 'America/Chicago';
+
+const formatDate = (dateStr) => {
+    const options = { weekday: 'long', month: 'long', day: 'numeric', timeZone: 'UTC' };
+    return new Date(`${dateStr}T00:00:00Z`).toLocaleDateString('en-US', options);
+};
+
+const formatTime = (timeStr, tz) => {
+    return new Date(timeStr).toLocaleTimeString('en-US', {
+        hour: '2-digit',
+        minute: '2-digit',
+        timeZone: tz || FESTIVAL_TZ
     });
 };
 
@@ -361,17 +485,57 @@ const groupedScreenings = computed(() => {
 });
 
 const toggleDay = (date) => {
-    if (openDays.value.has(date)) {
-        openDays.value.delete(date);
-    } else {
-        openDays.value.add(date);
-    }
-}
+    if (openDays.value.has(date)) openDays.value.delete(date);
+    else openDays.value.add(date);
+};
 
 const isOpen = (date) => {
     if (scheduleSearchActiveQuery.value) return true;
     return openDays.value.has(date);
 };
+
+const scheduleDays = computed(() => Object.entries(groupedScreenings.value).map(([date, arr]) => ({ date, label: formatDate(date), count: arr.length })));
+const onDayHeaderClick = (date) => { if (!isMobile.value) return; toggleDay(date); };
+const scrollToDay = (date) => {
+    activeDay.value = date;
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-day]');
+    for (const el of els) { if (el.getAttribute('data-day') === date) { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); break; } }
+};
+const setupDayObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (dayObserver) dayObserver.disconnect();
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-day]');
+    if (!els.length) return;
+    dayObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) { if (entry.isIntersecting) activeDay.value = entry.target.getAttribute('data-day'); }
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => dayObserver.observe(el));
+};
+watch(scheduleDays, (days) => {
+    if (!days.length) return;
+    if (!days.some((d) => d.date === activeDay.value)) activeDay.value = days[0]?.date || '';
+}, { immediate: true });
+watch([loading, activeTab, scheduleDays], () => {
+    if (!loading.value && activeTab.value === 'schedule') nextTick(() => setupDayObserver());
+    else if (dayObserver) dayObserver.disconnect();
+}, { flush: 'post' });
+const updateIsMobile = (e) => { isMobile.value = e.matches; };
+onMounted(() => {
+    if (typeof window !== 'undefined' && window.matchMedia) {
+        mobileMql = window.matchMedia('(max-width: 900px)');
+        isMobile.value = mobileMql.matches;
+        mobileMql.addEventListener('change', updateIsMobile);
+    }
+});
+onBeforeUnmount(() => {
+    if (sectionObserver) sectionObserver.disconnect();
+    if (dayObserver) dayObserver.disconnect();
+    if (mobileMql) mobileMql.removeEventListener('change', updateIsMobile);
+});
 
 onMounted(async () => {
     try {
@@ -405,60 +569,156 @@ onMounted(async () => {
     font-size: 1.2rem;
 }
 
-.film-category {
-    margin-bottom: 2.5rem;
-}
-
-// Compact catalog cards (~25%+ smaller than global default).
-// Scoped to .films-grid so other listings (home, search, etc.) are untouched.
-// Uses :deep() because festival cards are child components (scoped CSS).
-.films-grid :deep(.listing__items > .card) {
-    width: 25%;
+// Poster sizing inside the Selection content column. The column is narrower than
+// the old full-bleed grid, so we use fewer columns / slightly larger posters.
+.selection :deep(.listing__items > .card) {
+    width: 33.3333%;
 
     @media (min-width: 640px) {
-        width: 20%;
+        width: 25%;
     }
     @media (min-width: 1024px) {
-        width: 14.2857143%;
+        width: 20%;
     }
     @media (min-width: 1500px) {
-        width: 12.5%;
+        width: 16.6666%;
     }
     @media (min-width: 1800px) {
-        width: 11.1111111%;
-    }
-    @media (min-width: 2500px) {
-        width: 10%;
+        width: 14.2857%;
     }
 }
 
 
 
-.category-header {
+/* ── Selection: sidebar scroll-spy + sections ───────────── */
+.selection-layout,
+.schedule-layout {
+    display: grid;
+    grid-template-columns: 330px minmax(0, 1fr);
+    gap: 2.5rem;
+    align-items: start;
+}
+
+/* Breathing room between the screenings search bar and the day list below it. */
+.schedule-layout {
+    margin-top: 1.75rem;
+}
+
+.selection-nav,
+.schedule-nav {
+    position: sticky;
+    top: 5.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-height: calc(100vh - 7rem);
+    overflow-y: auto;
+    padding: 1rem;
+    border: 1px solid transparent;
+    background:
+        linear-gradient(rgba(3, 6, 10, 0.85), rgba(3, 6, 10, 0.85)) padding-box,
+        linear-gradient(160deg, rgba(139, 233, 253, 0.55), rgba(31, 84, 103, 0.45) 60%, rgba(139, 233, 253, 0.16)) border-box;
+    border-radius: 14px;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
+}
+
+.nav-group-label {
+    font-size: 1rem;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    color: rgba(139, 233, 253, 0.9);
+    font-weight: 700;
+    margin: 1.2rem 0.4rem 0.55rem;
+
+    &:first-child {
+        margin-top: 0.2rem;
+    }
+}
+
+.nav-item {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 10px;
+    width: 100%;
+    background: none;
+    border: none;
+    border-left: 3px solid transparent;
+    border-radius: 0 8px 8px 0;
+    color: rgba(255, 255, 255, 0.88);
+    padding: 0.82rem 1rem;
+    font-size: 1.32rem;
+    font-family: inherit;
+    text-align: left;
     cursor: pointer;
-    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
-    padding-bottom: 5px;
-    margin-bottom: 15px;
-    transition: border-color 0.2s;
-    user-select: none;
-    
+    transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+
     &:hover {
-        border-color: rgba(139, 233, 253, 0.6);
+        background: rgba(139, 233, 253, 0.08);
+        color: #eafbff;
+    }
+
+    &.active {
+        background: rgba(139, 233, 253, 0.12);
+        color: #8BE9FD;
+        border-left-color: #8BE9FD;
+        font-weight: 600;
     }
 }
 
-.category-title {
-    margin: 0 !important;
+.nav-item-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
-.category-count {
-    font-size: 1.1rem;
-    color: rgba(255, 255, 255, 0.6);
-    margin-left: 10px;
-    font-weight: normal;
+.nav-item-count {
+    font-size: 1.12rem;
+    color: rgba(255, 255, 255, 0.62);
+    flex-shrink: 0;
+}
+
+.nav-item.active .nav-item-count {
+    color: rgba(139, 233, 253, 0.85);
+}
+
+.sel-section {
+    scroll-margin-top: 6.5rem;
+    margin-bottom: 3rem;
+}
+
+.sel-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
+    padding-bottom: 6px;
+    margin-bottom: 1.25rem;
+}
+
+.sel-section-title {
+    margin: 0;
+    font-size: 1.7rem;
+    font-weight: 700;
+    color: #fff;
+}
+
+.sel-section-meta {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-shrink: 0;
+}
+
+.sel-section-count {
+    font-size: 1.05rem;
+    color: rgba(255, 255, 255, 0.5);
+    white-space: nowrap;
+    flex-shrink: 0;
 }
 
 .expand-btn {
@@ -474,7 +734,7 @@ onMounted(async () => {
     cursor: pointer;
     transition: all 0.2s ease;
     flex-shrink: 0;
-    
+
     &:hover {
         background: rgba(139, 233, 253, 0.15);
         color: #8BE9FD;
@@ -487,6 +747,42 @@ onMounted(async () => {
         min-width: 20px;
         min-height: 20px;
         display: block;
+    }
+}
+
+.parallel-band {
+    font-size: 0.85rem;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: #8BE9FD;
+    border-top: 1px solid rgba(139, 233, 253, 0.25);
+    padding-top: 1.4rem;
+    margin: 0.5rem 0 1.5rem;
+}
+
+@media (max-width: 900px) {
+    .selection-layout,
+    .schedule-layout {
+        display: block;
+    }
+
+    .selection-nav,
+    .schedule-nav {
+        display: none;
+    }
+
+    .sel-section-header {
+        cursor: pointer;
+        user-select: none;
+        transition: border-color 0.2s;
+    }
+
+    .sel-section-header:hover {
+        border-color: rgba(139, 233, 253, 0.6);
+    }
+
+    .day-header {
+        cursor: pointer;
     }
 }
 
@@ -509,12 +805,16 @@ onMounted(async () => {
 .segmented-control {
     position: relative;
     display: flex;
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 20px; 
+    background: rgba(3, 4, 6, 0.6);
+    border: 1px solid rgba(139, 233, 253, 0.18);
+    border-radius: 16px;
     padding: 4px;
     height: 48px;
     align-items: center;
     min-width: 420px;
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
 }
 
 .segmented-control input[type="radio"] {
@@ -537,7 +837,7 @@ onMounted(async () => {
 }
 
 .segmented-control input:checked + label {
-    color: #000;
+    color: #02080d;
 }
 
 .segmented-control .glider {
@@ -546,9 +846,10 @@ onMounted(async () => {
     left: 4px;
     height: calc(100% - 8px);
     width: calc((100% - 8px) / 3);
-    background: #8BE9FD; 
-    border-radius: 16px;
+    background: linear-gradient(135deg, #8BE9FD, #5cc4d8);
+    border-radius: 12px;
     z-index: 1;
+    box-shadow: 0 4px 14px rgba(139, 233, 253, 0.3);
     transition: transform 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
 }
 
@@ -562,12 +863,15 @@ onMounted(async () => {
     max-width: 1200px;
     margin: 0 auto;
     position: relative;
-    border-radius: 15px;
+    border-radius: 16px;
     overflow: hidden;
-    background-color: transparent;
     display: flex;
     justify-content: center;
-    border: 1px solid #8BE9FD;
+    border: 2px solid transparent;
+    background:
+        linear-gradient(#02080d, #02080d) padding-box,
+        linear-gradient(140deg, #8BE9FD 0%, #1F5467 45%, rgba(31, 84, 103, 0.35) 100%) border-box;
+    box-shadow: 0 14px 36px rgba(0, 0, 0, 0.5), 0 0 30px rgba(139, 233, 253, 0.12);
 }
 
 .back-link {
@@ -597,7 +901,7 @@ onMounted(async () => {
         box-shadow: 0 8px 25px rgba(0,0,0,0.4);
         border-color: #fff;
     }
-    
+
     svg {
         width: 24px;
         height: 24px;
@@ -608,7 +912,7 @@ onMounted(async () => {
         left: 20px;
         font-size: 0.9rem;
         padding: 8px 16px;
-        
+
         svg {
             width: 18px;
             height: 18px;
@@ -620,7 +924,7 @@ onMounted(async () => {
     width: 100%;
     height: auto;
     position: relative;
-    
+
     img {
         width: 100%;
         height: auto;
@@ -674,47 +978,63 @@ onMounted(async () => {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    cursor: pointer;
+    cursor: default;
     user-select: none;
-    
+
     h2 {
         font-size: 1.8rem;
         margin: 0;
     }
-    
+
     .chevron {
         transition: transform 0.3s ease;
-        
+
         &.closed {
             transform: rotate(-90deg);
         }
     }
 }
 
+.schedule-day {
+    scroll-margin-top: 6.5rem;
+}
+
+.schedule-content > .schedule-day:first-child .day-header {
+    margin-top: 0;
+}
+
 .slide-enter-active,
 .slide-leave-active {
-    transition: all 0.3s ease-out;
-    max-height: 2000px;
-    opacity: 1;
-    overflow: hidden;
+  transition: all 0.3s ease-out;
+  max-height: 2000px;
+  opacity: 1;
+  overflow: hidden;
 }
 
 .slide-enter-from,
 .slide-leave-to {
-    max-height: 0;
-    opacity: 0;
-    margin-bottom: 0;
+  max-height: 0;
+  opacity: 0;
+  margin-bottom: 0;
 }
 
 .screening-card {
     display: flex;
-    background: #0a161b;
-    border: 1px solid #8BE9FD;
-    border-radius: 8px;
+    border: 1px solid transparent;
+    background:
+        linear-gradient(#0a161b, #0a161b) padding-box,
+        linear-gradient(140deg, #8BE9FD, #1F5467 60%, rgba(31, 84, 103, 0.3)) border-box;
+    border-radius: 10px;
     padding: 1.5rem;
     margin-bottom: 1rem;
     gap: 1.5rem;
-    transition: transform 0.2s;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.3);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.screening-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.4), 0 0 20px rgba(139, 233, 253, 0.1);
 }
 
 .time-block {
@@ -725,7 +1045,7 @@ onMounted(async () => {
     min-width: 80px;
     border-right: 1px solid #333;
     padding-right: 1.5rem;
-    
+
     .time {
         font-size: 1.2rem;
         font-weight: 700;
@@ -742,25 +1062,25 @@ onMounted(async () => {
     display: flex;
     flex-direction: column;
     justify-content: center;
-    
+
     .film-title {
         font-size: 1.6rem;
         font-weight: 700;
         color: #fff;
         text-decoration: none;
         margin-bottom: 0.5rem;
-        
+
         &:hover {
             color: #8BE9FD;
         }
     }
-    
+
     .film-meta {
         font-size: 1.05rem;
         color: #aaa;
         margin-bottom: 0.8rem;
     }
-    
+
     .venue-info {
         font-size: 1.25rem;
         color: #ccc;
@@ -768,7 +1088,7 @@ onMounted(async () => {
         display: flex;
         align-items: center;
         gap: 0.5rem;
-        
+
         svg {
             min-width: 18px;
         }
@@ -778,14 +1098,14 @@ onMounted(async () => {
 .tags {
     display: flex;
     gap: 0.5rem;
-    
+
     .tag {
         font-size: 0.75rem;
         padding: 4px 8px;
         border-radius: 4px;
         font-weight: 600;
         text-transform: uppercase;
-        
+
         &.in-person { background: rgba(52, 152, 219, 0.2); }
         &.online { background: rgba(46, 204, 113, 0.2); color: #2ecc71; }
         &.sold-out { background: rgba(231, 76, 60, 0.2); color: #e74c3c; }
@@ -795,7 +1115,7 @@ onMounted(async () => {
 .poster-mini {
     width: 60px;
     height: 90px;
-    
+
     img {
         width: 100%;
         height: 100%;
@@ -806,7 +1126,7 @@ onMounted(async () => {
 
 @media (max-width: 600px) {
     .screening-card {
-        flex-direction: column; 
+        flex-direction: column;
         gap: 1rem;
     }
     .time-block {
@@ -839,14 +1159,33 @@ onMounted(async () => {
 }
 
 .carousel-card {
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(139, 233, 253, 0.18);
+  position: relative;
+  background: rgba(3, 4, 6, 0.85);
+  background-image:
+    radial-gradient(circle at 15% 20%, rgba(31, 84, 103, 0.18), transparent 35%),
+    radial-gradient(circle at 85% 80%, rgba(139, 233, 253, 0.08), transparent 30%);
+  border: 1px solid rgba(31, 84, 103, 0.5);
   border-radius: 20px;
   padding: 2.2rem 2.5rem;
-  backdrop-filter: blur(12px);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
   color: rgba(255, 255, 255, 0.88);
   line-height: 1.8;
   min-height: 300px;
+  overflow: hidden;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5), inset 0 0 24px rgba(139, 233, 253, 0.04);
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: linear-gradient(90deg, transparent, #8BE9FD, #1F5467, transparent);
+    opacity: 0.85;
+    pointer-events: none;
+  }
 
   strong { color: #fff; }
 }
@@ -880,19 +1219,21 @@ onMounted(async () => {
   justify-content: center;
   width: 44px;
   height: 44px;
-  border-radius: 50%;
-  border: 1px solid rgba(139, 233, 253, 0.25);
-  background: rgba(0, 0, 0, 0.4);
+  border-radius: 12px;
+  border: 1px solid rgba(139, 233, 253, 0.4);
+  background: rgba(3, 4, 6, 0.75);
   color: #8BE9FD;
   cursor: pointer;
-  transition: all 0.25s ease;
+  transition: all 0.2s ease;
   flex-shrink: 0;
-  backdrop-filter: blur(6px);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
 
   &:hover {
-    background: rgba(139, 233, 253, 0.15);
-    border-color: #8BE9FD;
-    transform: scale(1.1);
+    background: #ffffff;
+    border-color: #ffffff;
+    color: #000;
+    transform: scale(1.05);
   }
 }
 
@@ -944,6 +1285,7 @@ onMounted(async () => {
   .carousel-arrow svg { width: 18px; height: 18px; }
 }
 
+/* ── Shared card content styles ───────────── */
 .price-list {
   list-style: none; padding: 0; margin: 1rem 0;
   li { display: flex; justify-content: space-between; align-items: center; padding: 0.65rem 0; border-bottom: 1px dashed rgba(255,255,255,0.08); &:last-child { border: none; } }
@@ -952,12 +1294,8 @@ onMounted(async () => {
 }
 
 .venue-list {
-  display: grid; grid-template-columns: repeat(2, 1fr); gap: 0.9rem;
-  @media (max-width: 600px) { grid-template-columns: 1fr; }
-  .venue-item { font-size: 0.98rem; padding: 0.7rem 0.9rem; background: rgba(255,255,255,0.04); border-radius: 10px; border: 1px solid rgba(255,255,255,0.06);
-    strong { color: #8BE9FD; display: block; margin-bottom: 3px; font-size: 1.02rem; }
-    span { color: rgba(255,255,255,0.7); }
-  }
+  display: flex; flex-direction: column; gap: 0.5rem; margin: 0.5rem 0;
+  .venue-item { display: flex; justify-content: space-between; align-items: center; padding: 0.5rem 0; border-bottom: 1px solid rgba(255,255,255,0.05); span { color: rgba(255,255,255,0.5); font-size: 0.95rem; } strong { color: #fff; } }
 }
 
 .bullet-list {
@@ -968,6 +1306,58 @@ onMounted(async () => {
 .accent-link {
   color: #8BE9FD; text-decoration: none; font-weight: 600; border-bottom: 1px solid transparent; transition: border-color 0.2s;
   &:hover { border-color: #8BE9FD; }
+}
+
+/* ── Initial-rollout banner (catalog/schedule placeholders) ─ */
+.rollout-banner {
+    display: flex;
+    gap: 1.25rem;
+    align-items: flex-start;
+    max-width: 720px;
+    margin: 2rem auto;
+    padding: 1.5rem 1.75rem;
+    background: rgba(16, 26, 35, 0.7);
+    border: 1px solid rgba(139, 233, 253, 0.22);
+    border-radius: 14px;
+    backdrop-filter: blur(8px);
+}
+
+.rollout-banner__icon {
+    flex-shrink: 0;
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    background: rgba(139, 233, 253, 0.08);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.rollout-banner__copy {
+    flex: 1;
+    color: rgba(255, 255, 255, 0.85);
+
+    h3 {
+        margin: 0 0 0.4rem;
+        font-size: 1.15rem;
+        font-weight: 700;
+        color: #8BE9FD;
+        letter-spacing: 0.3px;
+    }
+    p {
+        margin: 0;
+        font-size: 1rem;
+        line-height: 1.6;
+        color: rgba(255, 255, 255, 0.7);
+    }
+}
+
+@media (max-width: 600px) {
+    .rollout-banner {
+        flex-direction: column;
+        gap: 0.75rem;
+        padding: 1.25rem;
+    }
 }
 
 /* ── Schedule search toolbar ─────────────── */


### PR DESCRIPTION
### Motivation

- Improve the festival films and schedule UX by introducing a structured selection layout with jump-nav, scroll-spy and mobile-friendly collapsible sections.  
- Provide clearer messaging for incomplete rollouts by showing a contextual rollout banner when lineups or schedules are not yet published.  
- Normalize time/date and make schedule entries timezone-aware and robust across different festival APIs (including Rotterdam's Unix timestamp format).  

### Description

- Replaced the old flat `.films-grid` listing with a two-column `selection-layout` across festival pages, adding a left `selection-nav` jump menu and per-section `sel-section` listing driven by `selectionSections` computed data.  
- Added scroll-spy via `IntersectionObserver` and helpers: `selectionContentRef`, `setupSectionObserver`, `scrollToSection`, `activeSection`, and mobile collapse behavior using `isMobile` (media query listener) and `sectionOpen` toggles.  
- Implemented schedule improvements including a `schedule-nav` jump list, `scheduleContentRef`, day scroll-spy/observers (`setupDayObserver` / `activeDay`), mobile collapsible day headers, and a `rollout-banner` when schedules are empty.  
- Standardized date/time formatting and timezone handling per festival using `FESTIVAL_TZ` constants and updated `formatTime` to accept a timezone argument; Rotterdam schedule timestamps are normalized from Unix to ISO on fetch.  
- Safer film links and poster fallbacks: schedule film titles render as `a` only when `source_url` exists, and poster images use an `@error` fallback to a placeholder.  
- Added category mapping and ordering (`CATEGORY_ORDER`, `filmsByCategory`, `orderedCategories`, `selectionSections`) and per-festival small helpers (`categoryKeyForFilm` / `CATEGORY_LABELS`) to preserve section ordering and label fallbacks.  
- Large style / CSS overhaul scoped to each festival page: new styles for `.selection`, `.selection-nav`, `.schedule-layout`, `.screening-card`, `.rollout-banner`, updated carousel visuals and responsive adjustments.  
- Lifecycle cleanup and listeners: `onBeforeUnmount` disconnects observers and removes `matchMedia` listeners.  

### Testing

- Built the application locally with `npm run build` to verify no build-time regressions and asset generation succeeded.  
- Ran the linter (`npm run lint`) to ensure style and syntax changes conform to project rules.  
- Manual smoke checks in the development server (`npm run dev`) were performed to confirm the new selection sidebar, rollout banners, schedule nav, timezone formatting, and mobile collapse behavior render without runtime errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a14ca04b083268063c1d353a8d4ce)