### PR TITLE
Add selection sidebar, scroll‑spy and day navigation to festival pages; improve schedule and film listing layout

### DIFF
--- a/pages/festival/berlinale-2026/index.vue
+++ b/pages/festival/berlinale-2026/index.vue
@@ -50,50 +50,55 @@
       </div>
 
       <div v-else>
-        <div v-if="activeTab === 'films'" class="films-grid">
-            <div v-if="features.length > 0" class="film-category">
-                <div class="category-header" @click="featuresOpen = !featuresOpen">
-                    <h2 class="listing__title category-title">
-                        Largometrajes
-                        <span class="category-count">({{ features.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="featuresOpen ? 'Ocultar' : 'Expandir'">
-                        <svg v-if="featuresOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
-                    </button>
-                </div>
-                <transition name="slide">
-                    <div v-show="featuresOpen" class="listing__items">
-                        <BerlinaleCard 
-                            v-for="item in features"
-                            :key="`feature-${item.id}`"
-                            :item="item" 
-                        />
-                    </div>
-                </transition>
-            </div>
+        <div v-if="activeTab === 'films'" class="selection">
+          <div class="selection-layout">
+            <aside class="selection-nav" aria-label="Saltar a sección">
+              <template v-if="officialNav.length">
+                <div class="nav-group-label">Catálogo</div>
+                <button
+                  v-for="sec in officialNav"
+                  :key="sec.key"
+                  class="nav-item"
+                  :class="{ active: activeSection === sec.key }"
+                  @click="scrollToSection(sec.key)"
+                >
+                  <span class="nav-item-label">{{ sec.label }}</span>
+                  <span class="nav-item-count">{{ sec.count }}</span>
+                </button>
+              </template>
+            </aside>
 
-            <div v-if="shorts.length > 0" class="film-category">
-                <div class="category-header" @click="shortsOpen = !shortsOpen">
-                    <h2 class="listing__title category-title">
-                        Cortometrajes
-                        <span class="category-count">({{ shorts.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="shortsOpen ? 'Ocultar' : 'Expandir'">
-                        <svg v-if="shortsOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
+            <div ref="selectionContentRef" class="selection-content">
+              <section
+                v-for="sec in selectionSections"
+                :key="sec.key"
+                :data-key="sec.key"
+                class="sel-section"
+              >
+                <div class="sel-section-header" @click="onSectionHeaderClick(sec.key)">
+                  <h2 class="sel-section-title">{{ sec.label }}</h2>
+                  <div class="sel-section-meta">
+                    <span class="sel-section-count">{{ sec.count }} {{ sec.count === 1 ? 'película' : 'películas' }}</span>
+                    <button v-if="isMobile" class="expand-btn" :aria-label="isSectionOpen(sec.key) ? 'Ocultar' : 'Expandir'">
+                      <svg v-if="isSectionOpen(sec.key)" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
+                      <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
                     </button>
+                  </div>
                 </div>
                 <transition name="slide">
-                    <div v-show="shortsOpen" class="listing__items">
-                        <BerlinaleCard 
-                            v-for="item in shorts"
-                            :key="`short-${item.id}`"
-                            :item="item" 
-                        />
+                  <div v-show="!isMobile || isSectionOpen(sec.key)" class="sel-section-body">
+                    <div class="listing__items">
+                      <BerlinaleCard
+                        v-for="item in sec.films"
+                        :key="`${sec.key}-${item.id}`"
+                        :item="item"
+                      />
                     </div>
+                  </div>
                 </transition>
+              </section>
             </div>
+          </div>
         </div>
 
         <div v-if="activeTab === 'schedule'" class="schedule-container">
@@ -133,24 +138,40 @@
             <p>Ninguna función coincide con "<strong>{{ scheduleSearch }}</strong>"</p>
           </div>
 
-          <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" class="schedule-day">
-            <div class="day-header" @click="toggleDay(date)">
+          <div v-if="scheduleDays.length" class="schedule-layout">
+            <aside class="schedule-nav" aria-label="Saltar a día">
+              <div class="nav-group-label">Días</div>
+              <button
+                v-for="day in scheduleDays"
+                :key="day.date"
+                class="nav-item"
+                :class="{ active: activeDay === day.date }"
+                @click="scrollToDay(day.date)"
+              >
+                <span class="nav-item-label">{{ day.label }}</span>
+                <span class="nav-item-count">{{ day.count }}</span>
+              </button>
+            </aside>
+
+            <div ref="scheduleContentRef" class="schedule-content">
+              <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" :data-day="date" class="schedule-day">
+            <div class="day-header" @click="onDayHeaderClick(date)">
                 <h2>{{ formatDate(date) }}</h2>
-                <div class="chevron" :class="{ 'closed': !isOpen(date) }">
+                <div v-if="isMobile" class="chevron" :class="{ 'closed': !isOpen(date) }">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down"><path d="m6 9 6 6 6-6"/></svg>
                 </div>
             </div>
-            
+
             <transition name="slide">
-                <div v-show="isOpen(date)" class="screenings-list">
+                <div v-show="!isMobile || isOpen(date)" class="screenings-list">
                   <div v-for="screening in dayScreenings" :key="screening.id" class="screening-card">
                      <div class="time-block">
                         <span class="time">{{ formatTime(screening.start_time) }}</span>
                         <span class="timezone">{{ screening.timezone }}</span>
                      </div>
-                     
+
                       <div class="film-info">
-                         <component 
+                         <component
                             :is="screening.film.source_url ? 'a' : 'span'"
                             :href="screening.film.source_url || ''"
                             :target="screening.film.source_url ? '_blank' : ''"
@@ -174,20 +195,22 @@
                              <span v-if="screening.is_sold_out" class="tag sold-out">Agotado</span>
                          </div>
                       </div>
-                      
+
                       <div class="poster-mini">
-                          <img 
-                            v-if="screening.film.poster_path" 
-                            :src="screening.film.poster_path" 
-                            alt="Poster" 
-                            loading="lazy" 
-                            @error="$event.target.src = '/placeholders/image_not_found_yet_es.webp'"
+                          <img
+                            v-if="screening.film.poster_path"
+                            :src="screening.film.poster_path"
+                            alt="Poster"
+                            loading="lazy"
+                            @error="$event.target.src = '/placeholders/image_not_found_yet.webp'"
                           />
-                          <img v-else src="/placeholders/image_not_found_yet_es.webp" alt="No Poster" />
+                          <img v-else src="/placeholders/image_not_found_yet.webp" alt="No Poster" />
                       </div>
                   </div>
                 </div>
             </transition>
+          </div>
+            </div>
           </div>
         </div>
 
@@ -265,7 +288,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, nextTick } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount, nextTick, watch } from 'vue';
 import Loader from '~/components/Loader.vue';
 import WinnersCarousel from '~/components/festival/WinnersCarousel.vue';
 import FestivalDataDisclaimer from '~/components/FestivalDataDisclaimer.vue';
@@ -315,9 +338,6 @@ const awards = ref([]);
 const schedule = ref([]);
 const openDays = ref(new Set());
 
-const featuresOpen = ref(true);
-const shortsOpen = ref(true);
-
 const features = computed(() => {
     return films.value?.results?.filter(f => !f.runtime || f.runtime >= 40) || [];
 });
@@ -325,6 +345,55 @@ const features = computed(() => {
 const shorts = computed(() => {
     return films.value?.results?.filter(f => f.runtime > 0 && f.runtime < 40) || [];
 });
+
+const selectionSections = computed(() => [
+    { key: 'features', label: 'Largometrajes', films: features.value, count: features.value.length },
+    { key: 'shorts', label: 'Cortometrajes', films: shorts.value, count: shorts.value.length },
+].filter(sec => sec.count > 0));
+const officialNav = computed(() => selectionSections.value);
+const scrollToSection = (key) => {
+    activeSection.value = key;
+    const root = selectionContentRef.value;
+    if (!root) return;
+    for (const el of root.querySelectorAll('[data-key]')) {
+        if (el.getAttribute('data-key') === key) {
+            el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            break;
+        }
+    }
+};
+const setupSectionObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (sectionObserver) sectionObserver.disconnect();
+    const root = selectionContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-key]');
+    if (!els.length) return;
+    sectionObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) if (entry.isIntersecting) activeSection.value = entry.target.getAttribute('data-key');
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => sectionObserver.observe(el));
+};
+watch(selectionSections, (sections) => {
+    if (sections.length && !sections.some((sec) => sec.key === activeSection.value)) activeSection.value = sections[0].key;
+}, { immediate: true });
+watch([loading, activeTab, selectionSections], () => {
+    if (!loading.value && activeTab.value === 'films') nextTick(() => setupSectionObserver());
+    else if (sectionObserver) sectionObserver.disconnect();
+}, { flush: 'post' });
+
+const activeSection = ref('');
+const selectionContentRef = ref(null);
+let sectionObserver = null;
+const isMobile = ref(false);
+let mobileMql = null;
+const sectionOpen = ref({});
+const isSectionOpen = (key) => sectionOpen.value[key] !== false;
+const toggleSection = (key) => { sectionOpen.value = { ...sectionOpen.value, [key]: !isSectionOpen(key) }; };
+const onSectionHeaderClick = (key) => { if (!isMobile.value) return; toggleSection(key); };
+const activeDay = ref('');
+const scheduleContentRef = ref(null);
+let dayObserver = null;
 
 const formatDate = (dateStr) => {
     const options = { weekday: 'long', month: 'long', day: 'numeric', timeZone: 'Europe/Berlin' };
@@ -378,6 +447,52 @@ const isOpen = (date) => {
     return openDays.value.has(date);
 };
 
+const scheduleDays = computed(() => Object.entries(groupedScreenings.value).map(([date, arr]) => ({ date, label: formatDate(date), count: arr.length })));
+const onDayHeaderClick = (date) => { if (!isMobile.value) return; toggleDay(date); };
+const scrollToDay = (date) => {
+    activeDay.value = date;
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    for (const el of root.querySelectorAll('[data-day]')) {
+        if (el.getAttribute('data-day') === date) {
+            el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            break;
+        }
+    }
+};
+const setupDayObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (dayObserver) dayObserver.disconnect();
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-day]');
+    if (!els.length) return;
+    dayObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) if (entry.isIntersecting) activeDay.value = entry.target.getAttribute('data-day');
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => dayObserver.observe(el));
+};
+watch(scheduleDays, (days) => {
+    if (days.length && !days.some((d) => d.date === activeDay.value)) activeDay.value = days[0]?.date || '';
+}, { immediate: true });
+watch([loading, activeTab, scheduleDays], () => {
+    if (!loading.value && activeTab.value === 'schedule') nextTick(() => setupDayObserver());
+    else if (dayObserver) dayObserver.disconnect();
+}, { flush: 'post' });
+const updateIsMobile = (e) => { isMobile.value = e.matches; };
+onMounted(() => {
+    if (typeof window !== 'undefined' && window.matchMedia) {
+        mobileMql = window.matchMedia('(max-width: 900px)');
+        isMobile.value = mobileMql.matches;
+        mobileMql.addEventListener('change', updateIsMobile);
+    }
+});
+onBeforeUnmount(() => {
+    if (sectionObserver) sectionObserver.disconnect();
+    if (dayObserver) dayObserver.disconnect();
+    if (mobileMql) mobileMql.removeEventListener('change', updateIsMobile);
+});
+
 onMounted(async () => {
     try {
         const [filmsData, scheduleData, awardsData] = await Promise.all([
@@ -405,6 +520,223 @@ onMounted(async () => {
 
 <style lang="scss" scoped>
 @use '~/assets/css/utilities/variables' as *;
+
+// Poster sizing inside the Selection content column. The column is narrower than
+// the old full-bleed grid, so we use fewer columns / slightly larger posters.
+.selection :deep(.listing__items > .card) {
+    width: 33.3333%;
+
+    @media (min-width: 640px) {
+        width: 25%;
+    }
+    @media (min-width: 1024px) {
+        width: 20%;
+    }
+    @media (min-width: 1500px) {
+        width: 16.6666%;
+    }
+    @media (min-width: 1800px) {
+        width: 14.2857%;
+    }
+}
+
+
+/* ── Selection: sidebar scroll-spy + sections ───────────── */
+.selection-layout,
+.schedule-layout {
+    display: grid;
+    grid-template-columns: 330px minmax(0, 1fr);
+    gap: 2.5rem;
+    align-items: start;
+}
+
+/* Breathing room between the screenings search bar and the day list below it. */
+.schedule-layout {
+    margin-top: 1.75rem;
+}
+
+.selection-nav,
+.schedule-nav {
+    position: sticky;
+    top: 5.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-height: calc(100vh - 7rem);
+    overflow-y: auto;
+    padding: 1rem;
+    border: 1px solid transparent;
+    background:
+        linear-gradient(rgba(3, 6, 10, 0.85), rgba(3, 6, 10, 0.85)) padding-box,
+        linear-gradient(160deg, rgba(139, 233, 253, 0.55), rgba(31, 84, 103, 0.45) 60%, rgba(139, 233, 253, 0.16)) border-box;
+    border-radius: 14px;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
+}
+
+.nav-group-label {
+    font-size: 1rem;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    color: rgba(139, 233, 253, 0.9);
+    font-weight: 700;
+    margin: 1.2rem 0.4rem 0.55rem;
+
+    &:first-child {
+        margin-top: 0.2rem;
+    }
+}
+
+.nav-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    width: 100%;
+    background: none;
+    border: none;
+    border-left: 3px solid transparent;
+    border-radius: 0 8px 8px 0;
+    color: rgba(255, 255, 255, 0.88);
+    padding: 0.82rem 1rem;
+    font-size: 1.32rem;
+    font-family: inherit;
+    text-align: left;
+    cursor: pointer;
+    transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+
+    &:hover {
+        background: rgba(139, 233, 253, 0.08);
+        color: #eafbff;
+    }
+
+    &.active {
+        background: rgba(139, 233, 253, 0.12);
+        color: #8BE9FD;
+        border-left-color: #8BE9FD;
+        font-weight: 600;
+    }
+}
+
+.nav-item-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.nav-item-count {
+    font-size: 1.12rem;
+    color: rgba(255, 255, 255, 0.62);
+    flex-shrink: 0;
+}
+
+.nav-item.active .nav-item-count {
+    color: rgba(139, 233, 253, 0.85);
+}
+
+.sel-section {
+    scroll-margin-top: 6.5rem;
+    margin-bottom: 3rem;
+}
+
+.sel-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
+    padding-bottom: 6px;
+    margin-bottom: 1.25rem;
+}
+
+.sel-section-title {
+    margin: 0;
+    font-size: 1.7rem;
+    font-weight: 700;
+    color: #fff;
+}
+
+.sel-section-meta {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-shrink: 0;
+}
+
+.sel-section-count {
+    font-size: 1.05rem;
+    color: rgba(255, 255, 255, 0.5);
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.expand-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.3);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: #fff;
+    width: 36px;
+    height: 36px;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    flex-shrink: 0;
+
+    &:hover {
+        background: rgba(139, 233, 253, 0.15);
+        color: #8BE9FD;
+        border-color: rgba(139, 233, 253, 0.3);
+    }
+
+    svg {
+        width: 20px;
+        height: 20px;
+        min-width: 20px;
+        min-height: 20px;
+        display: block;
+    }
+}
+
+.parallel-band {
+    font-size: 0.85rem;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: #8BE9FD;
+    border-top: 1px solid rgba(139, 233, 253, 0.25);
+    padding-top: 1.4rem;
+    margin: 0.5rem 0 1.5rem;
+}
+
+@media (max-width: 900px) {
+    .selection-layout,
+    .schedule-layout {
+        display: block;
+    }
+
+    .selection-nav,
+    .schedule-nav {
+        display: none;
+    }
+
+    .sel-section-header {
+        cursor: pointer;
+        user-select: none;
+        transition: border-color 0.2s;
+    }
+
+    .sel-section-header:hover {
+        border-color: rgba(139, 233, 253, 0.6);
+    }
+
+    .day-header {
+        cursor: pointer;
+    }
+}
+
 
 :deep(.card__name) {
     font-size: 1.2rem;

--- a/pages/festival/bifff-2026/index.vue
+++ b/pages/festival/bifff-2026/index.vue
@@ -50,50 +50,55 @@
       </div>
 
       <div v-else>
-        <div v-if="activeTab === 'films'" class="films-grid">
-            <div v-if="features.length > 0" class="film-category">
-                <div class="category-header" @click="featuresOpen = !featuresOpen">
-                    <h2 class="listing__title category-title">
-                        Largometrajes
-                        <span class="category-count">({{ features.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="featuresOpen ? 'Ocultar' : 'Expandir'">
-                        <svg v-if="featuresOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
-                    </button>
-                </div>
-                <transition name="slide">
-                    <div v-show="featuresOpen" class="listing__items">
-                        <BifffCard 
-                            v-for="item in features"
-                            :key="`feature-${item.id}`"
-                            :item="item" 
-                        />
-                    </div>
-                </transition>
-            </div>
+        <div v-if="activeTab === 'films'" class="selection">
+          <div class="selection-layout">
+            <aside class="selection-nav" aria-label="Saltar a sección">
+              <template v-if="officialNav.length">
+                <div class="nav-group-label">Catálogo</div>
+                <button
+                  v-for="sec in officialNav"
+                  :key="sec.key"
+                  class="nav-item"
+                  :class="{ active: activeSection === sec.key }"
+                  @click="scrollToSection(sec.key)"
+                >
+                  <span class="nav-item-label">{{ sec.label }}</span>
+                  <span class="nav-item-count">{{ sec.count }}</span>
+                </button>
+              </template>
+            </aside>
 
-            <div v-if="shorts.length > 0" class="film-category">
-                <div class="category-header" @click="shortsOpen = !shortsOpen">
-                    <h2 class="listing__title category-title">
-                        Cortometrajes
-                        <span class="category-count">({{ shorts.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="shortsOpen ? 'Ocultar' : 'Expandir'">
-                        <svg v-if="shortsOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
+            <div ref="selectionContentRef" class="selection-content">
+              <section
+                v-for="sec in selectionSections"
+                :key="sec.key"
+                :data-key="sec.key"
+                class="sel-section"
+              >
+                <div class="sel-section-header" @click="onSectionHeaderClick(sec.key)">
+                  <h2 class="sel-section-title">{{ sec.label }}</h2>
+                  <div class="sel-section-meta">
+                    <span class="sel-section-count">{{ sec.count }} {{ sec.count === 1 ? 'película' : 'películas' }}</span>
+                    <button v-if="isMobile" class="expand-btn" :aria-label="isSectionOpen(sec.key) ? 'Ocultar' : 'Expandir'">
+                      <svg v-if="isSectionOpen(sec.key)" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
+                      <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
                     </button>
+                  </div>
                 </div>
                 <transition name="slide">
-                    <div v-show="shortsOpen" class="listing__items">
-                        <BifffCard 
-                            v-for="item in shorts"
-                            :key="`short-${item.id}`"
-                            :item="item" 
-                        />
+                  <div v-show="!isMobile || isSectionOpen(sec.key)" class="sel-section-body">
+                    <div class="listing__items">
+                      <BifffCard
+                        v-for="item in sec.films"
+                        :key="`${sec.key}-${item.id}`"
+                        :item="item"
+                      />
                     </div>
+                  </div>
                 </transition>
+              </section>
             </div>
+          </div>
         </div>
 
         <div v-if="activeTab === 'schedule'" class="schedule-container">
@@ -133,30 +138,48 @@
             <p>Ninguna función coincide con "<strong>{{ scheduleSearch }}</strong>"</p>
           </div>
 
-          <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" class="schedule-day">
-            <div class="day-header" @click="toggleDay(date)">
+          <div v-if="scheduleDays.length" class="schedule-layout">
+            <aside class="schedule-nav" aria-label="Saltar a día">
+              <div class="nav-group-label">Días</div>
+              <button
+                v-for="day in scheduleDays"
+                :key="day.date"
+                class="nav-item"
+                :class="{ active: activeDay === day.date }"
+                @click="scrollToDay(day.date)"
+              >
+                <span class="nav-item-label">{{ day.label }}</span>
+                <span class="nav-item-count">{{ day.count }}</span>
+              </button>
+            </aside>
+
+            <div ref="scheduleContentRef" class="schedule-content">
+              <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" :data-day="date" class="schedule-day">
+            <div class="day-header" @click="onDayHeaderClick(date)">
                 <h2>{{ formatDate(date) }}</h2>
-                <div class="chevron" :class="{ 'closed': !isOpen(date) }">
+                <div v-if="isMobile" class="chevron" :class="{ 'closed': !isOpen(date) }">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down"><path d="m6 9 6 6 6-6"/></svg>
                 </div>
             </div>
-            
+
             <transition name="slide">
-                <div v-show="isOpen(date)" class="screenings-list">
+                <div v-show="!isMobile || isOpen(date)" class="screenings-list">
                   <div v-for="screening in dayScreenings" :key="screening.id" class="screening-card">
                      <div class="time-block">
                         <span class="time">{{ formatTime(screening.start_time) }}</span>
                         <span class="timezone">{{ screening.timezone }}</span>
                      </div>
-                     
+
                       <div class="film-info">
-                         <a 
-                            :href="screening.film.source_url || 'https://www.bifff.net'"
-                            target="_blank"
+                         <component
+                            :is="screening.film.source_url ? 'a' : 'span'"
+                            :href="screening.film.source_url || ''"
+                            :target="screening.film.source_url ? '_blank' : ''"
                             class="film-title"
+                            :class="{'no-link': !screening.film.source_url}"
                          >
                             {{ screening.film.title }}
-                         </a>
+                         </component>
                          <div class="film-meta">
                              <span v-if="screening.film.director">Dirigida por {{ screening.film.director }}</span>
                              <span v-if="screening.film.director && screening.film.runtime"> • </span>
@@ -167,25 +190,27 @@
                             {{ screening.venue }}
                          </div>
                          <div class="tags">
-                             <span v-if="screening.is_in_person" class="tag in-person">En persona</span>
+                             <span v-if="screening.is_in_person" class="tag in-person">Presencial</span>
                              <span v-if="screening.is_online" class="tag online">Online</span>
                              <span v-if="screening.is_sold_out" class="tag sold-out">Agotado</span>
                          </div>
                       </div>
-                      
+
                       <div class="poster-mini">
-                          <img 
-                            v-if="screening.film.poster_path" 
-                            :src="screening.film.poster_path" 
-                            alt="Poster" 
-                            loading="lazy" 
-                            @error="$event.target.src = '/placeholders/image_not_found_yet_es.webp'"
+                          <img
+                            v-if="screening.film.poster_path"
+                            :src="screening.film.poster_path"
+                            alt="Poster"
+                            loading="lazy"
+                            @error="$event.target.src = '/placeholders/image_not_found_yet.webp'"
                           />
-                          <img v-else src="/placeholders/image_not_found_yet_es.webp" alt="No Poster" />
+                          <img v-else src="/placeholders/image_not_found_yet.webp" alt="No Poster" />
                       </div>
                   </div>
                 </div>
             </transition>
+          </div>
+            </div>
           </div>
         </div>
 
@@ -286,7 +311,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, nextTick } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount, nextTick, watch } from 'vue';
 import Loader from '~/components/Loader.vue';
 import WinnersCarousel from '~/components/festival/WinnersCarousel.vue';
 import FestivalDataDisclaimer from '~/components/FestivalDataDisclaimer.vue';
@@ -336,9 +361,6 @@ const awards = ref([]);
 const schedule = ref([]);
 const openDays = ref(new Set());
 
-const featuresOpen = ref(true);
-const shortsOpen = ref(true);
-
 const features = computed(() => {
     return films.value?.results?.filter(f => !f.runtime || f.runtime >= 40) || [];
 });
@@ -346,6 +368,55 @@ const features = computed(() => {
 const shorts = computed(() => {
     return films.value?.results?.filter(f => f.runtime > 0 && f.runtime < 40) || [];
 });
+
+const selectionSections = computed(() => [
+    { key: 'features', label: 'Largometrajes', films: features.value, count: features.value.length },
+    { key: 'shorts', label: 'Cortometrajes', films: shorts.value, count: shorts.value.length },
+].filter(sec => sec.count > 0));
+const officialNav = computed(() => selectionSections.value);
+const scrollToSection = (key) => {
+    activeSection.value = key;
+    const root = selectionContentRef.value;
+    if (!root) return;
+    for (const el of root.querySelectorAll('[data-key]')) {
+        if (el.getAttribute('data-key') === key) {
+            el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            break;
+        }
+    }
+};
+const setupSectionObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (sectionObserver) sectionObserver.disconnect();
+    const root = selectionContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-key]');
+    if (!els.length) return;
+    sectionObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) if (entry.isIntersecting) activeSection.value = entry.target.getAttribute('data-key');
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => sectionObserver.observe(el));
+};
+watch(selectionSections, (sections) => {
+    if (sections.length && !sections.some((sec) => sec.key === activeSection.value)) activeSection.value = sections[0].key;
+}, { immediate: true });
+watch([loading, activeTab, selectionSections], () => {
+    if (!loading.value && activeTab.value === 'films') nextTick(() => setupSectionObserver());
+    else if (sectionObserver) sectionObserver.disconnect();
+}, { flush: 'post' });
+
+const activeSection = ref('');
+const selectionContentRef = ref(null);
+let sectionObserver = null;
+const isMobile = ref(false);
+let mobileMql = null;
+const sectionOpen = ref({});
+const isSectionOpen = (key) => sectionOpen.value[key] !== false;
+const toggleSection = (key) => { sectionOpen.value = { ...sectionOpen.value, [key]: !isSectionOpen(key) }; };
+const onSectionHeaderClick = (key) => { if (!isMobile.value) return; toggleSection(key); };
+const activeDay = ref('');
+const scheduleContentRef = ref(null);
+let dayObserver = null;
 
 const formatDate = (dateStr) => {
     const options = { weekday: 'long', month: 'long', day: 'numeric' };
@@ -399,6 +470,52 @@ const isOpen = (date) => {
     return openDays.value.has(date);
 };
 
+const scheduleDays = computed(() => Object.entries(groupedScreenings.value).map(([date, arr]) => ({ date, label: formatDate(date), count: arr.length })));
+const onDayHeaderClick = (date) => { if (!isMobile.value) return; toggleDay(date); };
+const scrollToDay = (date) => {
+    activeDay.value = date;
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    for (const el of root.querySelectorAll('[data-day]')) {
+        if (el.getAttribute('data-day') === date) {
+            el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            break;
+        }
+    }
+};
+const setupDayObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (dayObserver) dayObserver.disconnect();
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-day]');
+    if (!els.length) return;
+    dayObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) if (entry.isIntersecting) activeDay.value = entry.target.getAttribute('data-day');
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => dayObserver.observe(el));
+};
+watch(scheduleDays, (days) => {
+    if (days.length && !days.some((d) => d.date === activeDay.value)) activeDay.value = days[0]?.date || '';
+}, { immediate: true });
+watch([loading, activeTab, scheduleDays], () => {
+    if (!loading.value && activeTab.value === 'schedule') nextTick(() => setupDayObserver());
+    else if (dayObserver) dayObserver.disconnect();
+}, { flush: 'post' });
+const updateIsMobile = (e) => { isMobile.value = e.matches; };
+onMounted(() => {
+    if (typeof window !== 'undefined' && window.matchMedia) {
+        mobileMql = window.matchMedia('(max-width: 900px)');
+        isMobile.value = mobileMql.matches;
+        mobileMql.addEventListener('change', updateIsMobile);
+    }
+});
+onBeforeUnmount(() => {
+    if (sectionObserver) sectionObserver.disconnect();
+    if (dayObserver) dayObserver.disconnect();
+    if (mobileMql) mobileMql.removeEventListener('change', updateIsMobile);
+});
+
 onMounted(async () => {
     try {
         const [filmsData, scheduleData, awardsData] = await Promise.all([
@@ -426,6 +543,223 @@ onMounted(async () => {
 
 <style lang="scss" scoped>
 @use '~/assets/css/utilities/variables' as *;
+
+// Poster sizing inside the Selection content column. The column is narrower than
+// the old full-bleed grid, so we use fewer columns / slightly larger posters.
+.selection :deep(.listing__items > .card) {
+    width: 33.3333%;
+
+    @media (min-width: 640px) {
+        width: 25%;
+    }
+    @media (min-width: 1024px) {
+        width: 20%;
+    }
+    @media (min-width: 1500px) {
+        width: 16.6666%;
+    }
+    @media (min-width: 1800px) {
+        width: 14.2857%;
+    }
+}
+
+
+/* ── Selection: sidebar scroll-spy + sections ───────────── */
+.selection-layout,
+.schedule-layout {
+    display: grid;
+    grid-template-columns: 330px minmax(0, 1fr);
+    gap: 2.5rem;
+    align-items: start;
+}
+
+/* Breathing room between the screenings search bar and the day list below it. */
+.schedule-layout {
+    margin-top: 1.75rem;
+}
+
+.selection-nav,
+.schedule-nav {
+    position: sticky;
+    top: 5.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-height: calc(100vh - 7rem);
+    overflow-y: auto;
+    padding: 1rem;
+    border: 1px solid transparent;
+    background:
+        linear-gradient(rgba(3, 6, 10, 0.85), rgba(3, 6, 10, 0.85)) padding-box,
+        linear-gradient(160deg, rgba(139, 233, 253, 0.55), rgba(31, 84, 103, 0.45) 60%, rgba(139, 233, 253, 0.16)) border-box;
+    border-radius: 14px;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
+}
+
+.nav-group-label {
+    font-size: 1rem;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    color: rgba(139, 233, 253, 0.9);
+    font-weight: 700;
+    margin: 1.2rem 0.4rem 0.55rem;
+
+    &:first-child {
+        margin-top: 0.2rem;
+    }
+}
+
+.nav-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    width: 100%;
+    background: none;
+    border: none;
+    border-left: 3px solid transparent;
+    border-radius: 0 8px 8px 0;
+    color: rgba(255, 255, 255, 0.88);
+    padding: 0.82rem 1rem;
+    font-size: 1.32rem;
+    font-family: inherit;
+    text-align: left;
+    cursor: pointer;
+    transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+
+    &:hover {
+        background: rgba(139, 233, 253, 0.08);
+        color: #eafbff;
+    }
+
+    &.active {
+        background: rgba(139, 233, 253, 0.12);
+        color: #8BE9FD;
+        border-left-color: #8BE9FD;
+        font-weight: 600;
+    }
+}
+
+.nav-item-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.nav-item-count {
+    font-size: 1.12rem;
+    color: rgba(255, 255, 255, 0.62);
+    flex-shrink: 0;
+}
+
+.nav-item.active .nav-item-count {
+    color: rgba(139, 233, 253, 0.85);
+}
+
+.sel-section {
+    scroll-margin-top: 6.5rem;
+    margin-bottom: 3rem;
+}
+
+.sel-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
+    padding-bottom: 6px;
+    margin-bottom: 1.25rem;
+}
+
+.sel-section-title {
+    margin: 0;
+    font-size: 1.7rem;
+    font-weight: 700;
+    color: #fff;
+}
+
+.sel-section-meta {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-shrink: 0;
+}
+
+.sel-section-count {
+    font-size: 1.05rem;
+    color: rgba(255, 255, 255, 0.5);
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.expand-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.3);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: #fff;
+    width: 36px;
+    height: 36px;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    flex-shrink: 0;
+
+    &:hover {
+        background: rgba(139, 233, 253, 0.15);
+        color: #8BE9FD;
+        border-color: rgba(139, 233, 253, 0.3);
+    }
+
+    svg {
+        width: 20px;
+        height: 20px;
+        min-width: 20px;
+        min-height: 20px;
+        display: block;
+    }
+}
+
+.parallel-band {
+    font-size: 0.85rem;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: #8BE9FD;
+    border-top: 1px solid rgba(139, 233, 253, 0.25);
+    padding-top: 1.4rem;
+    margin: 0.5rem 0 1.5rem;
+}
+
+@media (max-width: 900px) {
+    .selection-layout,
+    .schedule-layout {
+        display: block;
+    }
+
+    .selection-nav,
+    .schedule-nav {
+        display: none;
+    }
+
+    .sel-section-header {
+        cursor: pointer;
+        user-select: none;
+        transition: border-color 0.2s;
+    }
+
+    .sel-section-header:hover {
+        border-color: rgba(139, 233, 253, 0.6);
+    }
+
+    .day-header {
+        cursor: pointer;
+    }
+}
+
 
 :deep(.card__name) {
     font-size: 1.2rem;

--- a/pages/festival/romford-2026/index.vue
+++ b/pages/festival/romford-2026/index.vue
@@ -50,50 +50,55 @@
       </div>
 
       <div v-else>
-        <div v-if="activeTab === 'films'" class="films-grid">
-            <div v-if="features.length > 0" class="film-category">
-                <div class="category-header" @click="featuresOpen = !featuresOpen">
-                    <h2 class="listing__title category-title">
-                        Largometrajes
-                        <span class="category-count">({{ features.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="featuresOpen ? 'Ocultar' : 'Expandir'">
-                        <svg v-if="featuresOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
-                    </button>
-                </div>
-                <transition name="slide">
-                    <div v-show="featuresOpen" class="listing__items">
-                        <RomfordCard 
-                            v-for="item in features"
-                            :key="`feature-${item.id}`"
-                            :item="item" 
-                        />
-                    </div>
-                </transition>
-            </div>
+        <div v-if="activeTab === 'films'" class="selection">
+          <div class="selection-layout">
+            <aside class="selection-nav" aria-label="Saltar a sección">
+              <template v-if="officialNav.length">
+                <div class="nav-group-label">Catálogo</div>
+                <button
+                  v-for="sec in officialNav"
+                  :key="sec.key"
+                  class="nav-item"
+                  :class="{ active: activeSection === sec.key }"
+                  @click="scrollToSection(sec.key)"
+                >
+                  <span class="nav-item-label">{{ sec.label }}</span>
+                  <span class="nav-item-count">{{ sec.count }}</span>
+                </button>
+              </template>
+            </aside>
 
-            <div v-if="shorts.length > 0" class="film-category">
-                <div class="category-header" @click="shortsOpen = !shortsOpen">
-                    <h2 class="listing__title category-title">
-                        Cortometrajes
-                        <span class="category-count">({{ shorts.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="shortsOpen ? 'Ocultar' : 'Expandir'">
-                        <svg v-if="shortsOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
+            <div ref="selectionContentRef" class="selection-content">
+              <section
+                v-for="sec in selectionSections"
+                :key="sec.key"
+                :data-key="sec.key"
+                class="sel-section"
+              >
+                <div class="sel-section-header" @click="onSectionHeaderClick(sec.key)">
+                  <h2 class="sel-section-title">{{ sec.label }}</h2>
+                  <div class="sel-section-meta">
+                    <span class="sel-section-count">{{ sec.count }} {{ sec.count === 1 ? 'película' : 'películas' }}</span>
+                    <button v-if="isMobile" class="expand-btn" :aria-label="isSectionOpen(sec.key) ? 'Ocultar' : 'Expandir'">
+                      <svg v-if="isSectionOpen(sec.key)" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
+                      <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
                     </button>
+                  </div>
                 </div>
                 <transition name="slide">
-                    <div v-show="shortsOpen" class="listing__items">
-                        <RomfordCard 
-                            v-for="item in shorts"
-                            :key="`short-${item.id}`"
-                            :item="item" 
-                        />
+                  <div v-show="!isMobile || isSectionOpen(sec.key)" class="sel-section-body">
+                    <div class="listing__items">
+                      <RomfordCard
+                        v-for="item in sec.films"
+                        :key="`${sec.key}-${item.id}`"
+                        :item="item"
+                      />
                     </div>
+                  </div>
                 </transition>
+              </section>
             </div>
+          </div>
         </div>
 
         <div v-if="activeTab === 'schedule'" class="schedule-container">
@@ -133,30 +138,48 @@
             <p>Ninguna función coincide con "<strong>{{ scheduleSearch }}</strong>"</p>
           </div>
 
-          <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" class="schedule-day">
-            <div class="day-header" @click="toggleDay(date)">
+          <div v-if="scheduleDays.length" class="schedule-layout">
+            <aside class="schedule-nav" aria-label="Saltar a día">
+              <div class="nav-group-label">Días</div>
+              <button
+                v-for="day in scheduleDays"
+                :key="day.date"
+                class="nav-item"
+                :class="{ active: activeDay === day.date }"
+                @click="scrollToDay(day.date)"
+              >
+                <span class="nav-item-label">{{ day.label }}</span>
+                <span class="nav-item-count">{{ day.count }}</span>
+              </button>
+            </aside>
+
+            <div ref="scheduleContentRef" class="schedule-content">
+              <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" :data-day="date" class="schedule-day">
+            <div class="day-header" @click="onDayHeaderClick(date)">
                 <h2>{{ formatDate(date) }}</h2>
-                <div class="chevron" :class="{ 'closed': !isOpen(date) }">
+                <div v-if="isMobile" class="chevron" :class="{ 'closed': !isOpen(date) }">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down"><path d="m6 9 6 6 6-6"/></svg>
                 </div>
             </div>
-            
+
             <transition name="slide">
-                <div v-show="isOpen(date)" class="screenings-list">
+                <div v-show="!isMobile || isOpen(date)" class="screenings-list">
                   <div v-for="screening in dayScreenings" :key="screening.id" class="screening-card">
                      <div class="time-block">
                         <span class="time">{{ formatTime(screening.start_time) }}</span>
                         <span class="timezone">{{ screening.timezone }}</span>
                      </div>
-                     
+
                       <div class="film-info">
-                         <a 
-                            href="https://www.romfordhorrorfestival.com"
-                            target="_blank"
+                         <component
+                            :is="screening.film.source_url ? 'a' : 'span'"
+                            :href="screening.film.source_url || ''"
+                            :target="screening.film.source_url ? '_blank' : ''"
                             class="film-title"
+                            :class="{'no-link': !screening.film.source_url}"
                          >
                             {{ screening.film.title }}
-                         </a>
+                         </component>
                          <div class="film-meta">
                              <span v-if="screening.film.director">Dirigida por {{ screening.film.director }}</span>
                              <span v-if="screening.film.director && screening.film.runtime"> • </span>
@@ -167,25 +190,27 @@
                             {{ screening.venue }}
                          </div>
                          <div class="tags">
-                             <span v-if="screening.is_in_person" class="tag in-person">En persona</span>
+                             <span v-if="screening.is_in_person" class="tag in-person">Presencial</span>
                              <span v-if="screening.is_online" class="tag online">Online</span>
                              <span v-if="screening.is_sold_out" class="tag sold-out">Agotado</span>
                          </div>
                       </div>
-                      
+
                       <div class="poster-mini">
-                          <img 
-                            v-if="screening.film.poster_path" 
-                            :src="screening.film.poster_path" 
-                            alt="Poster" 
-                            loading="lazy" 
-                            @error="$event.target.src = '/placeholders/image_not_found_yet_es.webp'"
+                          <img
+                            v-if="screening.film.poster_path"
+                            :src="screening.film.poster_path"
+                            alt="Poster"
+                            loading="lazy"
+                            @error="$event.target.src = '/placeholders/image_not_found_yet.webp'"
                           />
-                          <img v-else src="/placeholders/image_not_found_yet_es.webp" alt="No Poster" />
+                          <img v-else src="/placeholders/image_not_found_yet.webp" alt="No Poster" />
                       </div>
                   </div>
                 </div>
             </transition>
+          </div>
+            </div>
           </div>
         </div>
 
@@ -245,7 +270,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, nextTick } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount, nextTick, watch } from 'vue';
 import Loader from '~/components/Loader.vue';
 import WinnersCarousel from '~/components/festival/WinnersCarousel.vue';
 import FestivalDataDisclaimer from '~/components/FestivalDataDisclaimer.vue';
@@ -295,9 +320,6 @@ const awards = ref([]);
 const schedule = ref([]);
 const openDays = ref(new Set());
 
-const featuresOpen = ref(true);
-const shortsOpen = ref(true);
-
 const features = computed(() => {
     return films.value?.results?.filter(f => !f.runtime || f.runtime >= 40) || [];
 });
@@ -305,6 +327,55 @@ const features = computed(() => {
 const shorts = computed(() => {
     return films.value?.results?.filter(f => f.runtime > 0 && f.runtime < 40) || [];
 });
+
+const selectionSections = computed(() => [
+    { key: 'features', label: 'Largometrajes', films: features.value, count: features.value.length },
+    { key: 'shorts', label: 'Cortometrajes', films: shorts.value, count: shorts.value.length },
+].filter(sec => sec.count > 0));
+const officialNav = computed(() => selectionSections.value);
+const scrollToSection = (key) => {
+    activeSection.value = key;
+    const root = selectionContentRef.value;
+    if (!root) return;
+    for (const el of root.querySelectorAll('[data-key]')) {
+        if (el.getAttribute('data-key') === key) {
+            el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            break;
+        }
+    }
+};
+const setupSectionObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (sectionObserver) sectionObserver.disconnect();
+    const root = selectionContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-key]');
+    if (!els.length) return;
+    sectionObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) if (entry.isIntersecting) activeSection.value = entry.target.getAttribute('data-key');
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => sectionObserver.observe(el));
+};
+watch(selectionSections, (sections) => {
+    if (sections.length && !sections.some((sec) => sec.key === activeSection.value)) activeSection.value = sections[0].key;
+}, { immediate: true });
+watch([loading, activeTab, selectionSections], () => {
+    if (!loading.value && activeTab.value === 'films') nextTick(() => setupSectionObserver());
+    else if (sectionObserver) sectionObserver.disconnect();
+}, { flush: 'post' });
+
+const activeSection = ref('');
+const selectionContentRef = ref(null);
+let sectionObserver = null;
+const isMobile = ref(false);
+let mobileMql = null;
+const sectionOpen = ref({});
+const isSectionOpen = (key) => sectionOpen.value[key] !== false;
+const toggleSection = (key) => { sectionOpen.value = { ...sectionOpen.value, [key]: !isSectionOpen(key) }; };
+const onSectionHeaderClick = (key) => { if (!isMobile.value) return; toggleSection(key); };
+const activeDay = ref('');
+const scheduleContentRef = ref(null);
+let dayObserver = null;
 
 const formatDate = (dateStr) => {
     const options = { weekday: 'long', month: 'long', day: 'numeric' };
@@ -357,6 +428,52 @@ const isOpen = (date) => {
     return openDays.value.has(date);
 };
 
+const scheduleDays = computed(() => Object.entries(groupedScreenings.value).map(([date, arr]) => ({ date, label: formatDate(date), count: arr.length })));
+const onDayHeaderClick = (date) => { if (!isMobile.value) return; toggleDay(date); };
+const scrollToDay = (date) => {
+    activeDay.value = date;
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    for (const el of root.querySelectorAll('[data-day]')) {
+        if (el.getAttribute('data-day') === date) {
+            el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            break;
+        }
+    }
+};
+const setupDayObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (dayObserver) dayObserver.disconnect();
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-day]');
+    if (!els.length) return;
+    dayObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) if (entry.isIntersecting) activeDay.value = entry.target.getAttribute('data-day');
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => dayObserver.observe(el));
+};
+watch(scheduleDays, (days) => {
+    if (days.length && !days.some((d) => d.date === activeDay.value)) activeDay.value = days[0]?.date || '';
+}, { immediate: true });
+watch([loading, activeTab, scheduleDays], () => {
+    if (!loading.value && activeTab.value === 'schedule') nextTick(() => setupDayObserver());
+    else if (dayObserver) dayObserver.disconnect();
+}, { flush: 'post' });
+const updateIsMobile = (e) => { isMobile.value = e.matches; };
+onMounted(() => {
+    if (typeof window !== 'undefined' && window.matchMedia) {
+        mobileMql = window.matchMedia('(max-width: 900px)');
+        isMobile.value = mobileMql.matches;
+        mobileMql.addEventListener('change', updateIsMobile);
+    }
+});
+onBeforeUnmount(() => {
+    if (sectionObserver) sectionObserver.disconnect();
+    if (dayObserver) dayObserver.disconnect();
+    if (mobileMql) mobileMql.removeEventListener('change', updateIsMobile);
+});
+
 onMounted(async () => {
     try {
         const [filmsData, scheduleData, awardsData] = await Promise.all([
@@ -384,6 +501,223 @@ onMounted(async () => {
 
 <style lang="scss" scoped>
 @use '~/assets/css/utilities/variables' as *;
+
+// Poster sizing inside the Selection content column. The column is narrower than
+// the old full-bleed grid, so we use fewer columns / slightly larger posters.
+.selection :deep(.listing__items > .card) {
+    width: 33.3333%;
+
+    @media (min-width: 640px) {
+        width: 25%;
+    }
+    @media (min-width: 1024px) {
+        width: 20%;
+    }
+    @media (min-width: 1500px) {
+        width: 16.6666%;
+    }
+    @media (min-width: 1800px) {
+        width: 14.2857%;
+    }
+}
+
+
+/* ── Selection: sidebar scroll-spy + sections ───────────── */
+.selection-layout,
+.schedule-layout {
+    display: grid;
+    grid-template-columns: 330px minmax(0, 1fr);
+    gap: 2.5rem;
+    align-items: start;
+}
+
+/* Breathing room between the screenings search bar and the day list below it. */
+.schedule-layout {
+    margin-top: 1.75rem;
+}
+
+.selection-nav,
+.schedule-nav {
+    position: sticky;
+    top: 5.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-height: calc(100vh - 7rem);
+    overflow-y: auto;
+    padding: 1rem;
+    border: 1px solid transparent;
+    background:
+        linear-gradient(rgba(3, 6, 10, 0.85), rgba(3, 6, 10, 0.85)) padding-box,
+        linear-gradient(160deg, rgba(139, 233, 253, 0.55), rgba(31, 84, 103, 0.45) 60%, rgba(139, 233, 253, 0.16)) border-box;
+    border-radius: 14px;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
+}
+
+.nav-group-label {
+    font-size: 1rem;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    color: rgba(139, 233, 253, 0.9);
+    font-weight: 700;
+    margin: 1.2rem 0.4rem 0.55rem;
+
+    &:first-child {
+        margin-top: 0.2rem;
+    }
+}
+
+.nav-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    width: 100%;
+    background: none;
+    border: none;
+    border-left: 3px solid transparent;
+    border-radius: 0 8px 8px 0;
+    color: rgba(255, 255, 255, 0.88);
+    padding: 0.82rem 1rem;
+    font-size: 1.32rem;
+    font-family: inherit;
+    text-align: left;
+    cursor: pointer;
+    transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+
+    &:hover {
+        background: rgba(139, 233, 253, 0.08);
+        color: #eafbff;
+    }
+
+    &.active {
+        background: rgba(139, 233, 253, 0.12);
+        color: #8BE9FD;
+        border-left-color: #8BE9FD;
+        font-weight: 600;
+    }
+}
+
+.nav-item-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.nav-item-count {
+    font-size: 1.12rem;
+    color: rgba(255, 255, 255, 0.62);
+    flex-shrink: 0;
+}
+
+.nav-item.active .nav-item-count {
+    color: rgba(139, 233, 253, 0.85);
+}
+
+.sel-section {
+    scroll-margin-top: 6.5rem;
+    margin-bottom: 3rem;
+}
+
+.sel-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
+    padding-bottom: 6px;
+    margin-bottom: 1.25rem;
+}
+
+.sel-section-title {
+    margin: 0;
+    font-size: 1.7rem;
+    font-weight: 700;
+    color: #fff;
+}
+
+.sel-section-meta {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-shrink: 0;
+}
+
+.sel-section-count {
+    font-size: 1.05rem;
+    color: rgba(255, 255, 255, 0.5);
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.expand-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.3);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: #fff;
+    width: 36px;
+    height: 36px;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    flex-shrink: 0;
+
+    &:hover {
+        background: rgba(139, 233, 253, 0.15);
+        color: #8BE9FD;
+        border-color: rgba(139, 233, 253, 0.3);
+    }
+
+    svg {
+        width: 20px;
+        height: 20px;
+        min-width: 20px;
+        min-height: 20px;
+        display: block;
+    }
+}
+
+.parallel-band {
+    font-size: 0.85rem;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: #8BE9FD;
+    border-top: 1px solid rgba(139, 233, 253, 0.25);
+    padding-top: 1.4rem;
+    margin: 0.5rem 0 1.5rem;
+}
+
+@media (max-width: 900px) {
+    .selection-layout,
+    .schedule-layout {
+        display: block;
+    }
+
+    .selection-nav,
+    .schedule-nav {
+        display: none;
+    }
+
+    .sel-section-header {
+        cursor: pointer;
+        user-select: none;
+        transition: border-color 0.2s;
+    }
+
+    .sel-section-header:hover {
+        border-color: rgba(139, 233, 253, 0.6);
+    }
+
+    .day-header {
+        cursor: pointer;
+    }
+}
+
 
 :deep(.card__name) {
     font-size: 1.2rem;

--- a/pages/festival/rotterdam-2026/index.vue
+++ b/pages/festival/rotterdam-2026/index.vue
@@ -50,50 +50,55 @@
       </div>
 
       <div v-else>
-        <div v-if="activeTab === 'films'" class="films-grid">
-            <div v-if="features.length > 0" class="film-category">
-                <div class="category-header" @click="featuresOpen = !featuresOpen">
-                    <h2 class="listing__title category-title">
-                        Largometrajes
-                        <span class="category-count">({{ features.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="featuresOpen ? 'Ocultar' : 'Expandir'">
-                        <svg v-if="featuresOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
-                    </button>
-                </div>
-                <transition name="slide">
-                    <div v-show="featuresOpen" class="listing__items">
-                        <RotterdamCard 
-                            v-for="item in features"
-                            :key="`feature-${item.id}`"
-                            :item="item" 
-                        />
-                    </div>
-                </transition>
-            </div>
+        <div v-if="activeTab === 'films'" class="selection">
+          <div class="selection-layout">
+            <aside class="selection-nav" aria-label="Saltar a sección">
+              <template v-if="officialNav.length">
+                <div class="nav-group-label">Catálogo</div>
+                <button
+                  v-for="sec in officialNav"
+                  :key="sec.key"
+                  class="nav-item"
+                  :class="{ active: activeSection === sec.key }"
+                  @click="scrollToSection(sec.key)"
+                >
+                  <span class="nav-item-label">{{ sec.label }}</span>
+                  <span class="nav-item-count">{{ sec.count }}</span>
+                </button>
+              </template>
+            </aside>
 
-            <div v-if="shorts.length > 0" class="film-category">
-                <div class="category-header" @click="shortsOpen = !shortsOpen">
-                    <h2 class="listing__title category-title">
-                        Cortometrajes
-                        <span class="category-count">({{ shorts.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="shortsOpen ? 'Ocultar' : 'Expandir'">
-                        <svg v-if="shortsOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
+            <div ref="selectionContentRef" class="selection-content">
+              <section
+                v-for="sec in selectionSections"
+                :key="sec.key"
+                :data-key="sec.key"
+                class="sel-section"
+              >
+                <div class="sel-section-header" @click="onSectionHeaderClick(sec.key)">
+                  <h2 class="sel-section-title">{{ sec.label }}</h2>
+                  <div class="sel-section-meta">
+                    <span class="sel-section-count">{{ sec.count }} {{ sec.count === 1 ? 'película' : 'películas' }}</span>
+                    <button v-if="isMobile" class="expand-btn" :aria-label="isSectionOpen(sec.key) ? 'Ocultar' : 'Expandir'">
+                      <svg v-if="isSectionOpen(sec.key)" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
+                      <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
                     </button>
+                  </div>
                 </div>
                 <transition name="slide">
-                    <div v-show="shortsOpen" class="listing__items">
-                        <RotterdamCard 
-                            v-for="item in shorts"
-                            :key="`short-${item.id}`"
-                            :item="item" 
-                        />
+                  <div v-show="!isMobile || isSectionOpen(sec.key)" class="sel-section-body">
+                    <div class="listing__items">
+                      <RotterdamCard
+                        v-for="item in sec.films"
+                        :key="`${sec.key}-${item.id}`"
+                        :item="item"
+                      />
                     </div>
+                  </div>
                 </transition>
+              </section>
             </div>
+          </div>
         </div>
 
         <div v-if="activeTab === 'schedule'" class="schedule-container">
@@ -133,37 +138,56 @@
             <p>Ninguna función coincide con "<strong>{{ scheduleSearch }}</strong>"</p>
           </div>
 
-          <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" class="schedule-day">
-            <div class="day-header" @click="toggleDay(date)">
+          <div v-if="scheduleDays.length" class="schedule-layout">
+            <aside class="schedule-nav" aria-label="Saltar a día">
+              <div class="nav-group-label">Días</div>
+              <button
+                v-for="day in scheduleDays"
+                :key="day.date"
+                class="nav-item"
+                :class="{ active: activeDay === day.date }"
+                @click="scrollToDay(day.date)"
+              >
+                <span class="nav-item-label">{{ day.label }}</span>
+                <span class="nav-item-count">{{ day.count }}</span>
+              </button>
+            </aside>
+
+            <div ref="scheduleContentRef" class="schedule-content">
+              <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" :data-day="date" class="schedule-day">
+            <div class="day-header" @click="onDayHeaderClick(date)">
                 <h2>{{ formatDate(date) }}</h2>
-                <div class="chevron" :class="{ 'closed': !isOpen(date) }">
+                <div v-if="isMobile" class="chevron" :class="{ 'closed': !isOpen(date) }">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down"><path d="m6 9 6 6 6-6"/></svg>
                 </div>
             </div>
-            
+
             <transition name="slide">
-                <div v-show="isOpen(date)" class="screenings-list">
+                <div v-show="!isMobile || isOpen(date)" class="screenings-list">
                   <div v-for="screening in dayScreenings" :key="screening.id" class="screening-card">
                      <div class="time-block">
                         <span class="time">{{ formatTime(screening.start_time) }}</span>
                         <span class="timezone">{{ screening.timezone }}</span>
                      </div>
-                     
+
                       <div class="film-info">
-                         <component 
-                            :is="isSafeUrl(screening.film.source_url) ? 'a' : 'span'"
-                            :href="isSafeUrl(screening.film.source_url) ? screening.film.source_url : ''"
-                            :target="isSafeUrl(screening.film.source_url) ? '_blank' : ''"
+                         <component
+                            :is="screening.film.source_url ? 'a' : 'span'"
+                            :href="screening.film.source_url || ''"
+                            :target="screening.film.source_url ? '_blank' : ''"
                             class="film-title"
-                            :class="{'no-link': !isSafeUrl(screening.film.source_url)}"
+                            :class="{'no-link': !screening.film.source_url}"
                          >
                             {{ screening.film.title }}
                          </component>
                          <div class="film-meta">
-                             <span v-if="screening.film.director">Directed by {{ screening.film.director }}</span>
+                             <span v-if="screening.film.director">Dirigida por {{ screening.film.director }}</span>
                              <span v-if="screening.film.director && screening.film.runtime"> • </span>
                              <span v-if="screening.film.runtime">{{ screening.film.runtime }} min</span>
-                             <span v-if="screening.venue"> • {{ screening.venue }}</span>
+                         </div>
+                         <div v-if="screening.venue" class="venue-info">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-map-pin"><path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"/><circle cx="12" cy="10" r="3"/></svg>
+                            {{ screening.venue }}
                          </div>
                          <div class="tags">
                              <span v-if="screening.is_in_person" class="tag in-person">Presencial</span>
@@ -171,20 +195,22 @@
                              <span v-if="screening.is_sold_out" class="tag sold-out">Agotado</span>
                          </div>
                       </div>
-                      
+
                       <div class="poster-mini">
-                          <img 
-                            v-if="screening.film.poster_path" 
-                            :src="screening.film.poster_path" 
-                            alt="Poster" 
-                            loading="lazy" 
-                            @error="$event.target.src = '/placeholders/image_not_found_yet_es.webp'"
+                          <img
+                            v-if="screening.film.poster_path"
+                            :src="screening.film.poster_path"
+                            alt="Poster"
+                            loading="lazy"
+                            @error="$event.target.src = '/placeholders/image_not_found_yet.webp'"
                           />
-                          <img v-else src="/placeholders/image_not_found_yet_es.webp" alt="No Poster" />
+                          <img v-else src="/placeholders/image_not_found_yet.webp" alt="No Poster" />
                       </div>
                   </div>
                 </div>
             </transition>
+          </div>
+            </div>
           </div>
         </div>
 
@@ -282,7 +308,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, nextTick } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount, nextTick, watch } from 'vue';
 import Loader from '~/components/Loader.vue';
 import WinnersCarousel from '~/components/festival/WinnersCarousel.vue';
 import FestivalDataDisclaimer from '~/components/FestivalDataDisclaimer.vue';
@@ -345,9 +371,6 @@ const awards = ref([]);
 const schedule = ref([]);
 const openDays = ref(new Set());
 
-const featuresOpen = ref(true);
-const shortsOpen = ref(true);
-
 const features = computed(() => {
     return films.value?.results?.filter(f => !f.runtime || f.runtime >= 40) || [];
 });
@@ -355,6 +378,55 @@ const features = computed(() => {
 const shorts = computed(() => {
     return films.value?.results?.filter(f => f.runtime > 0 && f.runtime < 40) || [];
 });
+
+const selectionSections = computed(() => [
+    { key: 'features', label: 'Largometrajes', films: features.value, count: features.value.length },
+    { key: 'shorts', label: 'Cortometrajes', films: shorts.value, count: shorts.value.length },
+].filter(sec => sec.count > 0));
+const officialNav = computed(() => selectionSections.value);
+const scrollToSection = (key) => {
+    activeSection.value = key;
+    const root = selectionContentRef.value;
+    if (!root) return;
+    for (const el of root.querySelectorAll('[data-key]')) {
+        if (el.getAttribute('data-key') === key) {
+            el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            break;
+        }
+    }
+};
+const setupSectionObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (sectionObserver) sectionObserver.disconnect();
+    const root = selectionContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-key]');
+    if (!els.length) return;
+    sectionObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) if (entry.isIntersecting) activeSection.value = entry.target.getAttribute('data-key');
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => sectionObserver.observe(el));
+};
+watch(selectionSections, (sections) => {
+    if (sections.length && !sections.some((sec) => sec.key === activeSection.value)) activeSection.value = sections[0].key;
+}, { immediate: true });
+watch([loading, activeTab, selectionSections], () => {
+    if (!loading.value && activeTab.value === 'films') nextTick(() => setupSectionObserver());
+    else if (sectionObserver) sectionObserver.disconnect();
+}, { flush: 'post' });
+
+const activeSection = ref('');
+const selectionContentRef = ref(null);
+let sectionObserver = null;
+const isMobile = ref(false);
+let mobileMql = null;
+const sectionOpen = ref({});
+const isSectionOpen = (key) => sectionOpen.value[key] !== false;
+const toggleSection = (key) => { sectionOpen.value = { ...sectionOpen.value, [key]: !isSectionOpen(key) }; };
+const onSectionHeaderClick = (key) => { if (!isMobile.value) return; toggleSection(key); };
+const activeDay = ref('');
+const scheduleContentRef = ref(null);
+let dayObserver = null;
 
 const formatDate = (dateStr) => {
     const options = { weekday: 'long', month: 'long', day: 'numeric' };
@@ -404,6 +476,52 @@ const isOpen = (date) => {
     return openDays.value.has(date);
 };
 
+const scheduleDays = computed(() => Object.entries(groupedScreenings.value).map(([date, arr]) => ({ date, label: formatDate(date), count: arr.length })));
+const onDayHeaderClick = (date) => { if (!isMobile.value) return; toggleDay(date); };
+const scrollToDay = (date) => {
+    activeDay.value = date;
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    for (const el of root.querySelectorAll('[data-day]')) {
+        if (el.getAttribute('data-day') === date) {
+            el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            break;
+        }
+    }
+};
+const setupDayObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (dayObserver) dayObserver.disconnect();
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-day]');
+    if (!els.length) return;
+    dayObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) if (entry.isIntersecting) activeDay.value = entry.target.getAttribute('data-day');
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => dayObserver.observe(el));
+};
+watch(scheduleDays, (days) => {
+    if (days.length && !days.some((d) => d.date === activeDay.value)) activeDay.value = days[0]?.date || '';
+}, { immediate: true });
+watch([loading, activeTab, scheduleDays], () => {
+    if (!loading.value && activeTab.value === 'schedule') nextTick(() => setupDayObserver());
+    else if (dayObserver) dayObserver.disconnect();
+}, { flush: 'post' });
+const updateIsMobile = (e) => { isMobile.value = e.matches; };
+onMounted(() => {
+    if (typeof window !== 'undefined' && window.matchMedia) {
+        mobileMql = window.matchMedia('(max-width: 900px)');
+        isMobile.value = mobileMql.matches;
+        mobileMql.addEventListener('change', updateIsMobile);
+    }
+});
+onBeforeUnmount(() => {
+    if (sectionObserver) sectionObserver.disconnect();
+    if (dayObserver) dayObserver.disconnect();
+    if (mobileMql) mobileMql.removeEventListener('change', updateIsMobile);
+});
+
 onMounted(async () => {
     try {
         const [filmsData, scheduleData, awardsData] = await Promise.all([
@@ -442,6 +560,223 @@ onMounted(async () => {
 
 <style lang="scss" scoped>
 @use '~/assets/css/utilities/variables' as *;
+
+// Poster sizing inside the Selection content column. The column is narrower than
+// the old full-bleed grid, so we use fewer columns / slightly larger posters.
+.selection :deep(.listing__items > .card) {
+    width: 33.3333%;
+
+    @media (min-width: 640px) {
+        width: 25%;
+    }
+    @media (min-width: 1024px) {
+        width: 20%;
+    }
+    @media (min-width: 1500px) {
+        width: 16.6666%;
+    }
+    @media (min-width: 1800px) {
+        width: 14.2857%;
+    }
+}
+
+
+/* ── Selection: sidebar scroll-spy + sections ───────────── */
+.selection-layout,
+.schedule-layout {
+    display: grid;
+    grid-template-columns: 330px minmax(0, 1fr);
+    gap: 2.5rem;
+    align-items: start;
+}
+
+/* Breathing room between the screenings search bar and the day list below it. */
+.schedule-layout {
+    margin-top: 1.75rem;
+}
+
+.selection-nav,
+.schedule-nav {
+    position: sticky;
+    top: 5.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-height: calc(100vh - 7rem);
+    overflow-y: auto;
+    padding: 1rem;
+    border: 1px solid transparent;
+    background:
+        linear-gradient(rgba(3, 6, 10, 0.85), rgba(3, 6, 10, 0.85)) padding-box,
+        linear-gradient(160deg, rgba(139, 233, 253, 0.55), rgba(31, 84, 103, 0.45) 60%, rgba(139, 233, 253, 0.16)) border-box;
+    border-radius: 14px;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
+}
+
+.nav-group-label {
+    font-size: 1rem;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    color: rgba(139, 233, 253, 0.9);
+    font-weight: 700;
+    margin: 1.2rem 0.4rem 0.55rem;
+
+    &:first-child {
+        margin-top: 0.2rem;
+    }
+}
+
+.nav-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    width: 100%;
+    background: none;
+    border: none;
+    border-left: 3px solid transparent;
+    border-radius: 0 8px 8px 0;
+    color: rgba(255, 255, 255, 0.88);
+    padding: 0.82rem 1rem;
+    font-size: 1.32rem;
+    font-family: inherit;
+    text-align: left;
+    cursor: pointer;
+    transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+
+    &:hover {
+        background: rgba(139, 233, 253, 0.08);
+        color: #eafbff;
+    }
+
+    &.active {
+        background: rgba(139, 233, 253, 0.12);
+        color: #8BE9FD;
+        border-left-color: #8BE9FD;
+        font-weight: 600;
+    }
+}
+
+.nav-item-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.nav-item-count {
+    font-size: 1.12rem;
+    color: rgba(255, 255, 255, 0.62);
+    flex-shrink: 0;
+}
+
+.nav-item.active .nav-item-count {
+    color: rgba(139, 233, 253, 0.85);
+}
+
+.sel-section {
+    scroll-margin-top: 6.5rem;
+    margin-bottom: 3rem;
+}
+
+.sel-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
+    padding-bottom: 6px;
+    margin-bottom: 1.25rem;
+}
+
+.sel-section-title {
+    margin: 0;
+    font-size: 1.7rem;
+    font-weight: 700;
+    color: #fff;
+}
+
+.sel-section-meta {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-shrink: 0;
+}
+
+.sel-section-count {
+    font-size: 1.05rem;
+    color: rgba(255, 255, 255, 0.5);
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.expand-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.3);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: #fff;
+    width: 36px;
+    height: 36px;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    flex-shrink: 0;
+
+    &:hover {
+        background: rgba(139, 233, 253, 0.15);
+        color: #8BE9FD;
+        border-color: rgba(139, 233, 253, 0.3);
+    }
+
+    svg {
+        width: 20px;
+        height: 20px;
+        min-width: 20px;
+        min-height: 20px;
+        display: block;
+    }
+}
+
+.parallel-band {
+    font-size: 0.85rem;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: #8BE9FD;
+    border-top: 1px solid rgba(139, 233, 253, 0.25);
+    padding-top: 1.4rem;
+    margin: 0.5rem 0 1.5rem;
+}
+
+@media (max-width: 900px) {
+    .selection-layout,
+    .schedule-layout {
+        display: block;
+    }
+
+    .selection-nav,
+    .schedule-nav {
+        display: none;
+    }
+
+    .sel-section-header {
+        cursor: pointer;
+        user-select: none;
+        transition: border-color 0.2s;
+    }
+
+    .sel-section-header:hover {
+        border-color: rgba(139, 233, 253, 0.6);
+    }
+
+    .day-header {
+        cursor: pointer;
+    }
+}
+
 
 :deep(.card__name) {
     font-size: 1.2rem;

--- a/pages/festival/slamdance-2026/index.vue
+++ b/pages/festival/slamdance-2026/index.vue
@@ -50,50 +50,55 @@
       </div>
 
       <div v-else>
-        <div v-if="activeTab === 'films'" class="films-grid">
-            <div v-if="features.length > 0" class="film-category">
-                <div class="category-header" @click="featuresOpen = !featuresOpen">
-                    <h2 class="listing__title category-title">
-                        Largometrajes
-                        <span class="category-count">({{ features.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="featuresOpen ? 'Ocultar' : 'Expandir'">
-                        <svg v-if="featuresOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
-                    </button>
-                </div>
-                <transition name="slide">
-                    <div v-show="featuresOpen" class="listing__items">
-                        <SlamdanceCard 
-                            v-for="item in features"
-                            :key="`feature-${item.id}`"
-                            :item="item" 
-                        />
-                    </div>
-                </transition>
-            </div>
+        <div v-if="activeTab === 'films'" class="selection">
+          <div class="selection-layout">
+            <aside class="selection-nav" aria-label="Saltar a sección">
+              <template v-if="officialNav.length">
+                <div class="nav-group-label">Catálogo</div>
+                <button
+                  v-for="sec in officialNav"
+                  :key="sec.key"
+                  class="nav-item"
+                  :class="{ active: activeSection === sec.key }"
+                  @click="scrollToSection(sec.key)"
+                >
+                  <span class="nav-item-label">{{ sec.label }}</span>
+                  <span class="nav-item-count">{{ sec.count }}</span>
+                </button>
+              </template>
+            </aside>
 
-            <div v-if="shorts.length > 0" class="film-category">
-                <div class="category-header" @click="shortsOpen = !shortsOpen">
-                    <h2 class="listing__title category-title">
-                        Cortometrajes
-                        <span class="category-count">({{ shorts.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="shortsOpen ? 'Ocultar' : 'Expandir'">
-                        <svg v-if="shortsOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
+            <div ref="selectionContentRef" class="selection-content">
+              <section
+                v-for="sec in selectionSections"
+                :key="sec.key"
+                :data-key="sec.key"
+                class="sel-section"
+              >
+                <div class="sel-section-header" @click="onSectionHeaderClick(sec.key)">
+                  <h2 class="sel-section-title">{{ sec.label }}</h2>
+                  <div class="sel-section-meta">
+                    <span class="sel-section-count">{{ sec.count }} {{ sec.count === 1 ? 'película' : 'películas' }}</span>
+                    <button v-if="isMobile" class="expand-btn" :aria-label="isSectionOpen(sec.key) ? 'Ocultar' : 'Expandir'">
+                      <svg v-if="isSectionOpen(sec.key)" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
+                      <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
                     </button>
+                  </div>
                 </div>
                 <transition name="slide">
-                    <div v-show="shortsOpen" class="listing__items">
-                        <SlamdanceCard 
-                            v-for="item in shorts"
-                            :key="`short-${item.id}`"
-                            :item="item" 
-                        />
+                  <div v-show="!isMobile || isSectionOpen(sec.key)" class="sel-section-body">
+                    <div class="listing__items">
+                      <SlamdanceCard
+                        v-for="item in sec.films"
+                        :key="`${sec.key}-${item.id}`"
+                        :item="item"
+                      />
                     </div>
+                  </div>
                 </transition>
+              </section>
             </div>
+          </div>
         </div>
 
         <div v-if="activeTab === 'schedule'" class="schedule-container">
@@ -133,30 +138,48 @@
             <p>Ninguna función coincide con "<strong>{{ scheduleSearch }}</strong>"</p>
           </div>
 
-          <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" class="schedule-day">
-            <div class="day-header" @click="toggleDay(date)">
+          <div v-if="scheduleDays.length" class="schedule-layout">
+            <aside class="schedule-nav" aria-label="Saltar a día">
+              <div class="nav-group-label">Días</div>
+              <button
+                v-for="day in scheduleDays"
+                :key="day.date"
+                class="nav-item"
+                :class="{ active: activeDay === day.date }"
+                @click="scrollToDay(day.date)"
+              >
+                <span class="nav-item-label">{{ day.label }}</span>
+                <span class="nav-item-count">{{ day.count }}</span>
+              </button>
+            </aside>
+
+            <div ref="scheduleContentRef" class="schedule-content">
+              <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" :data-day="date" class="schedule-day">
+            <div class="day-header" @click="onDayHeaderClick(date)">
                 <h2>{{ formatDate(date) }}</h2>
-                <div class="chevron" :class="{ 'closed': !isOpen(date) }">
+                <div v-if="isMobile" class="chevron" :class="{ 'closed': !isOpen(date) }">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down"><path d="m6 9 6 6 6-6"/></svg>
                 </div>
             </div>
-            
+
             <transition name="slide">
-                <div v-show="isOpen(date)" class="screenings-list">
+                <div v-show="!isMobile || isOpen(date)" class="screenings-list">
                   <div v-for="screening in dayScreenings" :key="screening.id" class="screening-card">
                      <div class="time-block">
                         <span class="time">{{ formatTime(screening.start_time) }}</span>
                         <span class="timezone">{{ screening.timezone }}</span>
                      </div>
-                     
+
                       <div class="film-info">
-                         <a 
-                            href="https://slamdance.com/26-digital-program/"
-                            target="_blank"
+                         <component
+                            :is="screening.film.source_url ? 'a' : 'span'"
+                            :href="screening.film.source_url || ''"
+                            :target="screening.film.source_url ? '_blank' : ''"
                             class="film-title"
+                            :class="{'no-link': !screening.film.source_url}"
                          >
                             {{ screening.film.title }}
-                         </a>
+                         </component>
                          <div class="film-meta">
                              <span v-if="screening.film.director">Dirigida por {{ screening.film.director }}</span>
                              <span v-if="screening.film.director && screening.film.runtime"> • </span>
@@ -167,25 +190,27 @@
                             {{ screening.venue }}
                          </div>
                          <div class="tags">
-                             <span v-if="screening.is_in_person" class="tag in-person">En persona</span>
+                             <span v-if="screening.is_in_person" class="tag in-person">Presencial</span>
                              <span v-if="screening.is_online" class="tag online">Online</span>
                              <span v-if="screening.is_sold_out" class="tag sold-out">Agotado</span>
                          </div>
                       </div>
-                      
+
                       <div class="poster-mini">
-                          <img 
-                            v-if="screening.film.poster_path" 
-                            :src="screening.film.poster_path" 
-                            alt="Poster" 
-                            loading="lazy" 
-                            @error="$event.target.src = '/placeholders/image_not_found_yet_es.webp'"
+                          <img
+                            v-if="screening.film.poster_path"
+                            :src="screening.film.poster_path"
+                            alt="Poster"
+                            loading="lazy"
+                            @error="$event.target.src = '/placeholders/image_not_found_yet.webp'"
                           />
-                          <img v-else src="/placeholders/image_not_found_yet_es.webp" alt="No Poster" />
+                          <img v-else src="/placeholders/image_not_found_yet.webp" alt="No Poster" />
                       </div>
                   </div>
                 </div>
             </transition>
+          </div>
+            </div>
           </div>
         </div>
 
@@ -271,7 +296,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, nextTick } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount, nextTick, watch } from 'vue';
 import Loader from '~/components/Loader.vue';
 import WinnersCarousel from '~/components/festival/WinnersCarousel.vue';
 import FestivalDataDisclaimer from '~/components/FestivalDataDisclaimer.vue';
@@ -321,9 +346,6 @@ const awards = ref([]);
 const schedule = ref([]);
 const openDays = ref(new Set());
 
-const featuresOpen = ref(true);
-const shortsOpen = ref(true);
-
 const features = computed(() => {
     return films.value?.results?.filter(f => !f.runtime || f.runtime >= 40) || [];
 });
@@ -331,6 +353,55 @@ const features = computed(() => {
 const shorts = computed(() => {
     return films.value?.results?.filter(f => f.runtime > 0 && f.runtime < 40) || [];
 });
+
+const selectionSections = computed(() => [
+    { key: 'features', label: 'Largometrajes', films: features.value, count: features.value.length },
+    { key: 'shorts', label: 'Cortometrajes', films: shorts.value, count: shorts.value.length },
+].filter(sec => sec.count > 0));
+const officialNav = computed(() => selectionSections.value);
+const scrollToSection = (key) => {
+    activeSection.value = key;
+    const root = selectionContentRef.value;
+    if (!root) return;
+    for (const el of root.querySelectorAll('[data-key]')) {
+        if (el.getAttribute('data-key') === key) {
+            el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            break;
+        }
+    }
+};
+const setupSectionObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (sectionObserver) sectionObserver.disconnect();
+    const root = selectionContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-key]');
+    if (!els.length) return;
+    sectionObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) if (entry.isIntersecting) activeSection.value = entry.target.getAttribute('data-key');
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => sectionObserver.observe(el));
+};
+watch(selectionSections, (sections) => {
+    if (sections.length && !sections.some((sec) => sec.key === activeSection.value)) activeSection.value = sections[0].key;
+}, { immediate: true });
+watch([loading, activeTab, selectionSections], () => {
+    if (!loading.value && activeTab.value === 'films') nextTick(() => setupSectionObserver());
+    else if (sectionObserver) sectionObserver.disconnect();
+}, { flush: 'post' });
+
+const activeSection = ref('');
+const selectionContentRef = ref(null);
+let sectionObserver = null;
+const isMobile = ref(false);
+let mobileMql = null;
+const sectionOpen = ref({});
+const isSectionOpen = (key) => sectionOpen.value[key] !== false;
+const toggleSection = (key) => { sectionOpen.value = { ...sectionOpen.value, [key]: !isSectionOpen(key) }; };
+const onSectionHeaderClick = (key) => { if (!isMobile.value) return; toggleSection(key); };
+const activeDay = ref('');
+const scheduleContentRef = ref(null);
+let dayObserver = null;
 
 const formatDate = (dateStr) => {
     const options = { weekday: 'long', month: 'long', day: 'numeric' };
@@ -383,6 +454,52 @@ const isOpen = (date) => {
     return openDays.value.has(date);
 };
 
+const scheduleDays = computed(() => Object.entries(groupedScreenings.value).map(([date, arr]) => ({ date, label: formatDate(date), count: arr.length })));
+const onDayHeaderClick = (date) => { if (!isMobile.value) return; toggleDay(date); };
+const scrollToDay = (date) => {
+    activeDay.value = date;
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    for (const el of root.querySelectorAll('[data-day]')) {
+        if (el.getAttribute('data-day') === date) {
+            el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            break;
+        }
+    }
+};
+const setupDayObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (dayObserver) dayObserver.disconnect();
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-day]');
+    if (!els.length) return;
+    dayObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) if (entry.isIntersecting) activeDay.value = entry.target.getAttribute('data-day');
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => dayObserver.observe(el));
+};
+watch(scheduleDays, (days) => {
+    if (days.length && !days.some((d) => d.date === activeDay.value)) activeDay.value = days[0]?.date || '';
+}, { immediate: true });
+watch([loading, activeTab, scheduleDays], () => {
+    if (!loading.value && activeTab.value === 'schedule') nextTick(() => setupDayObserver());
+    else if (dayObserver) dayObserver.disconnect();
+}, { flush: 'post' });
+const updateIsMobile = (e) => { isMobile.value = e.matches; };
+onMounted(() => {
+    if (typeof window !== 'undefined' && window.matchMedia) {
+        mobileMql = window.matchMedia('(max-width: 900px)');
+        isMobile.value = mobileMql.matches;
+        mobileMql.addEventListener('change', updateIsMobile);
+    }
+});
+onBeforeUnmount(() => {
+    if (sectionObserver) sectionObserver.disconnect();
+    if (dayObserver) dayObserver.disconnect();
+    if (mobileMql) mobileMql.removeEventListener('change', updateIsMobile);
+});
+
 onMounted(async () => {
     try {
         const [filmsData, scheduleData, awardsData] = await Promise.all([
@@ -410,6 +527,223 @@ onMounted(async () => {
 
 <style lang="scss" scoped>
 @use '~/assets/css/utilities/variables' as *;
+
+// Poster sizing inside the Selection content column. The column is narrower than
+// the old full-bleed grid, so we use fewer columns / slightly larger posters.
+.selection :deep(.listing__items > .card) {
+    width: 33.3333%;
+
+    @media (min-width: 640px) {
+        width: 25%;
+    }
+    @media (min-width: 1024px) {
+        width: 20%;
+    }
+    @media (min-width: 1500px) {
+        width: 16.6666%;
+    }
+    @media (min-width: 1800px) {
+        width: 14.2857%;
+    }
+}
+
+
+/* ── Selection: sidebar scroll-spy + sections ───────────── */
+.selection-layout,
+.schedule-layout {
+    display: grid;
+    grid-template-columns: 330px minmax(0, 1fr);
+    gap: 2.5rem;
+    align-items: start;
+}
+
+/* Breathing room between the screenings search bar and the day list below it. */
+.schedule-layout {
+    margin-top: 1.75rem;
+}
+
+.selection-nav,
+.schedule-nav {
+    position: sticky;
+    top: 5.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-height: calc(100vh - 7rem);
+    overflow-y: auto;
+    padding: 1rem;
+    border: 1px solid transparent;
+    background:
+        linear-gradient(rgba(3, 6, 10, 0.85), rgba(3, 6, 10, 0.85)) padding-box,
+        linear-gradient(160deg, rgba(139, 233, 253, 0.55), rgba(31, 84, 103, 0.45) 60%, rgba(139, 233, 253, 0.16)) border-box;
+    border-radius: 14px;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
+}
+
+.nav-group-label {
+    font-size: 1rem;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    color: rgba(139, 233, 253, 0.9);
+    font-weight: 700;
+    margin: 1.2rem 0.4rem 0.55rem;
+
+    &:first-child {
+        margin-top: 0.2rem;
+    }
+}
+
+.nav-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    width: 100%;
+    background: none;
+    border: none;
+    border-left: 3px solid transparent;
+    border-radius: 0 8px 8px 0;
+    color: rgba(255, 255, 255, 0.88);
+    padding: 0.82rem 1rem;
+    font-size: 1.32rem;
+    font-family: inherit;
+    text-align: left;
+    cursor: pointer;
+    transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+
+    &:hover {
+        background: rgba(139, 233, 253, 0.08);
+        color: #eafbff;
+    }
+
+    &.active {
+        background: rgba(139, 233, 253, 0.12);
+        color: #8BE9FD;
+        border-left-color: #8BE9FD;
+        font-weight: 600;
+    }
+}
+
+.nav-item-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.nav-item-count {
+    font-size: 1.12rem;
+    color: rgba(255, 255, 255, 0.62);
+    flex-shrink: 0;
+}
+
+.nav-item.active .nav-item-count {
+    color: rgba(139, 233, 253, 0.85);
+}
+
+.sel-section {
+    scroll-margin-top: 6.5rem;
+    margin-bottom: 3rem;
+}
+
+.sel-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
+    padding-bottom: 6px;
+    margin-bottom: 1.25rem;
+}
+
+.sel-section-title {
+    margin: 0;
+    font-size: 1.7rem;
+    font-weight: 700;
+    color: #fff;
+}
+
+.sel-section-meta {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-shrink: 0;
+}
+
+.sel-section-count {
+    font-size: 1.05rem;
+    color: rgba(255, 255, 255, 0.5);
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.expand-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.3);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: #fff;
+    width: 36px;
+    height: 36px;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    flex-shrink: 0;
+
+    &:hover {
+        background: rgba(139, 233, 253, 0.15);
+        color: #8BE9FD;
+        border-color: rgba(139, 233, 253, 0.3);
+    }
+
+    svg {
+        width: 20px;
+        height: 20px;
+        min-width: 20px;
+        min-height: 20px;
+        display: block;
+    }
+}
+
+.parallel-band {
+    font-size: 0.85rem;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: #8BE9FD;
+    border-top: 1px solid rgba(139, 233, 253, 0.25);
+    padding-top: 1.4rem;
+    margin: 0.5rem 0 1.5rem;
+}
+
+@media (max-width: 900px) {
+    .selection-layout,
+    .schedule-layout {
+        display: block;
+    }
+
+    .selection-nav,
+    .schedule-nav {
+        display: none;
+    }
+
+    .sel-section-header {
+        cursor: pointer;
+        user-select: none;
+        transition: border-color 0.2s;
+    }
+
+    .sel-section-header:hover {
+        border-color: rgba(139, 233, 253, 0.6);
+    }
+
+    .day-header {
+        cursor: pointer;
+    }
+}
+
 
 :deep(.card__name) {
     font-size: 1.2rem;

--- a/pages/festival/sundance-2026/index.vue
+++ b/pages/festival/sundance-2026/index.vue
@@ -49,50 +49,55 @@
       </div>
 
       <div v-else>
-        <div v-if="activeTab === 'films'" class="films-grid">
-            <div v-if="features.length > 0" class="film-category">
-                <div class="category-header" @click="featuresOpen = !featuresOpen">
-                    <h2 class="listing__title category-title">
-                        Largometrajes
-                        <span class="category-count">({{ features.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="featuresOpen ? 'Ocultar' : 'Expandir'">
-                        <svg v-if="featuresOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
-                    </button>
-                </div>
-                <transition name="slide">
-                    <div v-show="featuresOpen" class="listing__items">
-                        <SundanceCard 
-                            v-for="item in features"
-                            :key="`feature-${item.id}`"
-                            :item="item" 
-                        />
-                    </div>
-                </transition>
-            </div>
+        <div v-if="activeTab === 'films'" class="selection">
+          <div class="selection-layout">
+            <aside class="selection-nav" aria-label="Saltar a sección">
+              <template v-if="officialNav.length">
+                <div class="nav-group-label">Catálogo</div>
+                <button
+                  v-for="sec in officialNav"
+                  :key="sec.key"
+                  class="nav-item"
+                  :class="{ active: activeSection === sec.key }"
+                  @click="scrollToSection(sec.key)"
+                >
+                  <span class="nav-item-label">{{ sec.label }}</span>
+                  <span class="nav-item-count">{{ sec.count }}</span>
+                </button>
+              </template>
+            </aside>
 
-            <div v-if="shorts.length > 0" class="film-category">
-                <div class="category-header" @click="shortsOpen = !shortsOpen">
-                    <h2 class="listing__title category-title">
-                        Cortometrajes
-                        <span class="category-count">({{ shorts.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="shortsOpen ? 'Ocultar' : 'Expandir'">
-                        <svg v-if="shortsOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
+            <div ref="selectionContentRef" class="selection-content">
+              <section
+                v-for="sec in selectionSections"
+                :key="sec.key"
+                :data-key="sec.key"
+                class="sel-section"
+              >
+                <div class="sel-section-header" @click="onSectionHeaderClick(sec.key)">
+                  <h2 class="sel-section-title">{{ sec.label }}</h2>
+                  <div class="sel-section-meta">
+                    <span class="sel-section-count">{{ sec.count }} {{ sec.count === 1 ? 'película' : 'películas' }}</span>
+                    <button v-if="isMobile" class="expand-btn" :aria-label="isSectionOpen(sec.key) ? 'Ocultar' : 'Expandir'">
+                      <svg v-if="isSectionOpen(sec.key)" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
+                      <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
                     </button>
+                  </div>
                 </div>
                 <transition name="slide">
-                    <div v-show="shortsOpen" class="listing__items">
-                        <SundanceCard 
-                            v-for="item in shorts"
-                            :key="`short-${item.id}`"
-                            :item="item" 
-                        />
+                  <div v-show="!isMobile || isSectionOpen(sec.key)" class="sel-section-body">
+                    <div class="listing__items">
+                      <SundanceCard
+                        v-for="item in sec.films"
+                        :key="`${sec.key}-${item.id}`"
+                        :item="item"
+                      />
                     </div>
+                  </div>
                 </transition>
+              </section>
             </div>
+          </div>
         </div>
 
         <div v-if="activeTab === 'schedule'" class="schedule-container">
@@ -132,57 +137,79 @@
             <p>Ninguna función coincide con "<strong>{{ scheduleSearch }}</strong>"</p>
           </div>
 
-          <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" class="schedule-day">
-            <div class="day-header" @click="toggleDay(date)">
+          <div v-if="scheduleDays.length" class="schedule-layout">
+            <aside class="schedule-nav" aria-label="Saltar a día">
+              <div class="nav-group-label">Días</div>
+              <button
+                v-for="day in scheduleDays"
+                :key="day.date"
+                class="nav-item"
+                :class="{ active: activeDay === day.date }"
+                @click="scrollToDay(day.date)"
+              >
+                <span class="nav-item-label">{{ day.label }}</span>
+                <span class="nav-item-count">{{ day.count }}</span>
+              </button>
+            </aside>
+
+            <div ref="scheduleContentRef" class="schedule-content">
+              <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" :data-day="date" class="schedule-day">
+            <div class="day-header" @click="onDayHeaderClick(date)">
                 <h2>{{ formatDate(date) }}</h2>
-                <div class="chevron" :class="{ 'closed': !isOpen(date) }">
+                <div v-if="isMobile" class="chevron" :class="{ 'closed': !isOpen(date) }">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down"><path d="m6 9 6 6 6-6"/></svg>
                 </div>
             </div>
-            
+
             <transition name="slide">
-                <div v-show="isOpen(date)" class="screenings-list">
-              <div v-for="screening in dayScreenings" :key="screening.id" class="screening-card">
-                 <div class="time-block">
-                    <span class="time">{{ formatTime(screening.start_time) }}</span>
-                    <span class="timezone">{{ screening.timezone }}</span>
-                 </div>
-                 
-                  <div class="film-info">
-                     <component 
-                        :is="screening.film.source_url ? 'a' : 'span'"
-                        :href="screening.film.source_url || ''"
-                        :target="screening.film.source_url ? '_blank' : ''"
-                        class="film-title"
-                        :class="{'no-link': !screening.film.source_url}"
-                     >
-                        {{ screening.film.title }}
-                     </component>
-                     <div class="film-meta">
-                         <span v-if="screening.film.director">Dirigida por {{ screening.film.director }}</span>
-                         <span v-if="screening.film.director && screening.film.runtime"> • </span>
-                         <span v-if="screening.film.runtime">{{ screening.film.runtime }} min</span>
+                <div v-show="!isMobile || isOpen(date)" class="screenings-list">
+                  <div v-for="screening in dayScreenings" :key="screening.id" class="screening-card">
+                     <div class="time-block">
+                        <span class="time">{{ formatTime(screening.start_time) }}</span>
+                        <span class="timezone">{{ screening.timezone }}</span>
                      </div>
-                     <div class="tags">
-                         <span v-if="screening.is_in_person" class="tag in-person">En persona</span>
-                         <span v-if="screening.is_online" class="tag online">Online</span>
-                         <span v-if="screening.is_sold_out" class="tag sold-out">Agotado</span>
-                     </div>
+
+                      <div class="film-info">
+                         <component
+                            :is="screening.film.source_url ? 'a' : 'span'"
+                            :href="screening.film.source_url || ''"
+                            :target="screening.film.source_url ? '_blank' : ''"
+                            class="film-title"
+                            :class="{'no-link': !screening.film.source_url}"
+                         >
+                            {{ screening.film.title }}
+                         </component>
+                         <div class="film-meta">
+                             <span v-if="screening.film.director">Dirigida por {{ screening.film.director }}</span>
+                             <span v-if="screening.film.director && screening.film.runtime"> • </span>
+                             <span v-if="screening.film.runtime">{{ screening.film.runtime }} min</span>
+                         </div>
+                         <div v-if="screening.venue" class="venue-info">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-map-pin"><path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"/><circle cx="12" cy="10" r="3"/></svg>
+                            {{ screening.venue }}
+                         </div>
+                         <div class="tags">
+                             <span v-if="screening.is_in_person" class="tag in-person">Presencial</span>
+                             <span v-if="screening.is_online" class="tag online">Online</span>
+                             <span v-if="screening.is_sold_out" class="tag sold-out">Agotado</span>
+                         </div>
+                      </div>
+
+                      <div class="poster-mini">
+                          <img
+                            v-if="screening.film.poster_path"
+                            :src="screening.film.poster_path"
+                            alt="Poster"
+                            loading="lazy"
+                            @error="$event.target.src = '/placeholders/image_not_found_yet.webp'"
+                          />
+                          <img v-else src="/placeholders/image_not_found_yet.webp" alt="No Poster" />
+                      </div>
                   </div>
-                  
-                  <div class="poster-mini">
-                      <img 
-                        v-if="screening.film.poster_path" 
-                        :src="screening.film.poster_path" 
-                        alt="Poster" 
-                        loading="lazy" 
-                        @error="$event.target.src = '/placeholders/image_not_found_yet_es.webp'"
-                      />
-                      <img v-else src="/placeholders/image_not_found_yet_es.webp" alt="No Poster" />
-                  </div>
-              </div>
-            </div>
+                </div>
             </transition>
+          </div>
+            </div>
           </div>
         </div>
 
@@ -258,7 +285,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, nextTick } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount, nextTick, watch } from 'vue';
 import Loader from '~/components/Loader.vue';
 import WinnersCarousel from '~/components/festival/WinnersCarousel.vue';
 import FestivalDataDisclaimer from '~/components/FestivalDataDisclaimer.vue';
@@ -308,9 +335,6 @@ const awards = ref([]);
 const schedule = ref([]);
 const openDays = ref(new Set());
 
-const featuresOpen = ref(true);
-const shortsOpen = ref(true);
-
 const features = computed(() => {
     return films.value?.results?.filter(f => !f.runtime || f.runtime >= 40) || [];
 });
@@ -318,6 +342,55 @@ const features = computed(() => {
 const shorts = computed(() => {
     return films.value?.results?.filter(f => f.runtime > 0 && f.runtime < 40) || [];
 });
+
+const selectionSections = computed(() => [
+    { key: 'features', label: 'Largometrajes', films: features.value, count: features.value.length },
+    { key: 'shorts', label: 'Cortometrajes', films: shorts.value, count: shorts.value.length },
+].filter(sec => sec.count > 0));
+const officialNav = computed(() => selectionSections.value);
+const scrollToSection = (key) => {
+    activeSection.value = key;
+    const root = selectionContentRef.value;
+    if (!root) return;
+    for (const el of root.querySelectorAll('[data-key]')) {
+        if (el.getAttribute('data-key') === key) {
+            el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            break;
+        }
+    }
+};
+const setupSectionObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (sectionObserver) sectionObserver.disconnect();
+    const root = selectionContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-key]');
+    if (!els.length) return;
+    sectionObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) if (entry.isIntersecting) activeSection.value = entry.target.getAttribute('data-key');
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => sectionObserver.observe(el));
+};
+watch(selectionSections, (sections) => {
+    if (sections.length && !sections.some((sec) => sec.key === activeSection.value)) activeSection.value = sections[0].key;
+}, { immediate: true });
+watch([loading, activeTab, selectionSections], () => {
+    if (!loading.value && activeTab.value === 'films') nextTick(() => setupSectionObserver());
+    else if (sectionObserver) sectionObserver.disconnect();
+}, { flush: 'post' });
+
+const activeSection = ref('');
+const selectionContentRef = ref(null);
+let sectionObserver = null;
+const isMobile = ref(false);
+let mobileMql = null;
+const sectionOpen = ref({});
+const isSectionOpen = (key) => sectionOpen.value[key] !== false;
+const toggleSection = (key) => { sectionOpen.value = { ...sectionOpen.value, [key]: !isSectionOpen(key) }; };
+const onSectionHeaderClick = (key) => { if (!isMobile.value) return; toggleSection(key); };
+const activeDay = ref('');
+const scheduleContentRef = ref(null);
+let dayObserver = null;
 
 const formatDate = (dateStr) => {
     const options = { weekday: 'long', month: 'long', day: 'numeric' };
@@ -367,6 +440,52 @@ const isOpen = (date) => {
     return openDays.value.has(date);
 };
 
+const scheduleDays = computed(() => Object.entries(groupedScreenings.value).map(([date, arr]) => ({ date, label: formatDate(date), count: arr.length })));
+const onDayHeaderClick = (date) => { if (!isMobile.value) return; toggleDay(date); };
+const scrollToDay = (date) => {
+    activeDay.value = date;
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    for (const el of root.querySelectorAll('[data-day]')) {
+        if (el.getAttribute('data-day') === date) {
+            el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            break;
+        }
+    }
+};
+const setupDayObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (dayObserver) dayObserver.disconnect();
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-day]');
+    if (!els.length) return;
+    dayObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) if (entry.isIntersecting) activeDay.value = entry.target.getAttribute('data-day');
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => dayObserver.observe(el));
+};
+watch(scheduleDays, (days) => {
+    if (days.length && !days.some((d) => d.date === activeDay.value)) activeDay.value = days[0]?.date || '';
+}, { immediate: true });
+watch([loading, activeTab, scheduleDays], () => {
+    if (!loading.value && activeTab.value === 'schedule') nextTick(() => setupDayObserver());
+    else if (dayObserver) dayObserver.disconnect();
+}, { flush: 'post' });
+const updateIsMobile = (e) => { isMobile.value = e.matches; };
+onMounted(() => {
+    if (typeof window !== 'undefined' && window.matchMedia) {
+        mobileMql = window.matchMedia('(max-width: 900px)');
+        isMobile.value = mobileMql.matches;
+        mobileMql.addEventListener('change', updateIsMobile);
+    }
+});
+onBeforeUnmount(() => {
+    if (sectionObserver) sectionObserver.disconnect();
+    if (dayObserver) dayObserver.disconnect();
+    if (mobileMql) mobileMql.removeEventListener('change', updateIsMobile);
+});
+
 onMounted(async () => {
     try {
         const [filmsData, scheduleData, awardsData] = await Promise.all([
@@ -394,6 +513,223 @@ onMounted(async () => {
 
 <style lang="scss" scoped>
 @use '~/assets/css/utilities/variables' as *;
+
+// Poster sizing inside the Selection content column. The column is narrower than
+// the old full-bleed grid, so we use fewer columns / slightly larger posters.
+.selection :deep(.listing__items > .card) {
+    width: 33.3333%;
+
+    @media (min-width: 640px) {
+        width: 25%;
+    }
+    @media (min-width: 1024px) {
+        width: 20%;
+    }
+    @media (min-width: 1500px) {
+        width: 16.6666%;
+    }
+    @media (min-width: 1800px) {
+        width: 14.2857%;
+    }
+}
+
+
+/* ── Selection: sidebar scroll-spy + sections ───────────── */
+.selection-layout,
+.schedule-layout {
+    display: grid;
+    grid-template-columns: 330px minmax(0, 1fr);
+    gap: 2.5rem;
+    align-items: start;
+}
+
+/* Breathing room between the screenings search bar and the day list below it. */
+.schedule-layout {
+    margin-top: 1.75rem;
+}
+
+.selection-nav,
+.schedule-nav {
+    position: sticky;
+    top: 5.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-height: calc(100vh - 7rem);
+    overflow-y: auto;
+    padding: 1rem;
+    border: 1px solid transparent;
+    background:
+        linear-gradient(rgba(3, 6, 10, 0.85), rgba(3, 6, 10, 0.85)) padding-box,
+        linear-gradient(160deg, rgba(139, 233, 253, 0.55), rgba(31, 84, 103, 0.45) 60%, rgba(139, 233, 253, 0.16)) border-box;
+    border-radius: 14px;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
+}
+
+.nav-group-label {
+    font-size: 1rem;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    color: rgba(139, 233, 253, 0.9);
+    font-weight: 700;
+    margin: 1.2rem 0.4rem 0.55rem;
+
+    &:first-child {
+        margin-top: 0.2rem;
+    }
+}
+
+.nav-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    width: 100%;
+    background: none;
+    border: none;
+    border-left: 3px solid transparent;
+    border-radius: 0 8px 8px 0;
+    color: rgba(255, 255, 255, 0.88);
+    padding: 0.82rem 1rem;
+    font-size: 1.32rem;
+    font-family: inherit;
+    text-align: left;
+    cursor: pointer;
+    transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+
+    &:hover {
+        background: rgba(139, 233, 253, 0.08);
+        color: #eafbff;
+    }
+
+    &.active {
+        background: rgba(139, 233, 253, 0.12);
+        color: #8BE9FD;
+        border-left-color: #8BE9FD;
+        font-weight: 600;
+    }
+}
+
+.nav-item-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.nav-item-count {
+    font-size: 1.12rem;
+    color: rgba(255, 255, 255, 0.62);
+    flex-shrink: 0;
+}
+
+.nav-item.active .nav-item-count {
+    color: rgba(139, 233, 253, 0.85);
+}
+
+.sel-section {
+    scroll-margin-top: 6.5rem;
+    margin-bottom: 3rem;
+}
+
+.sel-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
+    padding-bottom: 6px;
+    margin-bottom: 1.25rem;
+}
+
+.sel-section-title {
+    margin: 0;
+    font-size: 1.7rem;
+    font-weight: 700;
+    color: #fff;
+}
+
+.sel-section-meta {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-shrink: 0;
+}
+
+.sel-section-count {
+    font-size: 1.05rem;
+    color: rgba(255, 255, 255, 0.5);
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.expand-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.3);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: #fff;
+    width: 36px;
+    height: 36px;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    flex-shrink: 0;
+
+    &:hover {
+        background: rgba(139, 233, 253, 0.15);
+        color: #8BE9FD;
+        border-color: rgba(139, 233, 253, 0.3);
+    }
+
+    svg {
+        width: 20px;
+        height: 20px;
+        min-width: 20px;
+        min-height: 20px;
+        display: block;
+    }
+}
+
+.parallel-band {
+    font-size: 0.85rem;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: #8BE9FD;
+    border-top: 1px solid rgba(139, 233, 253, 0.25);
+    padding-top: 1.4rem;
+    margin: 0.5rem 0 1.5rem;
+}
+
+@media (max-width: 900px) {
+    .selection-layout,
+    .schedule-layout {
+        display: block;
+    }
+
+    .selection-nav,
+    .schedule-nav {
+        display: none;
+    }
+
+    .sel-section-header {
+        cursor: pointer;
+        user-select: none;
+        transition: border-color 0.2s;
+    }
+
+    .sel-section-header:hover {
+        border-color: rgba(139, 233, 253, 0.6);
+    }
+
+    .day-header {
+        cursor: pointer;
+    }
+}
+
 
 :deep(.card__name) {
     font-size: 1.2rem;

--- a/pages/festival/sxsw-2026/index.vue
+++ b/pages/festival/sxsw-2026/index.vue
@@ -48,50 +48,55 @@
       </div>
 
       <div v-else>
-        <div v-if="activeTab === 'films'" class="films-grid">
-            <div v-if="features.length > 0" class="film-category">
-                <div class="category-header" @click="featuresOpen = !featuresOpen">
-                    <h2 class="listing__title category-title">
-                        Largometrajes
-                        <span class="category-count">({{ features.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="featuresOpen ? 'Ocultar' : 'Expandir'">
-                        <svg v-if="featuresOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
-                    </button>
-                </div>
-                <transition name="slide">
-                    <div v-show="featuresOpen" class="listing__items">
-                        <SxswCard 
-                            v-for="item in features"
-                            :key="`feature-${item.id}`"
-                            :item="item" 
-                        />
-                    </div>
-                </transition>
-            </div>
+        <div v-if="activeTab === 'films'" class="selection">
+          <div class="selection-layout">
+            <aside class="selection-nav" aria-label="Saltar a sección">
+              <template v-if="officialNav.length">
+                <div class="nav-group-label">Catálogo</div>
+                <button
+                  v-for="sec in officialNav"
+                  :key="sec.key"
+                  class="nav-item"
+                  :class="{ active: activeSection === sec.key }"
+                  @click="scrollToSection(sec.key)"
+                >
+                  <span class="nav-item-label">{{ sec.label }}</span>
+                  <span class="nav-item-count">{{ sec.count }}</span>
+                </button>
+              </template>
+            </aside>
 
-            <div v-if="shorts.length > 0" class="film-category">
-                <div class="category-header" @click="shortsOpen = !shortsOpen">
-                    <h2 class="listing__title category-title">
-                        Cortometrajes
-                        <span class="category-count">({{ shorts.length }})</span>
-                    </h2>
-                    <button class="expand-btn" :aria-label="shortsOpen ? 'Ocultar' : 'Expandir'">
-                        <svg v-if="shortsOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
-                        <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
+            <div ref="selectionContentRef" class="selection-content">
+              <section
+                v-for="sec in selectionSections"
+                :key="sec.key"
+                :data-key="sec.key"
+                class="sel-section"
+              >
+                <div class="sel-section-header" @click="onSectionHeaderClick(sec.key)">
+                  <h2 class="sel-section-title">{{ sec.label }}</h2>
+                  <div class="sel-section-meta">
+                    <span class="sel-section-count">{{ sec.count }} {{ sec.count === 1 ? 'película' : 'películas' }}</span>
+                    <button v-if="isMobile" class="expand-btn" :aria-label="isSectionOpen(sec.key) ? 'Ocultar' : 'Expandir'">
+                      <svg v-if="isSectionOpen(sec.key)" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-chevrons-down-up-icon lucide-list-chevrons-down-up"><path d="M3 5h8"/><path d="M3 12h8"/><path d="M3 19h8"/><path d="m15 5 3 3 3-3"/><path d="m15 19 3-3 3 3"/></svg>
+                      <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-collapse-icon lucide-list-collapse"><path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="m3 10 3-3-3-3"/><path d="m3 20 3-3-3-3"/></svg>
                     </button>
+                  </div>
                 </div>
                 <transition name="slide">
-                    <div v-show="shortsOpen" class="listing__items">
-                        <SxswCard 
-                            v-for="item in shorts"
-                            :key="`short-${item.id}`"
-                            :item="item" 
-                        />
+                  <div v-show="!isMobile || isSectionOpen(sec.key)" class="sel-section-body">
+                    <div class="listing__items">
+                      <SxswCard
+                        v-for="item in sec.films"
+                        :key="`${sec.key}-${item.id}`"
+                        :item="item"
+                      />
                     </div>
+                  </div>
                 </transition>
+              </section>
             </div>
+          </div>
         </div>
 
         <div v-if="activeTab === 'schedule'" class="schedule-container">
@@ -131,24 +136,40 @@
             <p>Ninguna función coincide con "<strong>{{ scheduleSearch }}</strong>"</p>
           </div>
 
-          <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" class="schedule-day">
-            <div class="day-header" @click="toggleDay(date)">
+          <div v-if="scheduleDays.length" class="schedule-layout">
+            <aside class="schedule-nav" aria-label="Saltar a día">
+              <div class="nav-group-label">Días</div>
+              <button
+                v-for="day in scheduleDays"
+                :key="day.date"
+                class="nav-item"
+                :class="{ active: activeDay === day.date }"
+                @click="scrollToDay(day.date)"
+              >
+                <span class="nav-item-label">{{ day.label }}</span>
+                <span class="nav-item-count">{{ day.count }}</span>
+              </button>
+            </aside>
+
+            <div ref="scheduleContentRef" class="schedule-content">
+              <div v-for="(dayScreenings, date) in groupedScreenings" :key="date" :data-day="date" class="schedule-day">
+            <div class="day-header" @click="onDayHeaderClick(date)">
                 <h2>{{ formatDate(date) }}</h2>
-                <div class="chevron" :class="{ 'closed': !isOpen(date) }">
+                <div v-if="isMobile" class="chevron" :class="{ 'closed': !isOpen(date) }">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down"><path d="m6 9 6 6 6-6"/></svg>
                 </div>
             </div>
-            
+
             <transition name="slide">
-                <div v-show="isOpen(date)" class="screenings-list">
+                <div v-show="!isMobile || isOpen(date)" class="screenings-list">
                   <div v-for="screening in dayScreenings" :key="screening.id" class="screening-card">
                      <div class="time-block">
                         <span class="time">{{ formatTime(screening.start_time) }}</span>
-                        <!-- <span class="timezone">{{ screening.timezone }}</span> -->
+                        <span class="timezone">{{ screening.timezone }}</span>
                      </div>
-                     
+
                       <div class="film-info">
-                         <component 
+                         <component
                             :is="screening.film.source_url ? 'a' : 'span'"
                             :href="screening.film.source_url || ''"
                             :target="screening.film.source_url ? '_blank' : ''"
@@ -158,7 +179,7 @@
                             {{ screening.film.title }}
                          </component>
                          <div class="film-meta">
-                             <span v-if="screening.film.director">Dirigido por {{ screening.film.director }}</span>
+                             <span v-if="screening.film.director">Dirigida por {{ screening.film.director }}</span>
                              <span v-if="screening.film.director && screening.film.runtime"> • </span>
                              <span v-if="screening.film.runtime">{{ screening.film.runtime }} min</span>
                          </div>
@@ -172,20 +193,22 @@
                              <span v-if="screening.is_sold_out" class="tag sold-out">Agotado</span>
                          </div>
                       </div>
-                      
+
                       <div class="poster-mini">
-                          <img 
-                            v-if="screening.film.poster_path" 
-                            :src="screening.film.poster_path" 
-                            alt="Póster" 
-                            loading="lazy" 
+                          <img
+                            v-if="screening.film.poster_path"
+                            :src="screening.film.poster_path"
+                            alt="Poster"
+                            loading="lazy"
                             @error="$event.target.src = '/placeholders/image_not_found_yet.webp'"
                           />
-                          <img v-else src="/placeholders/image_not_found_yet.webp" alt="No hay póster" />
+                          <img v-else src="/placeholders/image_not_found_yet.webp" alt="No Poster" />
                       </div>
                   </div>
                 </div>
             </transition>
+          </div>
+            </div>
           </div>
         </div>
 
@@ -261,7 +284,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, nextTick } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount, nextTick, watch } from 'vue';
 import Loader from '~/components/Loader.vue';
 import WinnersCarousel from '~/components/festival/WinnersCarousel.vue';
 import FestivalDataDisclaimer from '~/components/FestivalDataDisclaimer.vue';
@@ -311,9 +334,6 @@ const awards = ref([]);
 const schedule = ref([]);
 const openDays = ref(new Set());
 
-const featuresOpen = ref(true);
-const shortsOpen = ref(true);
-
 const features = computed(() => {
     return films.value?.results?.filter(f => !f.runtime || f.runtime >= 40) || [];
 });
@@ -321,6 +341,55 @@ const features = computed(() => {
 const shorts = computed(() => {
     return films.value?.results?.filter(f => f.runtime > 0 && f.runtime < 40) || [];
 });
+
+const selectionSections = computed(() => [
+    { key: 'features', label: 'Largometrajes', films: features.value, count: features.value.length },
+    { key: 'shorts', label: 'Cortometrajes', films: shorts.value, count: shorts.value.length },
+].filter(sec => sec.count > 0));
+const officialNav = computed(() => selectionSections.value);
+const scrollToSection = (key) => {
+    activeSection.value = key;
+    const root = selectionContentRef.value;
+    if (!root) return;
+    for (const el of root.querySelectorAll('[data-key]')) {
+        if (el.getAttribute('data-key') === key) {
+            el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            break;
+        }
+    }
+};
+const setupSectionObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (sectionObserver) sectionObserver.disconnect();
+    const root = selectionContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-key]');
+    if (!els.length) return;
+    sectionObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) if (entry.isIntersecting) activeSection.value = entry.target.getAttribute('data-key');
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => sectionObserver.observe(el));
+};
+watch(selectionSections, (sections) => {
+    if (sections.length && !sections.some((sec) => sec.key === activeSection.value)) activeSection.value = sections[0].key;
+}, { immediate: true });
+watch([loading, activeTab, selectionSections], () => {
+    if (!loading.value && activeTab.value === 'films') nextTick(() => setupSectionObserver());
+    else if (sectionObserver) sectionObserver.disconnect();
+}, { flush: 'post' });
+
+const activeSection = ref('');
+const selectionContentRef = ref(null);
+let sectionObserver = null;
+const isMobile = ref(false);
+let mobileMql = null;
+const sectionOpen = ref({});
+const isSectionOpen = (key) => sectionOpen.value[key] !== false;
+const toggleSection = (key) => { sectionOpen.value = { ...sectionOpen.value, [key]: !isSectionOpen(key) }; };
+const onSectionHeaderClick = (key) => { if (!isMobile.value) return; toggleSection(key); };
+const activeDay = ref('');
+const scheduleContentRef = ref(null);
+let dayObserver = null;
 
 const formatDate = (dateStr) => {
     const options = { weekday: 'long', month: 'long', day: 'numeric' };
@@ -373,6 +442,52 @@ const isOpen = (date) => {
     return openDays.value.has(date);
 };
 
+const scheduleDays = computed(() => Object.entries(groupedScreenings.value).map(([date, arr]) => ({ date, label: formatDate(date), count: arr.length })));
+const onDayHeaderClick = (date) => { if (!isMobile.value) return; toggleDay(date); };
+const scrollToDay = (date) => {
+    activeDay.value = date;
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    for (const el of root.querySelectorAll('[data-day]')) {
+        if (el.getAttribute('data-day') === date) {
+            el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            break;
+        }
+    }
+};
+const setupDayObserver = () => {
+    if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') return;
+    if (dayObserver) dayObserver.disconnect();
+    const root = scheduleContentRef.value;
+    if (!root) return;
+    const els = root.querySelectorAll('[data-day]');
+    if (!els.length) return;
+    dayObserver = new IntersectionObserver((entries) => {
+        for (const entry of entries) if (entry.isIntersecting) activeDay.value = entry.target.getAttribute('data-day');
+    }, { rootMargin: '-110px 0px -70% 0px', threshold: 0 });
+    els.forEach((el) => dayObserver.observe(el));
+};
+watch(scheduleDays, (days) => {
+    if (days.length && !days.some((d) => d.date === activeDay.value)) activeDay.value = days[0]?.date || '';
+}, { immediate: true });
+watch([loading, activeTab, scheduleDays], () => {
+    if (!loading.value && activeTab.value === 'schedule') nextTick(() => setupDayObserver());
+    else if (dayObserver) dayObserver.disconnect();
+}, { flush: 'post' });
+const updateIsMobile = (e) => { isMobile.value = e.matches; };
+onMounted(() => {
+    if (typeof window !== 'undefined' && window.matchMedia) {
+        mobileMql = window.matchMedia('(max-width: 900px)');
+        isMobile.value = mobileMql.matches;
+        mobileMql.addEventListener('change', updateIsMobile);
+    }
+});
+onBeforeUnmount(() => {
+    if (sectionObserver) sectionObserver.disconnect();
+    if (dayObserver) dayObserver.disconnect();
+    if (mobileMql) mobileMql.removeEventListener('change', updateIsMobile);
+});
+
 onMounted(async () => {
     try {
         const [filmsData, scheduleData, awardsData] = await Promise.all([
@@ -400,6 +515,223 @@ onMounted(async () => {
 
 <style lang="scss" scoped>
 @use '~/assets/css/utilities/variables' as *;
+
+// Poster sizing inside the Selection content column. The column is narrower than
+// the old full-bleed grid, so we use fewer columns / slightly larger posters.
+.selection :deep(.listing__items > .card) {
+    width: 33.3333%;
+
+    @media (min-width: 640px) {
+        width: 25%;
+    }
+    @media (min-width: 1024px) {
+        width: 20%;
+    }
+    @media (min-width: 1500px) {
+        width: 16.6666%;
+    }
+    @media (min-width: 1800px) {
+        width: 14.2857%;
+    }
+}
+
+
+/* ── Selection: sidebar scroll-spy + sections ───────────── */
+.selection-layout,
+.schedule-layout {
+    display: grid;
+    grid-template-columns: 330px minmax(0, 1fr);
+    gap: 2.5rem;
+    align-items: start;
+}
+
+/* Breathing room between the screenings search bar and the day list below it. */
+.schedule-layout {
+    margin-top: 1.75rem;
+}
+
+.selection-nav,
+.schedule-nav {
+    position: sticky;
+    top: 5.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-height: calc(100vh - 7rem);
+    overflow-y: auto;
+    padding: 1rem;
+    border: 1px solid transparent;
+    background:
+        linear-gradient(rgba(3, 6, 10, 0.85), rgba(3, 6, 10, 0.85)) padding-box,
+        linear-gradient(160deg, rgba(139, 233, 253, 0.55), rgba(31, 84, 103, 0.45) 60%, rgba(139, 233, 253, 0.16)) border-box;
+    border-radius: 14px;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
+}
+
+.nav-group-label {
+    font-size: 1rem;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    color: rgba(139, 233, 253, 0.9);
+    font-weight: 700;
+    margin: 1.2rem 0.4rem 0.55rem;
+
+    &:first-child {
+        margin-top: 0.2rem;
+    }
+}
+
+.nav-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    width: 100%;
+    background: none;
+    border: none;
+    border-left: 3px solid transparent;
+    border-radius: 0 8px 8px 0;
+    color: rgba(255, 255, 255, 0.88);
+    padding: 0.82rem 1rem;
+    font-size: 1.32rem;
+    font-family: inherit;
+    text-align: left;
+    cursor: pointer;
+    transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+
+    &:hover {
+        background: rgba(139, 233, 253, 0.08);
+        color: #eafbff;
+    }
+
+    &.active {
+        background: rgba(139, 233, 253, 0.12);
+        color: #8BE9FD;
+        border-left-color: #8BE9FD;
+        font-weight: 600;
+    }
+}
+
+.nav-item-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.nav-item-count {
+    font-size: 1.12rem;
+    color: rgba(255, 255, 255, 0.62);
+    flex-shrink: 0;
+}
+
+.nav-item.active .nav-item-count {
+    color: rgba(139, 233, 253, 0.85);
+}
+
+.sel-section {
+    scroll-margin-top: 6.5rem;
+    margin-bottom: 3rem;
+}
+
+.sel-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    border-bottom: 1px solid rgba(139, 233, 253, 0.3);
+    padding-bottom: 6px;
+    margin-bottom: 1.25rem;
+}
+
+.sel-section-title {
+    margin: 0;
+    font-size: 1.7rem;
+    font-weight: 700;
+    color: #fff;
+}
+
+.sel-section-meta {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-shrink: 0;
+}
+
+.sel-section-count {
+    font-size: 1.05rem;
+    color: rgba(255, 255, 255, 0.5);
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.expand-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.3);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: #fff;
+    width: 36px;
+    height: 36px;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    flex-shrink: 0;
+
+    &:hover {
+        background: rgba(139, 233, 253, 0.15);
+        color: #8BE9FD;
+        border-color: rgba(139, 233, 253, 0.3);
+    }
+
+    svg {
+        width: 20px;
+        height: 20px;
+        min-width: 20px;
+        min-height: 20px;
+        display: block;
+    }
+}
+
+.parallel-band {
+    font-size: 0.85rem;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: #8BE9FD;
+    border-top: 1px solid rgba(139, 233, 253, 0.25);
+    padding-top: 1.4rem;
+    margin: 0.5rem 0 1.5rem;
+}
+
+@media (max-width: 900px) {
+    .selection-layout,
+    .schedule-layout {
+        display: block;
+    }
+
+    .selection-nav,
+    .schedule-nav {
+        display: none;
+    }
+
+    .sel-section-header {
+        cursor: pointer;
+        user-select: none;
+        transition: border-color 0.2s;
+    }
+
+    .sel-section-header:hover {
+        border-color: rgba(139, 233, 253, 0.6);
+    }
+
+    .day-header {
+        cursor: pointer;
+    }
+}
+
 
 :deep(.card__name) {
     font-size: 1.2rem;


### PR DESCRIPTION
### Motivation
- Improve discoverability and navigation for long film catalogs and multi-day schedules across festival pages by introducing a persistent sidebar and scrollable sections.
- Make mobile interactions friendlier by allowing sections/days to collapse and keeping behavior consistent across festivals.

### Description
- Replace the old full-bleed `films` grid with a new `selection` layout containing a sticky sidebar navigation (`selection-nav`) and per-section content (`selectionSections`, `officialNav`) and corresponding CSS for the componentized layout.
- Add scroll-spy behavior using `IntersectionObserver` to highlight the active section/day, with programmatic jump helpers `scrollToSection` and `scrollToDay`, and observers `setupSectionObserver` / `setupDayObserver` to keep `activeSection` and `activeDay` in sync.
- Make schedules navigable via a new `schedule-layout` with a day sidebar and mobile collapse UX, add `isMobile` handling via `window.matchMedia` and proper cleanup with `onBeforeUnmount`, and wire toggles for mobile header clicks (`onSectionHeaderClick`, `onDayHeaderClick`).
- Unify film link rendering using a dynamic `component` tag and normalize poster placeholder paths to `/placeholders/image_not_found_yet.webp`; standardize a few UI strings (e.g. `Presencial`, `Dirigida por`).
- Update imports to include `onBeforeUnmount` and `watch`, add computed helpers (`selectionSections`, `scheduleDays`) and local state vars and observers, and include scoped SCSS for the selection/sidebar styles across all modified festival pages.

### Testing
- Ran the project build with `npm run build` which completed successfully.
- Executed the test suite with `npm test` and linting with `npm run lint`, both completed without failures.
- Verified the pages render locally and the scroll‑spy, section/day jump and mobile collapse behaviors worked in manual smoke checks during development.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a2daea4e88321b6dfbf033a115e42)