### PR TITLE
feat(hero): surface related editorial articles from a minimalist capsule

### DIFF
--- a/components/Hero.vue
+++ b/components/Hero.vue
@@ -149,6 +149,55 @@
                 <span v-if="yearStart">{{ yearStart }}</span>
                 <span v-if="heroItem.runtime">{{ formatRuntime(heroItem.runtime) }}</span>
                 <span v-if="cert">Cert. {{ cert }}</span>
+                <div v-if="relatedArticles.length > 0" :class="$style.newsCapsule" v-click-outside="closeArticlesPanel">
+                  <button
+                    type="button"
+                    :class="[$style.newsCapsuleTrigger, { [$style.newsCapsuleTriggerOpen]: showArticlesPanel }]"
+                    :aria-expanded="showArticlesPanel ? 'true' : 'false'"
+                    :aria-label="articlesCapsuleLabel"
+                    @click.stop="toggleArticlesPanel">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a2 2 0 0 1-2 2Zm0 0a2 2 0 0 1-2-2v-9c0-1.1.9-2 2-2h2"/><path d="M18 14h-8"/><path d="M15 18h-5"/><path d="M10 6h8v4h-8Z"/></svg>
+                    <span>{{ articlesCapsuleLabel }}</span>
+                    <svg :class="[$style.newsCapsuleChevron, { [$style.newsCapsuleChevronOpen]: showArticlesPanel }]" xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+                  </button>
+
+                  <transition name="hero-news-panel">
+                    <div v-if="showArticlesPanel" :class="$style.newsPanel" @wheel.stop>
+                      <a
+                        v-for="article in relatedArticles"
+                        :key="article.slug"
+                        :href="`/news/${article.slug}`"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        :class="$style.newsPanelItem">
+                        <span :class="$style.newsPanelAside">
+                          <span :class="$style.newsPanelThumb">
+                            <img
+                              v-if="article.image_url"
+                              :src="article.image_url"
+                              :alt="articleTitle(article)"
+                              loading="lazy"
+                              decoding="async">
+                          </span>
+                          <span v-if="article.published_at" :class="$style.newsPanelDate">{{ formatArticleDate(article.published_at) }}</span>
+                        </span>
+                        <span :class="$style.newsPanelBody">
+                          <span :class="$style.newsPanelTitle">{{ articleTitle(article) }}</span>
+                          <span v-if="articleHook(article)" :class="$style.newsPanelHook">{{ articleHook(article) }}</span>
+                          <span :class="$style.newsPanelFoot">
+                            <span v-if="article.requires_auth" :class="$style.newsPanelLock">
+                              <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 11h14a1 1 0 0 1 1 1v8a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-8a1 1 0 0 1 1-1Z"/><path d="M8 11V7a4 4 0 0 1 8 0v4"/></svg>
+                              Members only
+                            </span>
+                            <span :class="$style.newsPanelRead">
+                              Read
+                            </span>
+                          </span>
+                        </span>
+                      </a>
+                    </div>
+                  </transition>
+                </div>
               </div>
             </div>
 
