### PR TITLE
FrightFest 2026 — Schedule Fixes & Card Promotion (Batch 4)

### DIFF
--- a/pages/festival/frightfest-2026/index.vue
+++ b/pages/festival/frightfest-2026/index.vue
@@ -449,14 +449,22 @@ watch([loading, activeTab, selectionSections], () => {
 }, { flush: 'post' });
 
 const formatDate = (dateStr) => {
+    // Parse the Y/M/D parts manually — new Date('2026-08-27') parses as UTC
+    // midnight, which shifts to the previous day once rendered in any
+    // timezone behind UTC (e.g. the Americas), mislabeling the day header.
+    const [year, month, day] = dateStr.split('-').map(Number);
+    const date = new Date(year, month - 1, day);
     const options = { weekday: 'long', month: 'long', day: 'numeric' };
-    return new Date(dateStr).toLocaleDateString('en-US', options);
+    return date.toLocaleDateString('en-US', options);
 };
 
 const formatTime = (timeStr) => {
+    // These are in-person London screenings — always show the venue-local
+    // time, not the viewer's browser timezone.
     return new Date(timeStr).toLocaleTimeString('en-US', {
         hour: '2-digit',
-        minute: '2-digit'
+        minute: '2-digit',
+        timeZone: 'Europe/London'
     });
 };
 

--- a/pages/festival/index.vue
+++ b/pages/festival/index.vue
@@ -27,7 +27,7 @@ const festivals = [
     image: '/festivals/fantasia/fantasia_backdrop_2026_en.webp' },
   { slug: 'frightfest-2026', name: 'FrightFest',    year: 2026, city: 'London',     country: 'UK',
     startDate: '2026-08-27', endDate: '2026-08-31', dateLabel: 'Aug 27 – 31, 2026',
-    image: '/festivals/frightfest/frightfest_backdrop_2026_en.png', comingSoon: true },
+    image: '/festivals/frightfest/frightfest_backdrop_2026_en.png' },
   { slug: 'tribeca-2026',   name: 'Tribeca',        year: 2026, city: 'New York',   country: 'USA',
     startDate: '2026-06-03', endDate: '2026-06-14', dateLabel: 'Jun 3 – 14, 2026',
     image: '/festivals/tribeca/tribeca_backdrop_2026_eng.webp' },

--- a/server/api/festival/frightfest/films.get.ts
+++ b/server/api/festival/frightfest/films.get.ts
@@ -51,8 +51,10 @@ export default defineEventHandler(async (event) => {
         });
 
         if (query.limit) {
-            const limit = parseInt(query.limit as string)
-            films = films.slice(0, limit)
+            const limit = parseInt(query.limit as string, 10)
+            if (!isNaN(limit)) {
+                films = films.slice(0, limit)
+            }
         }
 
         films.sort((a: any, b: any) => a.title.localeCompare(b.title))


### PR DESCRIPTION
## Summary
Resolves Gemini Code Assist's review on PR #398:
- **Accepted**: `formatDate`/`formatTime` UTC/timezone bug (dates showed one day off, times showed viewer-local instead of London-local — both confirmed empirically) + `query.limit` NaN guard on `films.get.ts`
- **Rejected** (with reasoning in #399): the `Set`-mutation "fix" for `toggleDay` (empirically verified Vue 3 already tracks this correctly) and the extra `name`/`media_type`/`profile_path`/`logo_path` fields (would misroute the card's media-type detection, or are simply unused person/company fields)
- Also fixes the Spanish frontends' locale leftover (`'en-US'` instead of `'es-ES'`) in the same two functions
- Removes `comingSoon` from the `/festival` FrightFest card — now a normal "Explore" link, since Batches 1-3 already shipped real films + screenings

Part of #394. Closes #399.

## Test plan
- [x] SFC syntax validated
- [x] Date/timezone fix verified empirically (`TZ=America/Argentina/Buenos_Aires node -e ...`) before and after
- [x] Manual check: `/festival` shows FrightFest as a clickable "Explore" card
- [x] Manual check: `/festival/frightfest-2026` Schedule tab shows correct day headers and London-local times regardless of viewer timezone
