### PR TITLE
feat(tiff): update venue list with the published schedule's real venues

### DIFF
--- a/pages/festival/tiff-2026/index.vue
+++ b/pages/festival/tiff-2026/index.vue
@@ -285,11 +285,13 @@
                       <h3>Venues</h3>
                     </div>
                     <div class="venue-list">
-                      <div class="venue-item"><strong>TIFF Bell Lightbox</strong><span>Main festival hub — King Street West, Toronto</span></div>
+                      <div class="venue-item"><strong>TIFF Lightbox</strong><span>Main festival hub — 4 screens, King Street West</span></div>
+                      <div class="venue-item"><strong>Scotiabank Theatre Toronto</strong><span>Largest venue — 14 screens</span></div>
                       <div class="venue-item"><strong>Roy Thomson Hall</strong><span>Galas &amp; the Opening Night premiere</span></div>
-                      <div class="venue-item"><strong>Metro Toronto Convention Centre — John Bassett Theatre</strong><span>New for 2026: home of TIFF: The Market</span></div>
+                      <div class="venue-item"><strong>Royal Alexandra Theatre</strong><span>Gala &amp; Special Presentations premieres</span></div>
+                      <div class="venue-item"><strong>VISA Screening Room at the Princess of Wales Theatre</strong><span>Premiere screenings, King Street West</span></div>
                     </div>
-                    <p class="carousel-desc">Screenings run across several downtown Toronto venues; check each film's listing for its specific theatre.</p>
+                    <p class="carousel-desc">All five venues sit within walking distance in downtown Toronto. Each screening's exact room is listed in the Schedule tab.</p>
                   </template>
                 </div>
               </transition>


### PR DESCRIPTION
## Summary
- TIFF published its full programme and screening schedule on 11 August 2026. The resulting data landed in the database: 24 further titles (215 total) and 590 public screenings across 21 rooms in 5 venues.
- The Schedule tab needed no structural change — it was built against the shared screening pattern in #416 and renders the new data as-is, with the "Official schedule pending" placeholder yielding to the real listing automatically.
- The one required change is content: the Info tab's **Venues** slide still listed the pre-announcement guess (TIFF Bell Lightbox, Roy Thomson Hall, Metro Toronto Convention Centre). It now lists the five venues the published schedule actually uses.

Closes #476.

## Test plan
- [x] Parsed with `@vue/compiler-sfc`, no errors
- [x] `/festival/tiff-2026` → Schedule tab renders 590 screenings grouped by day, Sep 10–21, with venue and room per screening
- [x] Info tab → Venues slide lists the five real venues