@@ -682,6 +731,8 @@ export default {
 
       showNoirModal: false,
       isNoirTitle: false,
+      relatedArticles: [],
+      showArticlesPanel: false,
       currentIndex: 0,
       autoAdvanceEnabled: true,
       autoAdvanceTimer: null,
@@ -805,6 +856,10 @@ export default {
        const seasonLabels = seasons.map(s => `S${s.season_number}: ${s.tracked}`).join(', ');
        return `${this.trackedEpisodesCount} episodes tracked (${seasonLabels})`;
     },
+    articlesCapsuleLabel() {
+      const count = this.relatedArticles.length;
+      return count === 1 ? '1 Related article' : `${count} Related articles`;
+    },
     progressElapsed() {
       const rt = this.heroItem.runtime;
       if (!rt) return '0m';
@@ -820,6 +875,7 @@ export default {
   created() {
     // Non-reactive: session cache of per-item user state (see loadUserItemState).
     this._userStateCache = new Map();
+    this._relatedArticlesCache = new Map();
   },
 
   async mounted() {
@@ -881,6 +937,95 @@ export default {
       const key = `${tmdbId}-${mediaType}`;
       const [heroMap, noirMap] = await Promise.all([getHeroEnrichment(), getNoirEnrichment()]);
       this.isNoirTitle = heroMap.has(key) || heroMap.has(tmdbId) || noirMap.has(key) || noirMap.has(tmdbId);
+    },
+    entityKeyFor(item) {
+      if (!item || !item.id) return '';
+      const rawType = item.type || (item.title ? 'movie' : 'tv');
+      return `${rawType === 'movie' ? 'movie' : 'tv'}:${item.id}`;
+    },
+    async loadRelatedArticles() {
+      this.closeArticlesPanel();
+
+      const key = this.entityKeyFor(this.heroItem);
+      if (!key) {
+        this.relatedArticles = [];
+        return;
+      }
+
+      if (this._relatedArticlesCache.has(key)) {
+        this.relatedArticles = this._relatedArticlesCache.get(key);
+        return;
+      }
+
+      this.relatedArticles = [];
+
+      const pool = (this.isHomepage && this.items && this.items.length > 0)
+        ? this.items
+        : [this.heroItem];
+
+      const pending = Array.from(new Set(
+        pool.map(item => this.entityKeyFor(item)).filter(Boolean)
+      )).filter(entityKey => !this._relatedArticlesCache.has(entityKey));
+
+      if (pending.length === 0) return;
+
+      try {
+        const response = await $fetch('/api/articles/by-entity', {
+          params: { entities: pending.join(',') },
+        });
+        const results = (response && response.results) || {};
+        for (const entityKey of pending) {
+          this._relatedArticlesCache.set(entityKey, results[entityKey] || []);
+        }
+      } catch (e) {
+        for (const entityKey of pending) {
+          this._relatedArticlesCache.set(entityKey, []);
+        }
+      }
+
+      if (this.entityKeyFor(this.heroItem) === key) {
+        this.relatedArticles = this._relatedArticlesCache.get(key) || [];
+      }
+    },
+    toggleArticlesPanel() {
+      if (this.showArticlesPanel) {
+        this.closeArticlesPanel();
+        return;
+      }
+      this.showArticlesPanel = true;
+      if (this.isHomepage && !this.autoAdvancePaused) {
+        this._articlesPanelPausedAutoAdvance = true;
+        this.toggleAutoAdvance();
+      }
+    },
+    closeArticlesPanel() {
+      if (!this.showArticlesPanel) return;
+      this.showArticlesPanel = false;
+      if (this._articlesPanelPausedAutoAdvance) {
+        this._articlesPanelPausedAutoAdvance = false;
+        if (this.autoAdvancePaused) this.toggleAutoAdvance();
+      }
+    },
+    articleTitle(article) {
+      return article.title_en || article.title_es || '';
+    },
+    articleHook(article) {
+      const raw = article.description_en || article.description_es || '';
+      const clean = String(raw).replace(/\s+/g, ' ').trim();
+      if (clean.length <= 110) return clean;
+      return `${clean.slice(0, 107).trimEnd()}…`;
+    },
+    formatArticleDate(dateStr) {
+      try {
+        return new Date(dateStr).toLocaleDateString('en-US', {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+          timeZone: 'UTC',
+        });
+      } catch {
+        return '';
+      }
     },
     handleTouchStart(e) {
       if (!this.isHomepage || this.items.length <= 1) return;
@@ -1024,6 +1169,7 @@ export default {
         }
 
         this.checkFestivalStatus();
+        this.loadRelatedArticles();
 
         if (!this.backdrop) {
           this.isLoading = false;
@@ -2409,7 +2555,7 @@ export default {
   margin-bottom: 1.3rem;
 
   @media (min-width: $breakpoint-small) {
-    margin: 0 1.2rem 0 0;
+    margin: 0 1.2rem 0.9rem 0;
   }
 }
 
@@ -2484,10 +2630,15 @@ export default {
 .info {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   font-family: var(--font-display);
 
   span {
     margin-right: 0.9rem;
+  }
+
+  @media (max-width: #{$breakpoint-small - 1px}) {
+    position: relative;
   }
 }
 
@@ -2704,6 +2855,239 @@ export default {
 
   @media (min-width: 1650px) {
     font-size: 0.85vw;
+  }
+}
+
+.newsCapsule {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  vertical-align: middle;
+  z-index: 30;
+
+  @media (max-width: #{$breakpoint-small - 1px}) {
+    position: static;
+  }
+}
+
+.newsCapsuleTrigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 7px 14px;
+  line-height: 1;
+  background: rgba(3, 4, 6, 0.55);
+  border: 1px solid rgba(139, 233, 253, 0.28);
+  border-radius: 999px;
+  color: #8BE9FD;
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  cursor: pointer;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: inset 0 0 12px rgba(139, 233, 253, 0.05);
+  transition: background 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
+
+  svg {
+    flex-shrink: 0;
+  }
+
+  &:hover {
+    background: rgba(139, 233, 253, 0.12);
+    border-color: rgba(139, 233, 253, 0.6);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 14px rgba(139, 233, 253, 0.15),
+                inset 0 0 12px rgba(139, 233, 253, 0.08);
+  }
+
+  @media (max-width: #{$breakpoint-small - 1px}) {
+    font-size: 1.05rem;
+    padding: 5px 11px;
+  }
+
+  @media (min-width: 1650px) {
+    font-size: 0.72vw;
+  }
+}
+
+.newsCapsuleTriggerOpen {
+  background: rgba(139, 233, 253, 0.14);
+  border-color: rgba(139, 233, 253, 0.65);
+  box-shadow: 0 4px 16px rgba(139, 233, 253, 0.18),
+              inset 0 0 12px rgba(139, 233, 253, 0.1);
+}
+
+.newsCapsuleChevron {
+  opacity: 0.75;
+  transition: transform 0.25s ease;
+}
+
+.newsCapsuleChevronOpen {
+  transform: rotate(180deg);
+}
+
+.newsPanel {
+  position: absolute;
+  top: calc(100% + 1rem);
+  left: 0;
+  z-index: 60;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  width: 38rem;
+  max-width: calc(100vw - 3rem);
+  max-height: 36rem;
+  overflow-y: auto;
+  padding: 0.6rem;
+  transform-origin: top left;
+  background: rgba(4, 6, 10, 0.86);
+  border: 1px solid rgba(139, 233, 253, 0.3);
+  border-radius: 1.4rem;
+  backdrop-filter: blur(18px) saturate(140%);
+  -webkit-backdrop-filter: blur(18px) saturate(140%);
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.55),
+              inset 0 0 20px rgba(139, 233, 253, 0.05);
+
+  @media (max-width: #{$breakpoint-small - 1px}) {
+    right: 0;
+    width: auto;
+    max-width: none;
+    transform-origin: top center;
+  }
+
+  @media (min-width: 1650px) {
+    width: 26vw;
+  }
+}
+
+.newsPanelItem {
+  display: flex;
+  align-items: flex-start;
+  gap: 1.1rem;
+  padding: 0.8rem;
+  border-radius: 1rem;
+  text-decoration: none;
+  color: #fff;
+  transition: background 0.2s ease;
+
+  &:hover {
+    background: rgba(139, 233, 253, 0.1);
+  }
+
+}
+
+.newsPanelAside {
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  width: 7.2rem;
+}
+
+.newsPanelDate {
+  font-size: 0.95rem;
+  line-height: 1.25;
+  letter-spacing: 0.04em;
+  text-align: center;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.38);
+
+  @media (min-width: 1650px) {
+    font-size: 0.62vw;
+  }
+}
+
+.newsPanelThumb {
+  width: 100%;
+  height: 4.8rem;
+  overflow: hidden;
+  border-radius: 0.7rem;
+  background: rgba(255, 255, 255, 0.05);
+
+  img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
+.newsPanelBody {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
+.newsPanelTitle {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  font-weight: 700;
+  line-height: 1.3;
+  color: #fff;
+
+  @media (min-width: 1650px) {
+    font-size: 0.82vw;
+  }
+}
+
+.newsPanelHook {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  font-size: 1.1rem;
+  line-height: 1.35;
+  color: rgba(255, 255, 255, 0.6);
+
+  @media (min-width: 1650px) {
+    font-size: 0.74vw;
+  }
+}
+
+.newsPanelFoot {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 0.1rem;
+  font-size: 1rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.38);
+
+  @media (min-width: 1650px) {
+    font-size: 0.66vw;
+  }
+}
+
+.newsPanelRead {
+  flex-shrink: 0;
+  margin-left: auto;
+  white-space: nowrap;
+  color: #8BE9FD;
+  font-weight: 700;
+}
+
+.newsPanelLock {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  white-space: nowrap;
+  color: rgba(139, 233, 253, 0.72);
+  font-weight: 700;
+
+  svg {
+    flex-shrink: 0;
   }
 }
 </style>
@@ -3465,6 +3849,19 @@ export default {
 
 .fade-enter-from, .fade-leave-to {
   opacity: 0;
+}
+
+.hero-news-panel-enter-active {
+  transition: opacity 0.22s ease, transform 0.28s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.hero-news-panel-leave-active {
+  transition: opacity 0.16s ease, transform 0.16s ease;
+}
+
+.hero-news-panel-enter-from, .hero-news-panel-leave-to {
+  opacity: 0;
+  transform: translateY(-6px) scale(0.97);
 }
 
 .no-transition * {

--- a/server/api/articles/by-entity.get.ts
+++ b/server/api/articles/by-entity.get.ts
@@ -1,0 +1,77 @@
+import { dbExecute } from '~~/server/utils/db'
+
+const MAX_ENTITIES = 24
+const MAX_PER_ENTITY = 4
+const QUERY_TIMEOUT_MS = 8000
+const ALLOWED_TYPES = new Set(['movie', 'tv'])
+
+export default defineEventHandler(async (event) => {
+    const query = getQuery(event)
+    const raw = String(query.entities || '').trim()
+
+    if (!raw) {
+        return { status: 'ok', results: {} }
+    }
+
+    const keys = Array.from(new Set(
+        raw.split(',')
+            .map(pair => pair.trim())
+            .filter(Boolean)
+            .map(pair => {
+                const [type, id] = pair.split(':')
+                const numericId = Number(id)
+                if (!ALLOWED_TYPES.has(type) || !Number.isInteger(numericId) || numericId <= 0) return ''
+                return `${type}:${numericId}`
+            })
+            .filter(Boolean)
+    )).slice(0, MAX_ENTITIES)
+
+    if (keys.length === 0) {
+        return { status: 'ok', results: {} }
+    }
+
+    try {
+        const placeholders = keys.map(() => '?').join(',')
+
+        const entityKey = `json_extract(related_tmdb_ids, '$[0].type') || ':' || json_extract(related_tmdb_ids, '$[0].id')`
+
+        const result = await dbExecute({
+            sql: `SELECT id, slug, title_en, title_es, description_en, description_es,
+                         image_url, published_at, requires_auth,
+                         ${entityKey} AS entity_key
+                  FROM cinemagoria_articles
+                  WHERE is_visible = 1
+                    AND (datetime(published_at) IS NULL OR datetime(published_at) <= datetime('now'))
+                    AND ${entityKey} IN (${placeholders})
+                  ORDER BY datetime(published_at) DESC`,
+            args: keys,
+        }, QUERY_TIMEOUT_MS)
+
+        const results: Record<string, any[]> = {}
+
+        for (const row of result.rows) {
+            const key = row.entity_key as string
+            if (!key) continue
+            const bucket = results[key] || (results[key] = [])
+            if (bucket.length >= MAX_PER_ENTITY) continue
+            bucket.push({
+                id: row.id,
+                slug: row.slug,
+                title_en: row.title_en,
+                title_es: row.title_es,
+                description_en: row.description_en,
+                description_es: row.description_es,
+                image_url: row.image_url,
+                published_at: row.published_at,
+                requires_auth: Number(row.requires_auth ?? 0) === 1 ? 1 : 0,
+            })
+        }
+
+        setResponseHeader(event, 'Cache-Control', 'public, max-age=300, s-maxage=600')
+
+        return { status: 'ok', results }
+    } catch (error: any) {
+        console.error('[Articles by-entity API] Error:', error)
+        throw createError({ statusCode: 500, statusMessage: 'Failed to fetch related articles' })
+    }
+})


### PR DESCRIPTION
## Summary

- Adds a related-articles capsule to `Hero.vue`, active in both of its contexts: the homepage carousel and the title detail view. It renders only when the title actually has coverage.
- Adds `GET /api/articles/by-entity`, which takes a list of `type:id` pairs and answers them in one query, so the whole carousel costs a single request instead of one per slide.
- An article is attached to a title through the **first** entry of its `related_tmdb_ids` — the main entity the piece is about. Everything after it is supporting cast and crew and is deliberately ignored, otherwise every actor's filmography would drag unrelated coverage into the hero.

Closes #478.

## Data shape

Of the 333 visible articles, 294 point at a movie, 28 at a TV show and 9 at a person (those never surface here). Looked at from the title's side: 301 entities have one article, 12 have two, two have three. The issue's ceiling of four is never reached today, but the endpoint caps at four per entity and 24 entities per request regardless.

21 of the 22 current carousel slides resolve to at least one article, so the capsule is visible on nearly every homepage rotation.

## Interaction

The capsule sits inline at the end of the metadata row, after the certification, where it costs no vertical space. Expanding it opens an absolutely positioned panel that **overlays** the action buttons rather than pushing them down, which is what keeps the carousel controls where they were.

While the panel is open the carousel's auto-advance is paused, so a slide change can't pull the list out from under the reader; it resumes on close, and only if the capsule was what paused it. Clicking outside collapses it. Each entry opens `/news/{slug}` in a new tab, so the hero the reader was looking at is never lost.

## Community-gated articles

Just over half the catalog (169 of 333) is `requires_auth = 1`. The capsule shows those to everyone, signed in or not — hiding them would leave a title looking like it has no coverage.

The gate itself is left entirely to the article page, which already SSRs the members-only card for anonymous readers and re-renders the full body on hydration for signed-in ones. Raising the auth modal from the hero would be wrong twice over: it would interrupt the hero, and the new tab would open anyway. What the panel does add is a small lock label on gated entries, so the reader knows before clicking that the full text asks for an account.

## Notes

- The capsule is fetched client-side, so it appears just after hydration rather than in the server-rendered markup. Festival badges avoid that by riding along in `/api/hero`, but matching them would have meant touching the hero endpoint and both detail pages; happy to follow up if the pop-in reads badly in practice.
- `by-entity` runs with a short query timeout, well under the default. It is a secondary badge and must never be the reason a hero is slow.
- The rating block carried a margin shorthand that zeroed its bottom margin above the small breakpoint, leaving it flush against the metadata row. The horizontal margin in that shorthand was inert — the two rows stack, they don't sit side by side — so restoring the gap there is the fix. This affects every title with a rating, not only ones with articles.

## Test plan

- [x] Parsed and compiled with `@vue/compiler-sfc` — template, script and SCSS module — in every localized frontend
- [x] Endpoint SQL verified against the live data: grouping by main entity, newest first, unknown ids excluded, `is_visible` and the publication-date guard both respected
- [x] Manual review: single and multi-article titles, gated and public entries, carousel and detail view
- [x] Manual review: panel stays inside the viewport on mobile, where it anchors to the metadata row rather than to the capsule