### PR TITLE
Modernize movie & TV detail panels + add Full Crew modal

### DIFF
--- a/components/common/FullCreditsModal.vue
+++ b/components/common/FullCreditsModal.vue
@@ -99,8 +99,15 @@ export default {
     };
   },
 
-  created() {
-    this.openKeys = this.groups.slice(0, 3).map((g) => g.key);
+  watch: {
+    // Re-evaluate the default-open departments whenever the crew changes,
+    // e.g. same-route navigation between titles while the modal stays mounted.
+    crew: {
+      immediate: true,
+      handler() {
+        this.openKeys = this.groups.slice(0, 3).map((g) => g.key);
+      },
+    },
   },
 
   computed: {
@@ -191,7 +198,7 @@ export default {
   border-radius: 20px;
   width: 100%;
   max-width: 880px;
-  max-height: calc(100vh - 40px);
+  max-height: calc(100vh - 56px);
   overflow-y: auto;
   box-shadow:
     0 20px 60px rgba(0, 0, 0, 0.6),
@@ -240,10 +247,6 @@ export default {
     border-color: rgba(255, 95, 95, 0.3);
     color: #ff7e7e;
   }
-}
-
-.modalContent {
-  max-height: calc(100vh - 56px);
 }
 
 .modalBody {

--- a/components/common/FullCreditsModal.vue
+++ b/components/common/FullCreditsModal.vue
@@ -1,0 +1,448 @@
+<template>
+  <div :class="$style.modalOverlay" @click.self="$emit('close')">
+    <div :class="$style.modalContent">
+      <button @click="$emit('close')" :class="$style.closeButton" aria-label="Close">
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+      </button>
+
+      <div :class="$style.modalBody">
+        <div :class="$style.intro">
+          <span :class="$style.eyebrow">Crew</span>
+          <h3>The people behind &lsquo;{{ title }}&rsquo;</h3>
+        </div>
+
+        <div :class="$style.groups">
+          <section
+            v-for="group in groups"
+            :key="group.key"
+            :class="[$style.group, isOpen(group.key) ? $style.open : '']">
+            <button type="button" :class="$style.groupHead" @click="toggle(group.key)">
+              <span :class="$style.groupLabel">{{ group.label }}</span>
+              <span :class="$style.groupCount">{{ group.people.length }}</span>
+              <svg :class="$style.chevron" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+            </button>
+
+            <div v-show="isOpen(group.key)" :class="$style.strip">
+              <nuxt-link
+                v-for="person in group.people"
+                :key="`${group.key}-${person.id}`"
+                :class="$style.card"
+                :to="{ name: 'person-id', params: { id: person.id } }">
+                <span :class="$style.avatar">
+                  <img
+                    v-if="person.profile_path"
+                    :src="img(person.profile_path)"
+                    loading="lazy"
+                    decoding="async"
+                    :alt="person.name">
+                  <span v-else :class="$style.avatarFallback" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="8.7" r="4.2"/><path d="M12 14.2c-5.2 0-9 3.1-9 7.8V24h18v-2c0-4.7-3.8-7.8-9-7.8Z"/></svg>
+                  </span>
+                </span>
+                <span :class="$style.meta">
+                  <span :class="$style.cardName">{{ person.name }}</span>
+                  <span :class="$style.cardRole">{{ person.roles }}</span>
+                </span>
+              </nuxt-link>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { apiImgUrl } from '~/utils/api';
+
+// Preferred department order; anything else is appended alphabetically after.
+const DEPARTMENT_ORDER = [
+  'Directing',
+  'Writing',
+  'Production',
+  'Camera',
+  'Editing',
+  'Sound',
+  'Art',
+  'Costume & Make-Up',
+  'Visual Effects',
+  'Lighting',
+  'Crew',
+];
+
+// Friendlier labels for a couple of TMDB department names.
+const DEPARTMENT_LABELS = {
+  Camera: 'Cinematography',
+  'Costume & Make-Up': 'Costume & Make-Up',
+  Crew: 'Other Crew',
+};
+
+export default {
+  name: 'FullCreditsModal',
+
+  props: {
+    crew: {
+      type: Array,
+      default: () => [],
+    },
+    title: {
+      type: String,
+      default: '',
+    },
+  },
+
+  data() {
+    return {
+      // Departments expanded by default; the rest open one at a time on click,
+      // so the modal height stays controlled whether a title has 3 or 500 people.
+      openKeys: [],
+    };
+  },
+
+  created() {
+    this.openKeys = this.groups.slice(0, 3).map((g) => g.key);
+  },
+
+  computed: {
+    groups() {
+      const byDept = new Map();
+
+      for (const member of this.crew) {
+        if (!member || !member.id) continue;
+        const dept = member.department || 'Crew';
+        if (!byDept.has(dept)) byDept.set(dept, new Map());
+
+        const people = byDept.get(dept);
+        const existing = people.get(member.id);
+        if (existing) {
+          if (member.job && !existing._jobs.includes(member.job)) {
+            existing._jobs.push(member.job);
+          }
+        } else {
+          people.set(member.id, {
+            id: member.id,
+            name: member.name,
+            profile_path: member.profile_path,
+            popularity: member.popularity || 0,
+            _jobs: member.job ? [member.job] : [],
+          });
+        }
+      }
+
+      const ordered = [...byDept.keys()].sort((a, b) => {
+        const ia = DEPARTMENT_ORDER.indexOf(a);
+        const ib = DEPARTMENT_ORDER.indexOf(b);
+        if (ia === -1 && ib === -1) return a.localeCompare(b);
+        if (ia === -1) return 1;
+        if (ib === -1) return -1;
+        return ia - ib;
+      });
+
+      return ordered.map((dept) => {
+        const people = [...byDept.get(dept).values()]
+          .sort((a, b) => b.popularity - a.popularity)
+          .map((p) => ({ ...p, roles: p._jobs.join(', ') }));
+        return {
+          key: dept,
+          label: DEPARTMENT_LABELS[dept] || dept,
+          people,
+        };
+      });
+    },
+  },
+
+  methods: {
+    img(path) {
+      return `${apiImgUrl}/w185${path}`;
+    },
+    isOpen(key) {
+      return this.openKeys.includes(key);
+    },
+    toggle(key) {
+      const i = this.openKeys.indexOf(key);
+      if (i >= 0) this.openKeys.splice(i, 1);
+      else this.openKeys.push(key);
+    },
+  },
+};
+</script>
+
+<style lang="scss" module>
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(3, 4, 6, 0.7);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1100;
+  padding: 20px;
+  font-family: 'Outfit', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+}
+
+.modalContent {
+  position: relative;
+  background: rgba(3, 4, 6, 0.85);
+  background-image:
+    radial-gradient(circle at 15% 12%, rgba(31, 84, 103, 0.20), transparent 38%),
+    radial-gradient(circle at 85% 88%, rgba(139, 233, 253, 0.09), transparent 32%);
+  border-radius: 20px;
+  width: 100%;
+  max-width: 880px;
+  max-height: calc(100vh - 40px);
+  overflow-y: auto;
+  box-shadow:
+    0 20px 60px rgba(0, 0, 0, 0.6),
+    0 0 0 1px rgba(31, 84, 103, 0.5),
+    inset 0 0 24px rgba(139, 233, 253, 0.04);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  animation: floatIn 0.5s cubic-bezier(0.16, 1, 0.3, 1);
+  box-sizing: border-box;
+}
+
+.modalContent::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, transparent, #8BE9FD, #1F5467, transparent);
+  opacity: 0.8;
+  border-top-left-radius: 20px;
+  border-top-right-radius: 20px;
+  pointer-events: none;
+}
+
+.closeButton {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: #a0aab2;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+  z-index: 3;
+  padding: 0;
+
+  &:hover {
+    background: rgba(255, 95, 95, 0.1);
+    border-color: rgba(255, 95, 95, 0.3);
+    color: #ff7e7e;
+  }
+}
+
+.modalContent {
+  max-height: calc(100vh - 56px);
+}
+
+.modalBody {
+  padding: 24px 24px 18px;
+}
+
+.intro {
+  margin-bottom: 16px;
+  padding-right: 36px;
+}
+
+.eyebrow {
+  display: inline-block;
+  font-size: 10px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: #8BE9FD;
+  font-weight: 700;
+  background: rgba(139, 233, 253, 0.08);
+  border: 1px solid rgba(139, 233, 253, 0.25);
+  border-radius: 999px;
+  padding: 4px 11px;
+  margin-bottom: 9px;
+}
+
+.intro h3 {
+  font-size: 20px;
+  font-weight: 800;
+  color: #fff;
+  margin: 0;
+  letter-spacing: -0.5px;
+  text-shadow: 0 0 20px rgba(139, 233, 253, 0.25);
+}
+
+.groups {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.group {
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(139, 233, 253, 0.15);
+  border-radius: 12px;
+  padding: 0 4px 0 14px;
+  transition: border-color 0.2s ease, background 0.2s ease;
+
+  &.open {
+    background: rgba(0, 0, 0, 0.38);
+    border-color: rgba(139, 233, 253, 0.25);
+    padding-bottom: 8px;
+  }
+}
+
+.groupHead {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  padding: 11px 10px 11px 0;
+  margin: 0;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  text-align: left;
+  transition: opacity 0.2s ease;
+
+  &:hover { opacity: 0.85; }
+}
+
+.chevron {
+  margin-left: auto;
+  color: rgba(139, 233, 253, 0.6);
+  flex-shrink: 0;
+  transition: transform 0.25s ease;
+
+  .open & { transform: rotate(180deg); color: #8BE9FD; }
+}
+
+.groupLabel {
+  font-size: 11px;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  color: #8BE9FD;
+  font-weight: 700;
+}
+
+.groupCount {
+  font-size: 11px;
+  font-weight: 700;
+  color: #a0aab2;
+  background: rgba(139, 233, 253, 0.08);
+  border: 1px solid rgba(139, 233, 253, 0.2);
+  border-radius: 999px;
+  padding: 1px 8px;
+}
+
+.strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(165px, 1fr));
+  gap: 4px 8px;
+  padding: 2px 8px 4px 0;
+}
+
+.card {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  padding: 6px 8px;
+  border-radius: 10px;
+  text-decoration: none;
+  transition: background 0.18s ease;
+
+  &:hover {
+    background: rgba(139, 233, 253, 0.07);
+
+    .avatar { border-color: rgba(139, 233, 253, 0.55); }
+    .cardName { color: #8BE9FD; }
+  }
+}
+
+.avatar {
+  flex: 0 0 42px;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  overflow: hidden;
+  background: rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(139, 233, 253, 0.18);
+  transition: border-color 0.18s ease;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+}
+
+.avatarFallback {
+  width: 100%;
+  height: 100%;
+  display: block;
+  color: rgba(154, 170, 178, 0.42);
+  background: rgba(255, 255, 255, 0.05);
+
+  svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+}
+
+.meta {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.cardName {
+  font-size: 12px;
+  font-weight: 600;
+  color: #e0e6ed;
+  line-height: 1.25;
+  transition: color 0.2s ease;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cardRole {
+  font-size: 10.5px;
+  color: #80868b;
+  line-height: 1.25;
+  margin-top: 1px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+@keyframes floatIn {
+  from { opacity: 0; transform: translateY(20px) scale(0.97); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+@media (max-width: 768px) {
+  .modalOverlay { padding: 10px; }
+  .modalContent { border-radius: 16px; max-height: calc(100dvh - 20px); }
+  .modalBody { padding: 22px 14px 16px; }
+  .intro { margin-bottom: 12px; }
+  .intro h3 { font-size: 17px; }
+  .groups { gap: 10px; }
+  .group { padding: 9px 4px 7px 12px; }
+  .strip { grid-template-columns: repeat(auto-fill, minmax(138px, 1fr)); }
+  .card { gap: 8px; padding: 5px 6px; }
+  .avatar { flex-basis: 38px; width: 38px; height: 38px; }
+  .cardName { font-size: 11.5px; }
+  .cardRole { font-size: 10px; }
+}
+</style>

--- a/components/movie/MovieInfo.vue
+++ b/components/movie/MovieInfo.vue
@@ -1006,7 +1006,7 @@ export default {
   @media (min-width: $breakpoint-large) { font-size: 1.6rem; }
   ul { @media (min-width: $breakpoint-medium) { display: flex; flex-wrap: wrap; } }
   li {
-    display: flex; padding: 0.85rem 0;
+    display: flex; align-items: baseline; padding: 0.85rem 0;
     border-bottom: 1px solid rgba(139, 233, 252, 0.08);
     @media (min-width: $breakpoint-medium) { width: 50%; }
     @media (min-width: $breakpoint-xlarge) { width: 100%; }

--- a/components/movie/MovieInfo.vue
+++ b/components/movie/MovieInfo.vue
@@ -45,9 +45,19 @@
               <div :class="$style.label">Runtime</div>
               <div :class="$style.value">{{ formatRuntime(item.runtime) }}</div>
             </li>
-            <li v-if="directors">
+            <li v-if="directors" :class="$style.directorRow">
               <div :class="$style.label">Director</div>
-              <div :class="$style.value" v-html="directors" />
+              <div :class="$style.value">
+                <span v-html="directors" />
+                <button
+                  v-if="hasCrew"
+                  type="button"
+                  :class="$style.crewBtn"
+                  @click="showCrewModal = true">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+                  Full Crew
+                </button>
+              </div>
             </li>
             <li v-if="item.budget">
               <div :class="$style.label">Budget</div>
@@ -253,8 +263,15 @@
       </div>
     </div>
     
+    <!-- Full cast & crew modal (lazy-mounted; reads already-loaded item.credits.crew) -->
+    <FullCreditsModal
+      v-if="showCrewModal"
+      :crew="crewList"
+      :title="item.title || item.name"
+      @close="showCrewModal = false" />
+
     <slot name="before-recommendations"></slot>
-    
+
     <div v-if="hasAnyRecommendations" class="recommendations-wrapper">
       <h2 :class="$style.title" style="padding-left: 2rem; padding-bottom: 1rem; top: 2rem !important; position:relative; background-image: transparent;">Recommendations</h2>
       
@@ -313,6 +330,7 @@ import Filters from '~/mixins/Filters';
 import ExternalLinks from '~/components/ExternalLinks';
 import WatchOn from '~/components/WatchOn';
 import ListingCarousel from '~/components/ListingCarousel';
+import FullCreditsModal from '~/components/common/FullCreditsModal';
 
 import { getProductionCompanySlug } from '~/utils/constants';
 
@@ -321,6 +339,7 @@ export default {
     ExternalLinks,
     WatchOn,
     ListingCarousel,
+    FullCreditsModal,
     AwardsTab: () => import('~/components/common/AwardsTab'),
 
     Loader: () => import('~/components/Loader'),
@@ -370,6 +389,9 @@ export default {
       hoverRating: 0,
       editUserReview: '',
 
+      // Full cast & crew modal
+      showCrewModal: false,
+
       // Progress tracking
       progressPercentage: 0,
     };
@@ -377,6 +399,12 @@ export default {
 
   computed: {
     MANUAL_OVERVIEWS() { return MANUAL_OVERVIEWS; },
+    crewList() {
+      return this.item.credits?.crew || [];
+    },
+    hasCrew() {
+      return this.crewList.length > 0;
+    },
     reviewCount() {
       return this.reviews.length;
     },
@@ -897,11 +925,32 @@ export default {
 <style lang="scss" module>
 @use '~/assets/css/utilities/variables' as *;
 
-.info { 
-  background-color: rgba(0, 0, 0, 0.307);
-  border-radius: 15px;;
+.info {
+  position: relative;
+  background: rgba(3, 4, 6, 0.6);
+  background-image:
+    radial-gradient(circle at 12% 15%, rgba(31, 84, 103, 0.16), transparent 32%),
+    radial-gradient(circle at 88% 85%, rgba(139, 233, 253, 0.07), transparent 30%);
+  border-radius: 20px;
+  padding: 1.5rem;
   padding-bottom: 4rem;
-  @media (min-width: $breakpoint-medium) { display: flex; }
+  box-shadow:
+    0 20px 50px rgba(0, 0, 0, 0.5),
+    0 0 0 1px rgba(31, 84, 103, 0.5),
+    inset 0 0 20px rgba(139, 233, 253, 0.04);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  overflow: hidden;
+  @media (min-width: $breakpoint-medium) { display: flex; padding: 2.5rem 2.5rem 4rem; }
+}
+.info::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, transparent, #8BE9FD, #1F5467, transparent);
+  opacity: 0.8;
+  pointer-events: none;
 }
 .left {
   display: none;
@@ -915,8 +964,8 @@ export default {
 }
 .right {
   padding-top: 1rem;
-  @media (min-width: $breakpoint-medium) { 
-    flex: 1; 
+  @media (min-width: $breakpoint-medium) {
+    flex: 1;
     padding-right: 2rem;
   }
 }
@@ -925,8 +974,11 @@ export default {
   height: 0;
   padding-top: 150.27%;
   overflow: hidden;
-  border-radius: 15px;;
+  border-radius: 16px;
   background-color: $secondary-color;
+  box-shadow:
+    0 14px 34px rgba(0, 0, 0, 0.55),
+    0 0 0 1px rgba(139, 233, 253, 0.12);
   img, span { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }
   span { display: flex; align-items: center; justify-content: center; }
 }
@@ -938,10 +990,13 @@ export default {
   @media (min-width: $breakpoint-large) { font-size: 1.6rem; }
 }
 .title {
-  margin-bottom: 1rem;
+  position: relative;
+  margin-bottom: 1.2rem;
   font-size: 1.8rem;
+  font-weight: 700;
   color: #fff;
   letter-spacing: $letter-spacing;
+  text-shadow: 0 0 18px rgba(139, 233, 253, 0.18);
   @media (min-width: $breakpoint-large) { font-size: 2.4rem; }
 }
 .stats {
@@ -951,17 +1006,59 @@ export default {
   @media (min-width: $breakpoint-large) { font-size: 1.6rem; }
   ul { @media (min-width: $breakpoint-medium) { display: flex; flex-wrap: wrap; } }
   li {
-    display: flex; padding: 0.2rem 0;
+    display: flex; padding: 0.85rem 0;
+    border-bottom: 1px solid rgba(139, 233, 252, 0.08);
     @media (min-width: $breakpoint-medium) { width: 50%; }
     @media (min-width: $breakpoint-xlarge) { width: 100%; }
   }
-  a { color: #8AE8FC; text-decoration: none; }
+  a { color: #8AE8FC; text-decoration: none; transition: color 0.2s ease; }
+  a:hover { color: #b8f3ff; }
 }
 .label {
-  flex: 1; max-width: 90px; margin-right: 1.5rem; color: #fff;
-  @media (min-width: $breakpoint-xsmall) { max-width: 110px; }
+  flex: 1; max-width: 90px; margin-right: 1.5rem;
+  color: #8BE9FD;
+  font-size: 0.82em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  opacity: 0.85;
+  @media (min-width: $breakpoint-xsmall) { max-width: 120px; }
 }
-.value { flex: 2; }
+.value { flex: 2; color: $text-color; }
+.directorRow {
+  .value {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.6rem;
+  }
+}
+.crewBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.6rem 1.2rem;
+  font-size: 1.2rem;
+  font-weight: 600;
+  font-family: inherit;
+  color: #8BE9FD;
+  background: rgba(139, 233, 253, 0.07);
+  border: 1px solid rgba(139, 233, 253, 0.3);
+  border-radius: 8px;
+  cursor: pointer;
+  letter-spacing: 0.3px;
+  transition: all 0.2s ease;
+
+  svg { flex-shrink: 0; }
+
+  &:hover {
+    background: rgba(139, 233, 253, 0.14);
+    border-color: rgba(139, 233, 253, 0.55);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 14px rgba(139, 233, 253, 0.15);
+  }
+  &:active { transform: translateY(0); }
+}
 .watchSection { margin-bottom: 2rem; }
 .external {
   ul { display: flex; margin-left: -0.5rem; }

--- a/components/tv/TvInfo.vue
+++ b/components/tv/TvInfo.vue
@@ -947,7 +947,7 @@ export default {
   @media (min-width: $breakpoint-large) { font-size: 1.6rem; }
   ul { @media (min-width: $breakpoint-medium) { display: flex; flex-wrap: wrap; } }
   li {
-    display: flex; padding: 0.85rem 0;
+    display: flex; align-items: baseline; padding: 0.85rem 0;
     border-bottom: 1px solid rgba(139, 233, 252, 0.08);
     @media (min-width: $breakpoint-medium) { width: 50%; }
     @media (min-width: $breakpoint-xlarge) { width: 100%; }

--- a/components/tv/TvInfo.vue
+++ b/components/tv/TvInfo.vue
@@ -49,9 +49,19 @@
               <div :class="$style.label">Runtime</div>
               <div :class="$style.value">{{ formatRunTime(item.episode_run_time) }}</div>
             </li>
-            <li v-if="creators">
+            <li v-if="creators" :class="$style.directorRow">
               <div :class="$style.label">Creator</div>
-              <div :class="$style.value" v-html="creators" />
+              <div :class="$style.value">
+                <span v-html="creators" />
+                <button
+                  v-if="hasCrew"
+                  type="button"
+                  :class="$style.crewBtn"
+                  @click="showCrewModal = true">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+                  Full Crew
+                </button>
+              </div>
             </li>
             <li v-if="item.genres && item.genres.length">
               <div :class="$style.label">Genre</div>
@@ -236,8 +246,15 @@
       </div>
     </div>
     
+    <!-- Full cast & crew modal (lazy-mounted; reads already-loaded item.credits.crew) -->
+    <FullCreditsModal
+      v-if="showCrewModal"
+      :crew="crewList"
+      :title="item.name || item.title"
+      @close="showCrewModal = false" />
+
     <slot name="before-recommendations"></slot>
-    
+
     <div v-if="hasAnyRecommendations" class="recommendations-wrapper">
       <h2 :class="$style.title" style="padding-left: 0; margin-bottom: 1rem;">Recommendations</h2>
 
@@ -293,12 +310,14 @@ import { name, creators, poster as posterMixin } from '~/mixins/Details';
 import ExternalLinks from '~/components/ExternalLinks';
 import WatchOn from '~/components/WatchOn';
 import ListingCarousel from '~/components/ListingCarousel';
+import FullCreditsModal from '~/components/common/FullCreditsModal';
 
 export default {
   components: {
     ExternalLinks,
     WatchOn,
     ListingCarousel,
+    FullCreditsModal,
     AwardsTab: () => import('~/components/common/AwardsTab'),
 
     Loader: () => import('~/components/Loader'),
@@ -347,6 +366,9 @@ export default {
       hoverRating: 0,
       editUserReview: '',
 
+      // Full cast & crew modal
+      showCrewModal: false,
+
       // Progress tracking
       progressPercentage: 0,
     };
@@ -354,6 +376,12 @@ export default {
 
   computed: {
     reviewCount() { return this.reviews.length; },
+    crewList() {
+      return this.item.credits?.crew || [];
+    },
+    hasCrew() {
+      return this.crewList.length > 0;
+    },
     isLoggedIn() {
       if (import.meta.client) {
          return localStorage.getItem('access_token') !== null;
@@ -832,11 +860,32 @@ export default {
 <style lang="scss" module>
 @use '~/assets/css/utilities/variables' as *;
 
-.info { 
-  background-color: rgba(0, 0, 0, 0.307);
-  border-radius: 15px;;
+.info {
+  position: relative;
+  background: rgba(3, 4, 6, 0.6);
+  background-image:
+    radial-gradient(circle at 12% 15%, rgba(31, 84, 103, 0.16), transparent 32%),
+    radial-gradient(circle at 88% 85%, rgba(139, 233, 253, 0.07), transparent 30%);
+  border-radius: 20px;
+  padding: 1.5rem;
   padding-bottom: 4rem;
-  @media (min-width: $breakpoint-medium) { display: flex; }
+  box-shadow:
+    0 20px 50px rgba(0, 0, 0, 0.5),
+    0 0 0 1px rgba(31, 84, 103, 0.5),
+    inset 0 0 20px rgba(139, 233, 253, 0.04);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  overflow: hidden;
+  @media (min-width: $breakpoint-medium) { display: flex; padding: 2.5rem 2.5rem 4rem; }
+}
+.info::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, transparent, #8BE9FD, #1F5467, transparent);
+  opacity: 0.8;
+  pointer-events: none;
 }
 
 .left {
@@ -852,8 +901,8 @@ export default {
 
 .right {
   padding-top: 1rem;
-  @media (min-width: $breakpoint-medium) { 
-    flex: 1; 
+  @media (min-width: $breakpoint-medium) {
+    flex: 1;
     padding-right: 2rem;
   }
 }
@@ -863,8 +912,11 @@ export default {
   height: 0;
   padding-top: 150.27%;
   overflow: hidden;
-  border-radius: 15px;;
+  border-radius: 16px;
   background-color: $secondary-color;
+  box-shadow:
+    0 14px 34px rgba(0, 0, 0, 0.55),
+    0 0 0 1px rgba(139, 233, 253, 0.12);
   img, span { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }
   span { display: flex; align-items: center; justify-content: center; }
 }
@@ -878,10 +930,13 @@ export default {
 }
 
 .title {
-  margin-bottom: 1rem;
+  position: relative;
+  margin-bottom: 1.2rem;
   font-size: 1.8rem;
+  font-weight: 700;
   color: #fff;
   letter-spacing: $letter-spacing;
+  text-shadow: 0 0 18px rgba(139, 233, 253, 0.18);
   @media (min-width: $breakpoint-large) { font-size: 2.4rem; }
 }
 
@@ -892,19 +947,63 @@ export default {
   @media (min-width: $breakpoint-large) { font-size: 1.6rem; }
   ul { @media (min-width: $breakpoint-medium) { display: flex; flex-wrap: wrap; } }
   li {
-    display: flex; padding: 0.2rem 0;
+    display: flex; padding: 0.85rem 0;
+    border-bottom: 1px solid rgba(139, 233, 252, 0.08);
     @media (min-width: $breakpoint-medium) { width: 50%; }
     @media (min-width: $breakpoint-xlarge) { width: 100%; }
   }
-  a { color: #8AE8FC; text-decoration: none; }
+  a { color: #8AE8FC; text-decoration: none; transition: color 0.2s ease; }
+  a:hover { color: #b8f3ff; }
 }
 
 .label {
-  flex: 1; max-width: 90px; margin-right: 1.5rem; color: #fff;
-  @media (min-width: $breakpoint-xsmall) { max-width: 110px; }
+  flex: 1; max-width: 90px; margin-right: 1.5rem;
+  color: #8BE9FD;
+  font-size: 0.82em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  opacity: 0.85;
+  @media (min-width: $breakpoint-xsmall) { max-width: 120px; }
 }
 
-.value { flex: 2; }
+.value { flex: 2; color: $text-color; }
+
+.directorRow {
+  .value {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.6rem;
+  }
+}
+
+.crewBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.6rem 1.2rem;
+  font-size: 1.2rem;
+  font-weight: 600;
+  font-family: inherit;
+  color: #8BE9FD;
+  background: rgba(139, 233, 253, 0.07);
+  border: 1px solid rgba(139, 233, 253, 0.3);
+  border-radius: 8px;
+  cursor: pointer;
+  letter-spacing: 0.3px;
+  transition: all 0.2s ease;
+
+  svg { flex-shrink: 0; }
+
+  &:hover {
+    background: rgba(139, 233, 253, 0.14);
+    border-color: rgba(139, 233, 253, 0.55);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 14px rgba(139, 233, 253, 0.15);
+  }
+  &:active { transform: translateY(0); }
+}
 
 .watchSection { margin-bottom: 2rem; }
 


### PR DESCRIPTION
## Description
Overhauls the movie and TV detail panels (`components/movie/MovieInfo.vue`,
`components/tv/TvInfo.vue`) to the current glassmorphism design standard, and
adds a dedicated **Full Crew** modal that surfaces the complete technical crew
on demand. Styling-focused; no existing behaviour was changed.

## Key Changes

### 1. Glassmorphism restyle of the detail panels (#384)
* Migrated the flat `rgba(0,0,0,0.307)` containers to the standard set by
  `HowItWorksModal.vue` / `auth-success.vue`: translucent blurred background,
  radial accent gradients, diffuse layered borders (`0 0 0 1px` + inset cyan
  glow) and the 3px cyan→teal top accent line.
* Modernized the metadata list (uppercase cyan labels, row separators), the
  poster frame (elevation + hairline), and section titles.
* Styling only — poster, reviews, ratings, progress, follow, providers,
  external links, recommendations and awards are untouched.

### 2. Full Crew modal (#385)
* New `components/common/FullCreditsModal.vue` in the same glassmorphism style,
  opened from a button beside the director/creator row.
* Groups the full crew by department (Directing, Writing, Production,
  Cinematography, Editing, Sound, …) as compact, responsive cards that link to
  the person pages, with a person-silhouette fallback for missing photos.
* An accordion (first three departments open) keeps the modal height controlled
  whether a title has 3 crew members or 500.
* **No added latency:** the modal is lazy-mounted and reads the crew already
  present in the `getMovie` / `getTvShow` payload (`append_to_response: credits`),
  so nothing extra is fetched on initial render.

### 3. Rollout across repositories
* Applied in lockstep to `cinemagoria-main`, `stream`, `es` and `estream`
  (Spanish strings and department labels localized in the `es` / `estream`
  variants).

## Closes
Closes #384
Closes #385
