### PR TITLE
feat(tiff): add Centrepiece, Wavelengths, TIFF Docs, TIFF Classics categories

### DIFF
--- a/pages/festival/tiff-2026/index.vue
+++ b/pages/festival/tiff-2026/index.vue
@@ -368,16 +368,24 @@ const openDays = ref(new Set());
 const CATEGORY_ORDER = [
     'GALA PRESENTATIONS',
     'SPECIAL PRESENTATIONS',
+    'CENTREPIECE',
     'PLATFORM',
     'DISCOVERY',
+    'WAVELENGTHS',
+    'TIFF DOCS',
+    'TIFF CLASSICS',
     'PRIMETIME',
 ];
 
 const CATEGORY_LABELS = {
     'GALA PRESENTATIONS': 'Gala Presentations',
     'SPECIAL PRESENTATIONS': 'Special Presentations',
+    CENTREPIECE: 'Centrepiece',
     PLATFORM: 'Platform',
     DISCOVERY: 'Discovery',
+    WAVELENGTHS: 'Wavelengths',
+    'TIFF DOCS': 'TIFF Docs',
+    'TIFF CLASSICS': 'TIFF Classics',
     PRIMETIME: 'Primetime',
     OTHER: 'Other',
 };


### PR DESCRIPTION
## Summary
- Adds `CENTREPIECE`, `WAVELENGTHS`, `TIFF DOCS` and `TIFF CLASSICS` to the TIFF 2026 catalog's `CATEGORY_ORDER`/`CATEGORY_LABELS` so Batch 3's 73 newly-inserted titles render on the existing selection tabs.
- No other page changes — same pattern as the Venice Classics category addition (#412).

Part of #254. Closes #428.

## Test plan
- [x] Parsed with `@vue/compiler-sfc` (done, no errors)
- [x] Manual review: `/festival/tiff-2026` shows the four new tabs with correct counts