### PR TITLE
Move news card categories into a filtering chip row

### DIFF
--- a/components/global/NewsCarousel.vue
+++ b/components/global/NewsCarousel.vue
@@ -59,7 +59,15 @@
 
             <div class="card-content">
               <div class="card-meta">
-                <span v-if="carouselBadge(article)" class="source-badge">{{ carouselBadge(article) }}</span>
+                <div v-if="article.editorial_category" class="card-cats-row">
+                  <NuxtLink
+                    v-for="chip in categoryChips(article)"
+                    :key="chip.label"
+                    :to="{ path: '/news', query: { category: chip.token } }"
+                    class="card-cat-tag"
+                  >{{ chip.label }}</NuxtLink>
+                </div>
+                <span v-else-if="carouselBadge(article)" class="source-badge">{{ carouselBadge(article) }}</span>
                 <span class="card-date">{{ formatDate(article.published_at) }}</span>
               </div>
 
@@ -195,6 +203,30 @@ export default {
         return categoryLabel(article.editorial_category);
       }
       return article?.source?.name || '';
+    },
+    // Primary editorial category (compound label split per segment) followed by
+    // any secondary categories, as { label, token } chips. Mirrors the news
+    // card chip row; each chip links to /news filtered by its token.
+    categoryChips(article) {
+      const out = [];
+      const seen = new Set();
+      const add = (raw) => {
+        const token = String(raw || '').trim().toLowerCase();
+        if (!token) return;
+        categoryLabel(token)
+          .split('/')
+          .map((s) => s.trim())
+          .filter(Boolean)
+          .forEach((label) => {
+            const key = label.toLowerCase();
+            if (seen.has(key)) return;
+            seen.add(key);
+            out.push({ label, token });
+          });
+      };
+      add(article?.editorial_category);
+      (Array.isArray(article?.secondary_categories) ? article.secondary_categories : []).forEach(add);
+      return out;
     },
     onImageLoad(id) {
        this.loadingMap[id] = false; 
@@ -401,6 +433,39 @@ export default {
   letter-spacing: 1.2px;
   line-height: 1.2;
   display: inline-block;
+}
+
+.card-cats-row {
+  display: flex;
+  gap: 5px;
+  width: 100%;
+  overflow-x: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.card-cats-row::-webkit-scrollbar { display: none; }
+
+.card-cat-tag {
+  flex-shrink: 0;
+  font-size: 10px;
+  font-weight: 700;
+  color: #8BE9FD;
+  background: rgba(139, 233, 253, 0.08);
+  border: 1px solid rgba(139, 233, 253, 0.35);
+  padding: 3px 9px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  white-space: nowrap;
+  text-decoration: none;
+  transition: all 0.2s ease;
+}
+
+.card-cat-tag:hover {
+  color: #aef2ff;
+  background: rgba(139, 233, 253, 0.16);
+  border-color: rgba(139, 233, 253, 0.55);
 }
 
 .card-title {

--- a/components/global/NewsCarousel.vue
+++ b/components/global/NewsCarousel.vue
@@ -59,7 +59,7 @@
 
             <div class="card-content">
               <div class="card-meta">
-                <div v-if="article.editorial_category" class="card-cats-row">
+                <div v-if="categoryChips(article).length" class="card-cats-row">
                   <NuxtLink
                     v-for="chip in categoryChips(article)"
                     :key="chip.label"
@@ -111,7 +111,7 @@ import Loader from '@/components/Loader';
 import carousel from '~/mixins/Carousel';
 import striptags from 'striptags';
 import { formatDate, handleImageError } from '~/utils/helpers';
-import { categoryLabel } from '~/utils/categoryLabels';
+import { categoryLabel, CATEGORY_LABELS } from '~/utils/categoryLabels';
 
 const AUTOPLAY_INTERVAL = 10000;
 
@@ -212,7 +212,7 @@ export default {
       const seen = new Set();
       const add = (raw) => {
         const token = String(raw || '').trim().toLowerCase();
-        if (!token) return;
+        if (!token || !CATEGORY_LABELS[token]) return; // canonical, filterable buckets only
         categoryLabel(token)
           .split('/')
           .map((s) => s.trim())

--- a/pages/news/index.vue
+++ b/pages/news/index.vue
@@ -209,7 +209,7 @@
                               :alt="item.title"
                               loading="lazy"
                           />
-                          <div v-if="!item.editorial_category" class="card-source">{{ cardBadge(item) }}</div>
+                          <div v-if="!categoryChips(item).length" class="card-source">{{ cardBadge(item) }}</div>
                           <button
                             v-if="userEmail"
                             class="bookmark-btn"
@@ -238,7 +238,7 @@
                               class="img-lazy"
                           />
                           
-                          <div v-if="!item.editorial_category" class="card-source">{{ cardBadge(item) }}</div>
+                          <div v-if="!categoryChips(item).length" class="card-source">{{ cardBadge(item) }}</div>
 
                           <button 
                             v-if="userEmail"
@@ -254,7 +254,7 @@
 
                       <div class="card-content">
                         <div class="meta-row">
-                          <div v-if="item.editorial_category" class="card-cats-row">
+                          <div v-if="categoryChips(item).length" class="card-cats-row">
                             <button v-for="chip in categoryChips(item)" :key="chip.label" type="button" class="card-cat-tag" @click="filterByCategory(chip.token)">{{ chip.label }}</button>
                           </div>
                           <span class="card-date">{{ formatDate(item.published_at) }}</span>
@@ -372,7 +372,7 @@ function categoryChips(item) {
   const seen = new Set();
   const add = (raw) => {
     const token = String(raw || '').trim().toLowerCase();
-    if (!token) return;
+    if (!token || !CATEGORY_OPTIONS.includes(token)) return; // canonical, filterable buckets only
     categoryLabel(token)
       .split('/')
       .map((s) => s.trim())

--- a/pages/news/index.vue
+++ b/pages/news/index.vue
@@ -52,24 +52,38 @@
           </div>
 
           <div class="header-status">
-            <h2 class="status-title" v-if="isSavedView">Saved Articles</h2>
-            <h2 class="status-title" v-else-if="selectedSource">
-              Latest from
-              <NuxtLink v-if="selectedSource === 'Cinemagoria'" to="/news" class="source-link-header">
-                {{ selectedSource }}
-              </NuxtLink>
-              <a
-                v-else
-                :href="getSourceUrl(selectedSource)"
-                target="_blank"
-                class="source-link-header"
+            <div class="header-status__left">
+              <h2 class="status-title" v-if="isSavedView">Saved Articles</h2>
+              <h2 class="status-title" v-else-if="selectedSource">
+                Latest from
+                <NuxtLink v-if="selectedSource === 'Cinemagoria'" to="/news" class="source-link-header">
+                  {{ selectedSource }}
+                </NuxtLink>
+                <a
+                  v-else
+                  :href="getSourceUrl(selectedSource)"
+                  target="_blank"
+                  class="source-link-header"
+                >
+                  {{ selectedSource }}
+                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="external-link-icon"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>
+                </a>
+              </h2>
+              <h2 class="status-title" v-else>All Updates</h2>
+
+              <button
+                v-if="categoryFilter && !isSavedView"
+                type="button"
+                class="active-category"
+                @click="pickCategory(null)"
+                title="Clear category filter"
               >
-                {{ selectedSource }}
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="external-link-icon"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>
-              </a>
-            </h2>
-            <h2 class="status-title" v-else>All Updates</h2>
-            
+                <span class="active-category__dot"></span>
+                {{ categoryLabel(categoryFilter) }}
+                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+              </button>
+            </div>
+
             <ClientOnly>
               <span class="count-badge">
                 <template v-if="isSavedView">
@@ -195,7 +209,7 @@
                               :alt="item.title"
                               loading="lazy"
                           />
-                          <div class="card-source">{{ cardBadge(item) }}</div>
+                          <div v-if="!item.editorial_category" class="card-source">{{ cardBadge(item) }}</div>
                           <button
                             v-if="userEmail"
                             class="bookmark-btn"
@@ -224,7 +238,7 @@
                               class="img-lazy"
                           />
                           
-                          <div class="card-source">{{ cardBadge(item) }}</div>
+                          <div v-if="!item.editorial_category" class="card-source">{{ cardBadge(item) }}</div>
 
                           <button 
                             v-if="userEmail"
@@ -240,6 +254,9 @@
 
                       <div class="card-content">
                         <div class="meta-row">
+                          <div v-if="item.editorial_category" class="card-cats-row">
+                            <button v-for="chip in categoryChips(item)" :key="chip.label" type="button" class="card-cat-tag" @click="filterByCategory(chip.token)">{{ chip.label }}</button>
+                          </div>
                           <span class="card-date">{{ formatDate(item.published_at) }}</span>
                         </div>
                         
@@ -346,6 +363,32 @@ function cardBadge(item) {
   return item?.source?.name || '';
 }
 
+// Build the card's category chips: the primary editorial category first (its
+// compound label split into one chip per segment), then any secondary
+// categories. Each chip carries the canonical token it filters by; duplicate
+// labels are dropped. Returns { label, token }[].
+function categoryChips(item) {
+  const out = [];
+  const seen = new Set();
+  const add = (raw) => {
+    const token = String(raw || '').trim().toLowerCase();
+    if (!token) return;
+    categoryLabel(token)
+      .split('/')
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .forEach((label) => {
+        const key = label.toLowerCase();
+        if (seen.has(key)) return;
+        seen.add(key);
+        out.push({ label, token });
+      });
+  };
+  add(item?.editorial_category);
+  (Array.isArray(item?.secondary_categories) ? item.secondary_categories : []).forEach(add);
+  return out;
+}
+
 // Category chip is visible only when looking at Cinemagoria-internal articles
 // (the only ones that carry editorial_category). Hidden during external-source
 // view and during active search (mixed sources, filter would only hit internal).
@@ -359,6 +402,17 @@ function pickCategory(cat) {
   const query = { ...route.query };
   if (cat) query.category = cat; else delete query.category;
   router.replace({ query });
+}
+
+// Filter the feed from a card's category chip, mirroring the top filter panel.
+// The /api/news payload is not lowercased, so normalize the token before it
+// reaches the case-sensitive CATEGORY_OPTIONS guard; only the canonical buckets
+// are filterable. Surface the result from the top like the panel does.
+function filterByCategory(token) {
+  const t = String(token || '').trim().toLowerCase();
+  if (!CATEGORY_OPTIONS.includes(t)) return;
+  pickCategory(t);
+  window.scrollTo({ top: 0, behavior: 'smooth' });
 }
 
 // Handle ?q= and ?from= query params (arriving from topic click in article page)
@@ -1017,6 +1071,48 @@ watch(userEmail, (val) => {
   -webkit-backdrop-filter: blur(10px);
 }
 
+.header-status__left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.active-category {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 4px 10px 4px 11px;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  color: #8BE9FD;
+  background: rgba(139, 233, 253, 0.08);
+  border: 1px solid rgba(139, 233, 253, 0.3);
+  border-radius: 999px;
+  cursor: pointer;
+  letter-spacing: 0.2px;
+  transition: all 0.2s ease;
+}
+
+.active-category__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #8BE9FD;
+  box-shadow: 0 0 8px rgba(139, 233, 253, 0.7);
+  flex-shrink: 0;
+}
+
+.active-category svg { opacity: 0.7; transition: opacity 0.2s ease; }
+
+.active-category:hover {
+  background: rgba(139, 233, 253, 0.16);
+  border-color: rgba(139, 233, 253, 0.55);
+}
+.active-category:hover svg { opacity: 1; }
+
 .status-title {
   font-size: 18px;
   font-weight: 600;
@@ -1309,10 +1405,25 @@ watch(userEmail, (val) => {
 }
 
 .meta-row {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
   margin-bottom: 10px;
   font-size: 12px;
   color: #888;
 }
+
+.card-cats-row {
+  display: flex;
+  gap: 5px;
+  width: 100%;
+  overflow-x: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.card-cats-row::-webkit-scrollbar { display: none; }
 
 .card-title {
   font-size: 18px;
@@ -1803,6 +1914,28 @@ watch(userEmail, (val) => {
   padding-top: 8px;
   margin-bottom: 12px;
   border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.card-cat-tag {
+  flex-shrink: 0;
+  font-size: 11px;
+  font-weight: 700;
+  color: #8BE9FD;
+  background: rgba(139, 233, 253, 0.08);
+  border: 1px solid rgba(139, 233, 253, 0.3);
+  padding: 3px 10px;
+  border-radius: 12px;
+  cursor: pointer;
+  white-space: nowrap;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  transition: all 0.2s ease;
+}
+
+.card-cat-tag:hover {
+  color: #aef2ff;
+  background: rgba(139, 233, 253, 0.16);
+  border-color: rgba(139, 233, 253, 0.5);
 }
 
 .card-tags-label {


### PR DESCRIPTION
## Description
Reworks how the editorial category is shown on the curated-news cards. It used to
be an absolutely-positioned pill overlaid on the card image; on compound labels
(e.g. `Industry / Acquisition / Box Office`) it wrapped onto two lines and
collided with the Save / Read-Later bookmark button. It is now a compact,
horizontally scrollable chip row inside the card, and the chips actually filter
the feed. Scoped to curated news, so `cinemagoria-main` and `cinemagoria-es`
only — `stream` / `estream` do not surface curated news.

## Key Changes

### 1. Category chip row replaces the image overlay
* Removed the long editorial category from the `.card-source` image overlay (it
  now only carries the publisher badge for external items, so it can no longer
  overlap the bookmark button).
* The category renders as a chip row at the top of the card content, above the
  date, mirroring the existing Topics row. No section label, single line,
  horizontal scroll (`overflow-x: auto`, `white-space: nowrap`) — keeps card
  height tight regardless of label length.
* Compound labels split into one chip per segment; any `secondary_categories`
  follow the primary, de-duplicated by label.

### 2. Chips filter the feed (parity with the top filter panel)
* **Root cause of the dead click:** `/api/news` returns `editorial_category`
  un-normalized (unlike the RSS feed, which lowercases it). `categoryLabel()`
  lowercases for display so the chip looked correct, but the raw token reaching
  the case-sensitive `CATEGORY_OPTIONS` guard in the route watcher reset the
  filter to `null`.
* `filterByCategory` now normalizes the token, only acts on the canonical
  buckets, and scrolls to the top so the filtered result is visible — the same
  UX as clicking the panel.

### 3. Selected-category indicator
* A minimal pill next to the `Latest from …` header shows the active category
  with a clear (×) affordance; visible only while a category filter is applied.

### 4. NewsCarousel parity
* `components/global/NewsCarousel.vue` adopts the same chip row above the date,
  with chips linking to the filtered news view (`/news?category=`).

## Closes
Closes #387
