### PR TITLE
Venice 2026 — Venice Classics Category (Batch 3)

### DIFF
--- a/pages/festival/venice-2026/index.vue
+++ b/pages/festival/venice-2026/index.vue
@@ -338,6 +338,7 @@ const CATEGORY_ORDER = [
     'VENEZIA SPOTLIGHT',
     'FILM ON FILMS',
     'SHORT FILMS',
+    'VENICE CLASSICS',
 ];
 
 const CATEGORY_LABELS_EN = {
@@ -350,6 +351,7 @@ const CATEGORY_LABELS_EN = {
     'VENEZIA SPOTLIGHT': 'Venezia Spotlight',
     'FILM ON FILMS': 'Film on Films',
     'SHORT FILMS': 'Short Films',
+    'VENICE CLASSICS': 'Venice Classics',
     OTHER: 'Other'
 };
 


### PR DESCRIPTION
## Summary
- 19 films inserted into `festival_films` (`category = 'VENICE CLASSICS'`, `festival_name = 'Venice Film Festival'`, `festival_year = 2026`) — La Biennale's restoration/retrospective strand (English August, Illusion Travels by Streetcar, Minnie and Moskowitz, To Be or Not to Be, Cul-de-sac, Journey to Italy, Ashes and Diamonds, and 12 more)
- `pages/festival/venice-2026/index.vue` — added `VENICE CLASSICS` to the Official Selection `CATEGORY_ORDER` + display label; no other files touched, per scope

Part of #253. Closes #412.

## Test plan
- [x] SFC syntax + template compile validated (`@vue/compiler-sfc`)
- [x] Manual check (pending local review): `/festival/venice-2026` Catalog/Selection tab shows a new "Venice Classics" section with 19 films

**Not merging** — held open for local dev-server review, same as Batch 2.
