### PR TITLE
Fix Festival Page Regressions

### DIFF
--- a/pages/festival/berlinale-2026/index.vue
+++ b/pages/festival/berlinale-2026/index.vue
@@ -551,7 +551,14 @@ onMounted(async () => {
         
         films.value = filmsData;
         awards.value = awardsData.results || [];
-        schedule.value = scheduleData.results || [];
+        
+        const toIsoString = (t) => (typeof t === 'number')
+            ? new Date(t * 1000).toISOString()
+            : String(t || '');
+        schedule.value = (scheduleData.results || []).map(s => ({
+            ...s,
+            start_time: toIsoString(s.start_time),
+        }));
         
         if (schedule.value.length > 0) {
             const dates = new Set(schedule.value.map(s => s.start_time.split('T')[0]));

--- a/server/api/festival/berlinale/schedule.get.ts
+++ b/server/api/festival/berlinale/schedule.get.ts
@@ -52,9 +52,16 @@ export default defineEventHandler(async (event) => {
                 tmdbData = {}
             }
 
+            const toIsoString = (t: any) => {
+                if (typeof t === 'number') {
+                    return new Date(t * 1000).toISOString()
+                }
+                return String(t || '')
+            }
+
             return {
                 id: row.screening_id,
-                start_time: row.start_time,
+                start_time: toIsoString(row.start_time),
                 timezone: row.timezone,
                 is_in_person: Boolean(row.is_in_person),
                 is_online: Boolean(row.is_online),


### PR DESCRIPTION
## Description
This PR resolves the critical rendering bug on the Berlinale schedule page and addresses layout constraint and UI styling regressions across the Spanish version (`cinemagoria-es`) of the Berlinale and Sundance 2026 festival pages.

## Key Changes

### 1. Berlinale Screenings Restoration & Date Normalization
* **Root Cause:** Due to inconsistent types in the database's `start_time` field (32 numeric Unix timestamps vs 279 ISO strings), the client-side code failed when calling `.split('T')[0]` on integer timestamps, causing a script crash and preventing screenings from rendering.
* **Backend Fix:** Updated `server/api/festival/berlinale/schedule.get.ts` to check `row.start_time` and dynamically convert numeric timestamps using `new Date(t * 1000).toISOString()`.
* **Frontend Safety Fallback:** Added clean conversion helpers in the script section of both `cinemagoria-main` and `cinemagoria-es` to guarantee the date parser always receives a valid ISO string.

### 2. Layout & Width Constraints (Sundance ES)
* **Root Cause:** The main section wrapper `<div class="container">` was missing after the header area, causing the selection, schedule, and info sections to stretch across the full width of the viewport on desktop.
* **Fix:** Wrapped the main page loader and tabs inside the standard `<div class="container">` wrapper to enforce the 1200px maximum width constraint.

### 3. UI/UX Style Migration & Localization (ES Repositories)
Harmonized elements on the Spanish pages for Berlinale and Sundance to match the premium design system deployed on the main repository:
* **Segmented Controls:** Updated switcher tabs to use dark glassmorphism, transparent borders, and the gradient slider glider.
* **Borders & Shadows:** Migrated the 2px transparent layout borders with gradient border-box layouts (via padding-box/border-box gradients) and hover translateY transforms for cards and hero images.
* **Carousel Cards:** Added the radial background gradients and the top accent line pseudo-element.
* **Rollout Banners:** Integrated localized empty-state rollout banners ("Actualizaciones del catálogo en curso" / "Programación pendiente") in Spanish for when catalog selections or schedules are empty.
* **Timezone Safety:** Aligned localized time formatting functions in the ES templates to accept the correct timezone parameters.

***

## Closes
Closes #382