### PR TITLE
List definitive Fantasia 2026 sections in the catalog

### DIFF
--- a/pages/festival/fantasia-2026/index.vue
+++ b/pages/festival/fantasia-2026/index.vue
@@ -359,29 +359,37 @@ const awards = ref([]);
 const schedule = ref([]);
 const openDays = ref(new Set());
 
-// Fantasia 2026 first-wave sections (#357). The OTHER bucket catches any
-// section that arrives in later waves before it gets added to CATEGORY_ORDER,
-// so newly announced films never disappear between releases.
+// Fantasia 2026 definitive sections (#389) — the festival published its
+// complete program, so these mirror festival_films.category exactly. The
+// OTHER bucket stays as a safety net for any late addition.
 const CATEGORY_ORDER = [
+    'Opening Film',
     'Cheval Noir Competition',
+    'Horizon 2026',
     'Septentrion Shadows',
     'Les Fantastiques Week-Ends du Cinéma Québécois',
     'Documentaries from the Edge',
     'Animation Plus',
     'Underground',
     'My First Fantasia',
-    'TBA',
+    'Fantasia Retro',
+    'Genre du pays',
+    'Before features',
 ];
 
 const CATEGORY_LABELS = {
+    'Opening Film': 'Opening Film',
     'Cheval Noir Competition': 'Cheval Noir Competition',
+    'Horizon 2026': 'Horizon 2026',
     'Septentrion Shadows': 'Septentrion Shadows',
     'Les Fantastiques Week-Ends du Cinéma Québécois': 'Les Fantastiques Week-Ends du Cinéma Québécois',
     'Documentaries from the Edge': 'Documentaries from the Edge',
     'Animation Plus': 'Animation Plus',
     'Underground': 'Underground',
     'My First Fantasia': 'My First Fantasia',
-    'TBA': 'TBA (To be announced)',
+    'Fantasia Retro': 'Fantasia Retro',
+    'Genre du pays': 'Genre du pays',
+    'Before features': 'Before features',
     OTHER: 'Other',
 };
 


### PR DESCRIPTION
## Summary

Update the Fantasia 2026 catalog to list the **twelve definitive selection sections**, replacing the first-wave list from #357 and dropping the `TBA` placeholder. `CATEGORY_ORDER` / `CATEGORY_LABELS` in `pages/festival/fantasia-2026/index.vue` now mirror `festival_films.category` exactly; the `OTHER` safety bucket stays in place.

## Motivation

The frontend was already rendering the new films, but everything outside the first-wave list was landing in the `OTHER` bucket. The real driver is on the data side: the festival published its **complete program** (all remaining features and shorts, plus the screening schedule), and the ingestion is done — the database now holds **161 films** (116 newly inserted and enriched, the 45 first-wave rows completed with `source_url` and their final sections, the 24 `TBA` rows recategorized) and **207 screenings** across the three Montreal venues (Jul 16 – Aug 2). With sections final, the catalog can name them all: `Opening Film`, `Horizon 2026`, `Fantasia Retro`, `Genre du pays` and `Before features` join the list.

Same change goes to `cinemagoria-es` via their direct-commit flow.

Closes #389 (parent #336).