### PR TITLE
Add official festival source links and group quick actions on catalog cards

### DIFF
--- a/components/BaficiCard.vue
+++ b/components/BaficiCard.vue
@@ -11,7 +11,22 @@
           <Loader :size="40" />
         </div>
 
-        <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" />
+        <div class="card__quick-actions">
+          <button
+            v-if="sourceUrl"
+            type="button"
+            class="card__ext-link"
+            :aria-label="`Open official festival page for ${name}`"
+            @click.prevent.stop="openSourceUrl"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+              <path d="M15 3h6v6" />
+              <path d="M10 14 21 3" />
+            </svg>
+          </button>
+          <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" grouped />
+        </div>
 
         <img
           v-if="poster"
@@ -120,6 +135,9 @@ export default {
     onImageLoaded() {
       this.isLoading = false;
     },
+    openSourceUrl() {
+      window.open(this.sourceUrl, '_blank', 'noopener,noreferrer');
+    },
     getRouteLink() {
         if (this.item.media_type === 'production') {
             return { name: 'production-slug', params: { slug: this.item.slug } };
@@ -132,6 +150,11 @@ export default {
   },
 
   computed: {
+    // Official festival page for this film; empty unless it's a real http(s) URL.
+    sourceUrl () {
+      const url = typeof this.item?.source_url === 'string' ? this.item.source_url.trim() : '';
+      return /^https?:\/\//i.test(url) ? url : '';
+    },
     poster () {
       if (this.poster_path) return this.poster_path;
       if (this.item.profile_path) {
@@ -253,5 +276,37 @@ export default {
     width: auto;
     filter: invert(1);
     object-fit: contain;
+}
+
+.card__quick-actions {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  z-index: 20;
+}
+
+.card__ext-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  background: rgba(0, 0, 0, 0.6);
+  border: 1px solid rgba(139, 233, 253, 0.3);
+  border-radius: 50%;
+  backdrop-filter: blur(4px);
+  cursor: pointer;
+  transition: all 0.3s ease;
+  pointer-events: auto;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.8);
+    border-color: #8BE9FD;
+    transform: scale(1.1);
+  }
 }
 </style>

--- a/components/BerlinaleCard.vue
+++ b/components/BerlinaleCard.vue
@@ -11,7 +11,22 @@
           <Loader :size="40" />
         </div>
 
-        <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" />
+        <div class="card__quick-actions">
+          <button
+            v-if="sourceUrl"
+            type="button"
+            class="card__ext-link"
+            :aria-label="`Open official festival page for ${name}`"
+            @click.prevent.stop="openSourceUrl"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+              <path d="M15 3h6v6" />
+              <path d="M10 14 21 3" />
+            </svg>
+          </button>
+          <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" grouped />
+        </div>
 
         <img
           v-if="poster"
@@ -119,6 +134,9 @@ export default {
     onImageLoaded() {
       this.isLoading = false;
     },
+    openSourceUrl() {
+      window.open(this.sourceUrl, '_blank', 'noopener,noreferrer');
+    },
     getRouteLink() {
         if (this.item.media_type === 'production') {
             return { name: 'production-slug', params: { slug: this.item.slug } };
@@ -131,6 +149,11 @@ export default {
   },
 
   computed: {
+    // Official festival page for this film; empty unless it's a real http(s) URL.
+    sourceUrl () {
+      const url = typeof this.item?.source_url === 'string' ? this.item.source_url.trim() : '';
+      return /^https?:\/\//i.test(url) ? url : '';
+    },
     hasLink() {
         return this.item.has_valid_tmdb_id;
     },
@@ -259,5 +282,37 @@ export default {
     width: auto;
     filter: invert(1);
     object-fit: contain;
+}
+
+.card__quick-actions {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  z-index: 20;
+}
+
+.card__ext-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  background: rgba(0, 0, 0, 0.6);
+  border: 1px solid rgba(139, 233, 253, 0.3);
+  border-radius: 50%;
+  backdrop-filter: blur(4px);
+  cursor: pointer;
+  transition: all 0.3s ease;
+  pointer-events: auto;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.8);
+    border-color: #8BE9FD;
+    transform: scale(1.1);
+  }
 }
 </style>

--- a/components/BifffCard.vue
+++ b/components/BifffCard.vue
@@ -11,7 +11,22 @@
           <Loader :size="40" />
         </div>
 
-        <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" />
+        <div class="card__quick-actions">
+          <button
+            v-if="sourceUrl"
+            type="button"
+            class="card__ext-link"
+            :aria-label="`Open official festival page for ${name}`"
+            @click.prevent.stop="openSourceUrl"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+              <path d="M15 3h6v6" />
+              <path d="M10 14 21 3" />
+            </svg>
+          </button>
+          <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" grouped />
+        </div>
 
         <img
           v-if="poster"
@@ -120,6 +135,9 @@ export default {
     onImageLoaded() {
       this.isLoading = false;
     },
+    openSourceUrl() {
+      window.open(this.sourceUrl, '_blank', 'noopener,noreferrer');
+    },
     getRouteLink() {
         if (this.item.media_type === 'production') {
             return { name: 'production-slug', params: { slug: this.item.slug } };
@@ -132,6 +150,11 @@ export default {
   },
 
   computed: {
+    // Official festival page for this film; empty unless it's a real http(s) URL.
+    sourceUrl () {
+      const url = typeof this.item?.source_url === 'string' ? this.item.source_url.trim() : '';
+      return /^https?:\/\//i.test(url) ? url : '';
+    },
     poster () {
       if (this.poster_path) return this.poster_path;
       if (this.item.profile_path) {
@@ -253,5 +276,37 @@ export default {
     width: auto;
     filter: invert(1);
     object-fit: contain;
+}
+
+.card__quick-actions {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  z-index: 20;
+}
+
+.card__ext-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  background: rgba(0, 0, 0, 0.6);
+  border: 1px solid rgba(139, 233, 253, 0.3);
+  border-radius: 50%;
+  backdrop-filter: blur(4px);
+  cursor: pointer;
+  transition: all 0.3s ease;
+  pointer-events: auto;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.8);
+    border-color: #8BE9FD;
+    transform: scale(1.1);
+  }
 }
 </style>

--- a/components/CannesCard.vue
+++ b/components/CannesCard.vue
@@ -11,7 +11,22 @@
           <Loader :size="40" />
         </div>
 
-        <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" />
+        <div class="card__quick-actions">
+          <button
+            v-if="sourceUrl"
+            type="button"
+            class="card__ext-link"
+            :aria-label="`Open official festival page for ${name}`"
+            @click.prevent.stop="openSourceUrl"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+              <path d="M15 3h6v6" />
+              <path d="M10 14 21 3" />
+            </svg>
+          </button>
+          <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" grouped />
+        </div>
 
         <img
           v-if="poster"
@@ -142,6 +157,9 @@ export default {
     onImageLoaded() {
       this.isLoading = false;
     },
+    openSourceUrl() {
+      window.open(this.sourceUrl, '_blank', 'noopener,noreferrer');
+    },
     getRouteLink() {
       if (this.item.media_type === 'production') {
         return { name: 'production-slug', params: { slug: this.item.slug } };
@@ -154,6 +172,11 @@ export default {
   },
 
   computed: {
+    // Official festival page for this film; empty unless it's a real http(s) URL.
+    sourceUrl () {
+      const url = typeof this.item?.source_url === 'string' ? this.item.source_url.trim() : '';
+      return /^https?:\/\//i.test(url) ? url : '';
+    },
     cannesSection () {
       const source = this.category || this.item?.festival_source || this.item?.section || this.item?.category || '';
       const up = String(source).toUpperCase();
@@ -274,5 +297,37 @@ export default {
     width: auto;
     filter: invert(1) brightness(1.05);
     object-fit: contain;
+}
+
+.card__quick-actions {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  z-index: 20;
+}
+
+.card__ext-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  background: rgba(0, 0, 0, 0.6);
+  border: 1px solid rgba(139, 233, 253, 0.3);
+  border-radius: 50%;
+  backdrop-filter: blur(4px);
+  cursor: pointer;
+  transition: all 0.3s ease;
+  pointer-events: auto;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.8);
+    border-color: #8BE9FD;
+    transform: scale(1.1);
+  }
 }
 </style>

--- a/components/CuffCard.vue
+++ b/components/CuffCard.vue
@@ -11,7 +11,22 @@
           <Loader :size="40" />
         </div>
 
-        <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" />
+        <div class="card__quick-actions">
+          <button
+            v-if="sourceUrl"
+            type="button"
+            class="card__ext-link"
+            :aria-label="`Open official festival page for ${name}`"
+            @click.prevent.stop="openSourceUrl"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+              <path d="M15 3h6v6" />
+              <path d="M10 14 21 3" />
+            </svg>
+          </button>
+          <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" grouped />
+        </div>
 
         <img
           v-if="poster"
@@ -120,6 +135,9 @@ export default {
     onImageLoaded() {
       this.isLoading = false;
     },
+    openSourceUrl() {
+      window.open(this.sourceUrl, '_blank', 'noopener,noreferrer');
+    },
     getRouteLink() {
         if (this.item.media_type === 'production') {
             return { name: 'production-slug', params: { slug: this.item.slug } };
@@ -132,6 +150,11 @@ export default {
   },
 
   computed: {
+    // Official festival page for this film; empty unless it's a real http(s) URL.
+    sourceUrl () {
+      const url = typeof this.item?.source_url === 'string' ? this.item.source_url.trim() : '';
+      return /^https?:\/\//i.test(url) ? url : '';
+    },
     poster () {
       if (this.poster_path) return this.poster_path;
       if (this.item.profile_path) {
@@ -253,5 +276,37 @@ export default {
     width: auto;
     filter: invert(1);
     object-fit: contain;
+}
+
+.card__quick-actions {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  z-index: 20;
+}
+
+.card__ext-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  background: rgba(0, 0, 0, 0.6);
+  border: 1px solid rgba(139, 233, 253, 0.3);
+  border-radius: 50%;
+  backdrop-filter: blur(4px);
+  cursor: pointer;
+  transition: all 0.3s ease;
+  pointer-events: auto;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.8);
+    border-color: #8BE9FD;
+    transform: scale(1.1);
+  }
 }
 </style>

--- a/components/FantasiaCard.vue
+++ b/components/FantasiaCard.vue
@@ -11,7 +11,22 @@
           <Loader :size="40" />
         </div>
 
-        <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" />
+        <div class="card__quick-actions">
+          <button
+            v-if="sourceUrl"
+            type="button"
+            class="card__ext-link"
+            :aria-label="`Open official festival page for ${name}`"
+            @click.prevent.stop="openSourceUrl"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+              <path d="M15 3h6v6" />
+              <path d="M10 14 21 3" />
+            </svg>
+          </button>
+          <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" grouped />
+        </div>
 
         <img
           v-if="poster"
@@ -120,6 +135,9 @@ export default {
     onImageLoaded() {
       this.isLoading = false;
     },
+    openSourceUrl() {
+      window.open(this.sourceUrl, '_blank', 'noopener,noreferrer');
+    },
     getRouteLink() {
         if (this.item.media_type === 'production') {
             return { name: 'production-slug', params: { slug: this.item.slug } };
@@ -132,6 +150,11 @@ export default {
   },
 
   computed: {
+    // Official festival page for this film; empty unless it's a real http(s) URL.
+    sourceUrl () {
+      const url = typeof this.item?.source_url === 'string' ? this.item.source_url.trim() : '';
+      return /^https?:\/\//i.test(url) ? url : '';
+    },
     poster () {
       if (this.poster_path) return this.poster_path;
       if (this.item.profile_path) {
@@ -253,5 +276,37 @@ export default {
     width: auto;
     filter: invert(1);
     object-fit: contain;
+}
+
+.card__quick-actions {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  z-index: 20;
+}
+
+.card__ext-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  background: rgba(0, 0, 0, 0.6);
+  border: 1px solid rgba(139, 233, 253, 0.3);
+  border-radius: 50%;
+  backdrop-filter: blur(4px);
+  cursor: pointer;
+  transition: all 0.3s ease;
+  pointer-events: auto;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.8);
+    border-color: #8BE9FD;
+    transform: scale(1.1);
+  }
 }
 </style>

--- a/components/FrightfestCard.vue
+++ b/components/FrightfestCard.vue
@@ -11,7 +11,22 @@
           <Loader :size="40" />
         </div>
 
-        <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" />
+        <div class="card__quick-actions">
+          <button
+            v-if="sourceUrl"
+            type="button"
+            class="card__ext-link"
+            :aria-label="`Open official festival page for ${name}`"
+            @click.prevent.stop="openSourceUrl"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+              <path d="M15 3h6v6" />
+              <path d="M10 14 21 3" />
+            </svg>
+          </button>
+          <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" grouped />
+        </div>
 
         <img
           v-if="poster"
@@ -120,6 +135,9 @@ export default {
     onImageLoaded() {
       this.isLoading = false;
     },
+    openSourceUrl() {
+      window.open(this.sourceUrl, '_blank', 'noopener,noreferrer');
+    },
     getRouteLink() {
         if (this.item.media_type === 'production') {
             return { name: 'production-slug', params: { slug: this.item.slug } };
@@ -132,6 +150,11 @@ export default {
   },
 
   computed: {
+    // Official festival page for this film; empty unless it's a real http(s) URL.
+    sourceUrl () {
+      const url = typeof this.item?.source_url === 'string' ? this.item.source_url.trim() : '';
+      return /^https?:\/\//i.test(url) ? url : '';
+    },
     poster () {
       if (this.poster_path) return this.poster_path;
       if (this.item.profile_path) {
@@ -253,5 +276,37 @@ export default {
     width: auto;
     filter: invert(1);
     object-fit: contain;
+}
+
+.card__quick-actions {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  z-index: 20;
+}
+
+.card__ext-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  background: rgba(0, 0, 0, 0.6);
+  border: 1px solid rgba(139, 233, 253, 0.3);
+  border-radius: 50%;
+  backdrop-filter: blur(4px);
+  cursor: pointer;
+  transition: all 0.3s ease;
+  pointer-events: auto;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.8);
+    border-color: #8BE9FD;
+    transform: scale(1.1);
+  }
 }
 </style>

--- a/components/KviffCard.vue
+++ b/components/KviffCard.vue
@@ -11,7 +11,22 @@
           <Loader :size="40" />
         </div>
 
-        <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" />
+        <div class="card__quick-actions">
+          <button
+            v-if="sourceUrl"
+            type="button"
+            class="card__ext-link"
+            :aria-label="`Open official festival page for ${name}`"
+            @click.prevent.stop="openSourceUrl"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+              <path d="M15 3h6v6" />
+              <path d="M10 14 21 3" />
+            </svg>
+          </button>
+          <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" grouped />
+        </div>
 
         <img
           v-if="poster"
@@ -120,6 +135,9 @@ export default {
     onImageLoaded() {
       this.isLoading = false;
     },
+    openSourceUrl() {
+      window.open(this.sourceUrl, '_blank', 'noopener,noreferrer');
+    },
     getRouteLink() {
         if (this.item.media_type === 'production') {
             return { name: 'production-slug', params: { slug: this.item.slug } };
@@ -132,6 +150,11 @@ export default {
   },
 
   computed: {
+    // Official festival page for this film; empty unless it's a real http(s) URL.
+    sourceUrl () {
+      const url = typeof this.item?.source_url === 'string' ? this.item.source_url.trim() : '';
+      return /^https?:\/\//i.test(url) ? url : '';
+    },
     poster () {
       if (this.poster_path) return this.poster_path;
       if (this.item.profile_path) {
@@ -253,5 +276,37 @@ export default {
     width: auto;
     filter: invert(1);
     object-fit: contain;
+}
+
+.card__quick-actions {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  z-index: 20;
+}
+
+.card__ext-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  background: rgba(0, 0, 0, 0.6);
+  border: 1px solid rgba(139, 233, 253, 0.3);
+  border-radius: 50%;
+  backdrop-filter: blur(4px);
+  cursor: pointer;
+  transition: all 0.3s ease;
+  pointer-events: auto;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.8);
+    border-color: #8BE9FD;
+    transform: scale(1.1);
+  }
 }
 </style>

--- a/components/RomfordCard.vue
+++ b/components/RomfordCard.vue
@@ -11,7 +11,22 @@
           <Loader :size="40" />
         </div>
 
-        <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" />
+        <div class="card__quick-actions">
+          <button
+            v-if="sourceUrl"
+            type="button"
+            class="card__ext-link"
+            :aria-label="`Open official festival page for ${name}`"
+            @click.prevent.stop="openSourceUrl"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+              <path d="M15 3h6v6" />
+              <path d="M10 14 21 3" />
+            </svg>
+          </button>
+          <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" grouped />
+        </div>
 
         <img
           v-if="poster"
@@ -120,6 +135,9 @@ export default {
     onImageLoaded() {
       this.isLoading = false;
     },
+    openSourceUrl() {
+      window.open(this.sourceUrl, '_blank', 'noopener,noreferrer');
+    },
     getRouteLink() {
         if (this.item.media_type === 'production') {
             return { name: 'production-slug', params: { slug: this.item.slug } };
@@ -132,6 +150,11 @@ export default {
   },
 
   computed: {
+    // Official festival page for this film; empty unless it's a real http(s) URL.
+    sourceUrl () {
+      const url = typeof this.item?.source_url === 'string' ? this.item.source_url.trim() : '';
+      return /^https?:\/\//i.test(url) ? url : '';
+    },
     poster () {
       if (this.poster_path) return this.poster_path;
       if (this.item.profile_path) {
@@ -253,5 +276,37 @@ export default {
     width: auto;
     filter: invert(1);
     object-fit: contain;
+}
+
+.card__quick-actions {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  z-index: 20;
+}
+
+.card__ext-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  background: rgba(0, 0, 0, 0.6);
+  border: 1px solid rgba(139, 233, 253, 0.3);
+  border-radius: 50%;
+  backdrop-filter: blur(4px);
+  cursor: pointer;
+  transition: all 0.3s ease;
+  pointer-events: auto;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.8);
+    border-color: #8BE9FD;
+    transform: scale(1.1);
+  }
 }
 </style>

--- a/components/RotterdamCard.vue
+++ b/components/RotterdamCard.vue
@@ -11,7 +11,22 @@
           <Loader :size="40" />
         </div>
 
-        <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" />
+        <div class="card__quick-actions">
+          <button
+            v-if="sourceUrl"
+            type="button"
+            class="card__ext-link"
+            :aria-label="`Open official festival page for ${name}`"
+            @click.prevent.stop="openSourceUrl"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+              <path d="M15 3h6v6" />
+              <path d="M10 14 21 3" />
+            </svg>
+          </button>
+          <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" grouped />
+        </div>
 
         <img
           v-if="poster"
@@ -120,6 +135,9 @@ export default {
     onImageLoaded() {
       this.isLoading = false;
     },
+    openSourceUrl() {
+      window.open(this.sourceUrl, '_blank', 'noopener,noreferrer');
+    },
     getRouteLink() {
         if (this.item.media_type === 'production') {
             return { name: 'production-slug', params: { slug: this.item.slug } };
@@ -132,6 +150,11 @@ export default {
   },
 
   computed: {
+    // Official festival page for this film; empty unless it's a real http(s) URL.
+    sourceUrl () {
+      const url = typeof this.item?.source_url === 'string' ? this.item.source_url.trim() : '';
+      return /^https?:\/\//i.test(url) ? url : '';
+    },
     poster () {
       if (this.poster_path) return this.poster_path;
       if (this.item.profile_path) {
@@ -253,5 +276,37 @@ export default {
     width: auto;
     filter: invert(1);
     object-fit: contain;
+}
+
+.card__quick-actions {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  z-index: 20;
+}
+
+.card__ext-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  background: rgba(0, 0, 0, 0.6);
+  border: 1px solid rgba(139, 233, 253, 0.3);
+  border-radius: 50%;
+  backdrop-filter: blur(4px);
+  cursor: pointer;
+  transition: all 0.3s ease;
+  pointer-events: auto;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.8);
+    border-color: #8BE9FD;
+    transform: scale(1.1);
+  }
 }
 </style>

--- a/components/SlamdanceCard.vue
+++ b/components/SlamdanceCard.vue
@@ -11,7 +11,22 @@
           <Loader :size="40" />
         </div>
 
-        <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" />
+        <div class="card__quick-actions">
+          <button
+            v-if="sourceUrl"
+            type="button"
+            class="card__ext-link"
+            :aria-label="`Open official festival page for ${name}`"
+            @click.prevent.stop="openSourceUrl"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+              <path d="M15 3h6v6" />
+              <path d="M10 14 21 3" />
+            </svg>
+          </button>
+          <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" grouped />
+        </div>
 
         <img
           v-if="poster"
@@ -120,6 +135,9 @@ export default {
     onImageLoaded() {
       this.isLoading = false;
     },
+    openSourceUrl() {
+      window.open(this.sourceUrl, '_blank', 'noopener,noreferrer');
+    },
     getRouteLink() {
         if (this.item.media_type === 'production') {
             return { name: 'production-slug', params: { slug: this.item.slug } };
@@ -132,6 +150,11 @@ export default {
   },
 
   computed: {
+    // Official festival page for this film; empty unless it's a real http(s) URL.
+    sourceUrl () {
+      const url = typeof this.item?.source_url === 'string' ? this.item.source_url.trim() : '';
+      return /^https?:\/\//i.test(url) ? url : '';
+    },
     poster () {
       if (this.poster_path) return this.poster_path;
       if (this.item.profile_path) {
@@ -253,5 +276,37 @@ export default {
     width: auto;
     filter: invert(1);
     object-fit: contain;
+}
+
+.card__quick-actions {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  z-index: 20;
+}
+
+.card__ext-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  background: rgba(0, 0, 0, 0.6);
+  border: 1px solid rgba(139, 233, 253, 0.3);
+  border-radius: 50%;
+  backdrop-filter: blur(4px);
+  cursor: pointer;
+  transition: all 0.3s ease;
+  pointer-events: auto;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.8);
+    border-color: #8BE9FD;
+    transform: scale(1.1);
+  }
 }
 </style>

--- a/components/SundanceCard.vue
+++ b/components/SundanceCard.vue
@@ -11,7 +11,22 @@
           <Loader :size="40" />
         </div>
 
-        <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" />
+        <div class="card__quick-actions">
+          <button
+            v-if="sourceUrl"
+            type="button"
+            class="card__ext-link"
+            :aria-label="`Open official festival page for ${name}`"
+            @click.prevent.stop="openSourceUrl"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+              <path d="M15 3h6v6" />
+              <path d="M10 14 21 3" />
+            </svg>
+          </button>
+          <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" grouped />
+        </div>
 
         <img
           v-if="poster"
@@ -120,6 +135,9 @@ export default {
     onImageLoaded() {
       this.isLoading = false;
     },
+    openSourceUrl() {
+      window.open(this.sourceUrl, '_blank', 'noopener,noreferrer');
+    },
     getRouteLink() {
         if (this.item.media_type === 'production') {
             return { name: 'production-slug', params: { slug: this.item.slug } };
@@ -132,6 +150,11 @@ export default {
   },
 
   computed: {
+    // Official festival page for this film; empty unless it's a real http(s) URL.
+    sourceUrl () {
+      const url = typeof this.item?.source_url === 'string' ? this.item.source_url.trim() : '';
+      return /^https?:\/\//i.test(url) ? url : '';
+    },
     poster () {
       if (this.poster_path) return this.poster_path;
       if (this.item.profile_path) {
@@ -253,5 +276,37 @@ export default {
     width: auto;
     filter: invert(1);
     object-fit: contain;
+}
+
+.card__quick-actions {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  z-index: 20;
+}
+
+.card__ext-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  background: rgba(0, 0, 0, 0.6);
+  border: 1px solid rgba(139, 233, 253, 0.3);
+  border-radius: 50%;
+  backdrop-filter: blur(4px);
+  cursor: pointer;
+  transition: all 0.3s ease;
+  pointer-events: auto;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.8);
+    border-color: #8BE9FD;
+    transform: scale(1.1);
+  }
 }
 </style>

--- a/components/TribecaCard.vue
+++ b/components/TribecaCard.vue
@@ -11,7 +11,22 @@
           <Loader :size="40" />
         </div>
 
-        <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" />
+        <div class="card__quick-actions">
+          <button
+            v-if="sourceUrl"
+            type="button"
+            class="card__ext-link"
+            :aria-label="`Open official festival page for ${name}`"
+            @click.prevent.stop="openSourceUrl"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+              <path d="M15 3h6v6" />
+              <path d="M10 14 21 3" />
+            </svg>
+          </button>
+          <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" grouped />
+        </div>
 
         <img
           v-if="poster"
@@ -139,6 +154,9 @@ export default {
       event.target.src = '/placeholders/image_not_found_yet.webp';
       this.onImageLoaded();
     },
+    openSourceUrl() {
+      window.open(this.sourceUrl, '_blank', 'noopener,noreferrer');
+    },
     getRouteLink() {
         if (this.item.media_type === 'production') {
             return { name: 'production-slug', params: { slug: this.item.slug } };
@@ -151,6 +169,11 @@ export default {
   },
 
   computed: {
+    // Official festival page for this film; empty unless it's a real http(s) URL.
+    sourceUrl () {
+      const url = typeof this.item?.source_url === 'string' ? this.item.source_url.trim() : '';
+      return /^https?:\/\//i.test(url) ? url : '';
+    },
     poster () {
       // posterMixin's `poster_path` already resolves the override hierarchy:
       //   1. title_overrides force-override (wins always)
@@ -276,5 +299,37 @@ export default {
     width: auto;
     filter: invert(1);
     object-fit: contain;
+}
+
+.card__quick-actions {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  z-index: 20;
+}
+
+.card__ext-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  background: rgba(0, 0, 0, 0.6);
+  border: 1px solid rgba(139, 233, 253, 0.3);
+  border-radius: 50%;
+  backdrop-filter: blur(4px);
+  cursor: pointer;
+  transition: all 0.3s ease;
+  pointer-events: auto;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.8);
+    border-color: #8BE9FD;
+    transform: scale(1.1);
+  }
 }
 </style>

--- a/components/festival/SxswCard.vue
+++ b/components/festival/SxswCard.vue
@@ -11,7 +11,22 @@
           <Loader :size="40" />
         </div>
 
-        <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" />
+        <div class="card__quick-actions">
+          <button
+            v-if="sourceUrl"
+            type="button"
+            class="card__ext-link"
+            :aria-label="`Open official festival page for ${name}`"
+            @click.prevent.stop="openSourceUrl"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#8BE9FD" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+              <path d="M15 3h6v6" />
+              <path d="M10 14 21 3" />
+            </svg>
+          </button>
+          <QuickFav v-if="media !== 'production' && media !== 'person' && media !== 'streaming'" :item="item" grouped />
+        </div>
 
         <img
           v-if="poster"
@@ -120,6 +135,9 @@ export default {
     onImageLoaded() {
       this.isLoading = false;
     },
+    openSourceUrl() {
+      window.open(this.sourceUrl, '_blank', 'noopener,noreferrer');
+    },
     getRouteLink() {
         if (this.item.media_type === 'production') {
             return { name: 'production-slug', params: { slug: this.item.slug } };
@@ -132,6 +150,11 @@ export default {
   },
 
   computed: {
+    // Official festival page for this film; empty unless it's a real http(s) URL.
+    sourceUrl () {
+      const url = typeof this.item?.source_url === 'string' ? this.item.source_url.trim() : '';
+      return /^https?:\/\//i.test(url) ? url : '';
+    },
     poster () {
       if (this.poster_path) return this.poster_path;
       if (this.item.profile_path) {
@@ -253,5 +276,37 @@ export default {
     width: auto;
     filter: invert(1);
     object-fit: contain;
+}
+
+.card__quick-actions {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  z-index: 20;
+}
+
+.card__ext-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  background: rgba(0, 0, 0, 0.6);
+  border: 1px solid rgba(139, 233, 253, 0.3);
+  border-radius: 50%;
+  backdrop-filter: blur(4px);
+  cursor: pointer;
+  transition: all 0.3s ease;
+  pointer-events: auto;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.8);
+    border-color: #8BE9FD;
+    transform: scale(1.1);
+  }
 }
 </style>

--- a/components/global/QuickFav.vue
+++ b/components/global/QuickFav.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="quick-fav-container" @click.prevent.stop>
+  <div class="quick-fav-container" :class="{ 'quick-fav--grouped': grouped }" @click.prevent.stop>
     <div class="quick-fav-wrapper">
       <button
         v-if="hasAccessToken"
@@ -67,6 +67,13 @@ export default {
     item: {
       type: Object,
       required: true,
+    },
+    // Grouped mode: the parent supplies an absolutely-positioned action row
+    // (festival catalog cards); QuickFav drops its full-bleed overlay and
+    // renders as a plain, slightly smaller flex-row button.
+    grouped: {
+      type: Boolean,
+      default: false,
     },
   },
 
@@ -296,6 +303,24 @@ export default {
   &.is-favorite {
     background: #8BE9FD;
     border-color: #000000;
+  }
+}
+
+// Grouped mode: container and wrapper stop generating boxes so the button
+// participates directly in the parent's flex row (and leaves no phantom gap
+// when the button itself isn't rendered for logged-out users).
+.quick-fav--grouped {
+  display: contents;
+  pointer-events: auto;
+
+  .quick-fav-wrapper {
+    display: contents;
+  }
+
+  .quick-fav-btn {
+    position: static;
+    width: 30px;
+    height: 30px;
   }
 }
 

--- a/server/api/festival/bafici/films.get.ts
+++ b/server/api/festival/bafici/films.get.ts
@@ -93,6 +93,7 @@ export default defineEventHandler(async (event) => {
 
                 imdb_id: row.imdb_id,
                 tmdb_id: row.tmdb_id,
+                source_url: row.source_url || null,
 
                 _debug_match: shouldUseTmdb,
                 _debug_tmdb_title: tmdbData.title || tmdbData.original_title

--- a/server/api/festival/berlinale/films.get.ts
+++ b/server/api/festival/berlinale/films.get.ts
@@ -92,6 +92,7 @@ export default defineEventHandler(async (event) => {
 
                 imdb_id: row.imdb_id,
                 tmdb_id: row.tmdb_id,
+                source_url: row.source_url || null,
 
                 _debug_match: shouldUseTmdb,
                 _debug_tmdb_title: tmdbData.title || tmdbData.original_title

--- a/server/api/festival/bifff/films.get.ts
+++ b/server/api/festival/bifff/films.get.ts
@@ -44,7 +44,8 @@ export default defineEventHandler(async (event) => {
                 imdb_id: row.imdb_id,
                 tmdb_id: row.tmdb_id,
                 _debug_tmdb_data: row.tmdb_data,
-                ...tmdbData
+                ...tmdbData,
+                source_url: row.source_url || null
             }
         }).filter((film: any) => {
             return film.tmdb_id && film.title && film.title.trim() !== '';

--- a/server/api/festival/cannes/films.get.ts
+++ b/server/api/festival/cannes/films.get.ts
@@ -43,7 +43,8 @@ export default defineEventHandler(async (event) => {
                 section: row.section || row.category,
                 imdb_id: row.imdb_id,
                 tmdb_id: row.tmdb_id,
-                ...tmdbData
+                ...tmdbData,
+                source_url: row.source_url || null
             }
         }).filter((film: any) => {
             return film.tmdb_id && film.title && film.title.trim() !== '';

--- a/server/api/festival/cuff/films.get.ts
+++ b/server/api/festival/cuff/films.get.ts
@@ -44,6 +44,7 @@ export default defineEventHandler(async (event) => {
                 section: row.section || row.category,
                 imdb_id: row.imdb_id,
                 tmdb_id: row.tmdb_id,
+                source_url: row.source_url || null,
                 _debug_tmdb_data: row.tmdb_data
             }
         }).filter((film: any) => {

--- a/server/api/festival/fantasia/films.get.ts
+++ b/server/api/festival/fantasia/films.get.ts
@@ -44,6 +44,7 @@ export default defineEventHandler(async (event) => {
                 section: row.section || row.category,
                 imdb_id: row.imdb_id,
                 tmdb_id: row.tmdb_id,
+                source_url: row.source_url || null,
                 _debug_tmdb_data: row.tmdb_data
             }
         }).filter((film: any) => {

--- a/server/api/festival/frightfest/films.get.ts
+++ b/server/api/festival/frightfest/films.get.ts
@@ -44,6 +44,7 @@ export default defineEventHandler(async (event) => {
                 section: row.section || row.category,
                 imdb_id: row.imdb_id,
                 tmdb_id: row.tmdb_id,
+                source_url: row.source_url || null,
                 _debug_tmdb_data: row.tmdb_data
             }
         }).filter((film: any) => {

--- a/server/api/festival/kviff/films.get.ts
+++ b/server/api/festival/kviff/films.get.ts
@@ -44,6 +44,7 @@ export default defineEventHandler(async (event) => {
                 section: row.section || row.category,
                 imdb_id: row.imdb_id,
                 tmdb_id: row.tmdb_id,
+                source_url: row.source_url || null,
                 _debug_tmdb_data: row.tmdb_data
             }
         }).filter((film: any) => {

--- a/server/api/festival/romford/films.get.ts
+++ b/server/api/festival/romford/films.get.ts
@@ -44,7 +44,8 @@ export default defineEventHandler(async (event) => {
                 imdb_id: row.imdb_id,
                 tmdb_id: row.tmdb_id,
                 _debug_tmdb_data: row.tmdb_data,
-                ...tmdbData
+                ...tmdbData,
+                source_url: row.source_url || null
             }
         }).filter((film: any) => {
             return film.tmdb_id && film.title && film.title.trim() !== '';

--- a/server/api/festival/rotterdam/films.get.ts
+++ b/server/api/festival/rotterdam/films.get.ts
@@ -13,6 +13,7 @@ interface DatabaseRow {
     section: string | null;
     category: string | null;
     tmdb_data: string | null;
+    source_url: string | null;
 }
 
 export default defineEventHandler(async (event) => {
@@ -57,7 +58,8 @@ export default defineEventHandler(async (event) => {
                 director: typedRow.director,
                 section: typedRow.section || typedRow.category,
                 imdb_id: typedRow.imdb_id,
-                tmdb_id: typedRow.tmdb_id
+                tmdb_id: typedRow.tmdb_id,
+                source_url: typedRow.source_url || null
             }
         });
 

--- a/server/api/festival/slamdance/films.get.ts
+++ b/server/api/festival/slamdance/films.get.ts
@@ -44,7 +44,8 @@ export default defineEventHandler(async (event) => {
                 imdb_id: row.imdb_id,
                 tmdb_id: row.tmdb_id,
                 _debug_tmdb_data: row.tmdb_data,
-                ...tmdbData
+                ...tmdbData,
+                source_url: row.source_url || null
             }
         }).filter((film: any) => {
             return film.tmdb_id && film.title && film.title.trim() !== '';

--- a/server/api/festival/sundance/films.get.ts
+++ b/server/api/festival/sundance/films.get.ts
@@ -44,7 +44,8 @@ export default defineEventHandler(async (event) => {
                 imdb_id: row.imdb_id,
                 tmdb_id: row.tmdb_id,
                 _debug_tmdb_data: row.tmdb_data,
-                ...tmdbData
+                ...tmdbData,
+                source_url: row.source_url || null
             }
         }).filter((film: any) => {
             if (!film.release_date) return true;

--- a/server/api/festival/sxsw/films.get.ts
+++ b/server/api/festival/sxsw/films.get.ts
@@ -44,7 +44,8 @@ export default defineEventHandler(async (event) => {
                 imdb_id: row.imdb_id,
                 tmdb_id: row.tmdb_id,
                 _debug_tmdb_data: row.tmdb_data,
-                ...tmdbData
+                ...tmdbData,
+                source_url: row.source_url || null
             }
         }).filter((film: any) => {
             if (!film.release_date) return true;

--- a/server/api/festival/tribeca/films.get.ts
+++ b/server/api/festival/tribeca/films.get.ts
@@ -46,6 +46,7 @@ export default defineEventHandler(async (event) => {
                 category: row.category || row.section,
                 imdb_id: row.imdb_id,
                 tmdb_id: row.tmdb_id,
+                source_url: row.source_url || null,
             }
         }).filter((film: any) => {
             if (!film.release_date) return true;


### PR DESCRIPTION
## Fix
This pull request introduces a direct external link to the official festival page for films listed across various festival catalogs (e.g., Cannes, Sundance, Berlinale, SXSW, Tribeca, etc.). It also refactors the card layout to group quick actions (the new external link and the existing `QuickFav` button) into a unified, absolutely-positioned container at the top-right of each card.

## Root Cause
Previously, users browsing film festival catalogs on Cinemagoria had no direct way to navigate to the official festival page for a specific film from the card view, even though the underlying database contained the `source_url` metadata. Additionally, placing multiple independent absolutely-positioned elements on the top-right of the cards would lead to overlapping UI elements, requiring a unified action container and a more flexible layout for the `QuickFav` component.

## Changes

### Frontend Components
*   **Unified Quick Actions Container (`.card__quick-actions`)**: Added to all festival card components (`BaficiCard`, `BerlinaleCard`, `BifffCard`, `CannesCard`, `CuffCard`, `FantasiaCard`, `FrightfestCard`, `KviffCard`, `RomfordCard`, `RotterdamCard`, `SlamdanceCard`, `SundanceCard`, `TribecaCard`, and `SxswCard`).
*   **Official Festival Link Button (`.card__ext-link`)**: Added a button with an external link SVG icon that safely opens the film's `sourceUrl` in a new tab (`_blank` with `noopener,noreferrer`) when clicked, stopping event propagation to prevent triggering card navigation.
*   **Computed `sourceUrl`**: Added a computed property to validate and sanitize the incoming `source_url` string, ensuring it matches a valid HTTP/HTTPS protocol before rendering the link button.
*   **`QuickFav.vue` Refactoring**:
    *   Introduced a new `grouped` boolean prop.
    *   When `grouped` is active, the component applies the `.quick-fav--grouped` class, which uses `display: contents` to allow the favorite button to participate directly in the parent's flexbox flow without leaving phantom layout gaps when the button is hidden (e.g., for logged-out users).

### Backend API Routes
Updated the following festival film list endpoints to select and return the `source_url` field from the database rows:
*   `server/api/festival/bafici/films.get.ts`
*   `server/api/festival/berlinale/films.get.ts`
*   `server/api/festival/bifff/films.get.ts`
*   `server/api/festival/cannes/films.get.ts`
*   `server/api/festival/cuff/films.get.ts`
*   `server/api/festival/fantasia/films.get.ts`
*   `server/api/festival/frightfest/films.get.ts`
*   `server/api/festival/kviff/films.get.ts`
*   `server/api/festival/romford/films.get.ts`
*   `server/api/festival/rotterdam/films.get.ts`
*   `server/api/festival/slamdance/films.get.ts`
*   `server/api/festival/sundance/films.get.ts`
*   `server/api/festival/sxsw/films.get.ts`
*   `server/api/festival/tribeca/films.get.ts`

## Verification

### Manual Testing
1.  **Link Verification**: Navigated to various festival catalog pages (e.g., Cannes, Sundance) and verified that cards with a valid `source_url` display the external link icon.
2.  **Redirection Behavior**: Clicked the external link icon and confirmed it opens the correct festival page in a new tab with `noopener,noreferrer` security attributes. Verified that clicking the icon does not trigger the card's main route navigation (propagation stopped successfully).
3.  **Layout & Responsiveness**: Verified that the quick actions container correctly aligns both the external link button and the `QuickFav` button side-by-side.
4.  **Logged-Out State**: Verified that when logged out (where `QuickFav` does not render), the external link button remains correctly positioned in the top-right corner without any layout shifting or empty gaps.

## Related Issues
No specific issue linked.