### PR TITLE
Venice 2026 — Lineup Audit, Screenings Import & Parallel Strands (Batch 4)

### DIFF
--- a/pages/festival/venice-2026/index.vue
+++ b/pages/festival/venice-2026/index.vue
@@ -430,55 +430,36 @@ const onSectionHeaderClick = (key) => {
     toggleSection(key);
 };
 
+const PARALLEL_SECTIONS = [
+    { key: 'giornate', label: 'Giornate degli Autori – Concorso', categoryProp: 'GIORNATE DEGLI AUTORI - CONCORSO', emptyText: 'No Giornate degli Autori selections announced yet.' },
+    { key: 'eventi-speciali', label: 'Eventi Speciali', categoryProp: 'EVENTI SPECIALI', emptyText: 'No Eventi Speciali selections announced yet.' },
+    { key: 'notti-veneziane', label: 'Notti Veneziane', categoryProp: 'NOTTI VENEZIANE', emptyText: 'No Notti Veneziane selections announced yet.' },
+    { key: 'miu-miu-womens-tales', label: "Miu Miu Women's Tales", categoryProp: 'MIU MIU WOMENS TALES', emptyText: "No Miu Miu Women's Tales selections announced yet." },
+    { key: 'critics-week', label: "Critics' Week", categoryProp: 'CRITICS WEEK', emptyText: "No Critics' Week selections announced yet." },
+    { key: 'critics-week-eventi-speciali', label: "Critics' Week – Eventi Speciali", categoryProp: 'CRITICS WEEK - EVENTI SPECIALI', emptyText: "No Critics' Week Eventi Speciali selections announced yet." },
+    { key: 'sic-at-sic', label: 'SIC@SIC', categoryProp: 'SIC@SIC', emptyText: 'No SIC@SIC selections announced yet.' },
+];
+
+const PARALLEL_CATEGORIES = new Set(PARALLEL_SECTIONS.map((s) => s.categoryProp));
+
+const categoryKeyOf = (f) => String(f.section || f.category || '').toUpperCase().trim();
+
 const filmsByCategory = computed(() => {
     const map = Object.fromEntries(CATEGORY_ORDER.map((c) => [c, []]));
     map.OTHER = [];
     for (const f of films.value?.results || []) {
-        const key = String(f.section || f.category || '').toUpperCase().trim();
-        if (key === 'GIORNATE DEGLI AUTORI - CONCORSO') continue;
-        if (key === 'EVENTI SPECIALI') continue;
-        if (key === 'NOTTI VENEZIANE') continue;
-        if (key === 'CRITICS WEEK') continue;
+        const key = categoryKeyOf(f);
+        if (PARALLEL_CATEGORIES.has(key)) continue;
         if (key && map[key]) map[key].push(f);
         else map.OTHER.push(f);
     }
     return map;
 });
 
-const giornateFilms = computed(() => {
-    return (films.value?.results || []).filter((f) => {
-        const key = String(f.section || f.category || '').toUpperCase().trim();
-        return key === 'GIORNATE DEGLI AUTORI - CONCORSO';
-    });
-});
-
-const eventiSpecialiFilms = computed(() => {
-    return (films.value?.results || []).filter((f) => {
-        const key = String(f.section || f.category || '').toUpperCase().trim();
-        return key === 'EVENTI SPECIALI';
-    });
-});
-
-const nottiVenezianeFilms = computed(() => {
-    return (films.value?.results || []).filter((f) => {
-        const key = String(f.section || f.category || '').toUpperCase().trim();
-        return key === 'NOTTI VENEZIANE';
-    });
-});
-
-const criticsWeekFilms = computed(() => {
-    return (films.value?.results || []).filter((f) => {
-        const key = String(f.section || f.category || '').toUpperCase().trim();
-        return key === 'CRITICS WEEK';
-    });
-});
-
-const parallelSections = computed(() => [
-    { key: 'giornate', label: 'Giornate degli Autori – Concorso', films: giornateFilms.value, categoryProp: 'GIORNATE DEGLI AUTORI - CONCORSO', emptyText: 'No Giornate degli Autori selections announced yet.' },
-    { key: 'eventi-speciali', label: 'Eventi Speciali', films: eventiSpecialiFilms.value, categoryProp: 'EVENTI SPECIALI', emptyText: 'No Eventi Speciali selections announced yet.' },
-    { key: 'notti-veneziane', label: 'Notti Veneziane', films: nottiVenezianeFilms.value, categoryProp: 'NOTTI VENEZIANE', emptyText: 'No Notti Veneziane selections announced yet.' },
-    { key: 'critics-week', label: "Critics' Week", films: criticsWeekFilms.value, categoryProp: 'CRITICS WEEK', emptyText: "No Critics' Week selections announced yet." },
-]);
+const parallelSections = computed(() => PARALLEL_SECTIONS.map((section) => ({
+    ...section,
+    films: (films.value?.results || []).filter((f) => categoryKeyOf(f) === section.categoryProp),
+})));
 
 const orderedCategories = computed(() => {
     const out = CATEGORY_ORDER.filter((c) => (filmsByCategory.value[c] || []).length > 0);


### PR DESCRIPTION
## Summary
- **378 screenings** inserted into `festival_screenings` for Venice 2026, scraped from the `source_url` already stored per title (official programme table for the Biennale strands, schedule blocks on the two sidebar sites for the parallel ones). `start_time` as `2026-09-DDTHH:MM:00+02:00`, `time_zone = 'CEST'`, `is_in_person = 1`, matching the other European festivals.
- **20 titles** inserted into `festival_films` — selections the official programme added after the announced lineup, TMDB-enriched and director-verified. Venice is now **163 films across 17 categories**.
- `pages/festival/venice-2026/index.vue` — `MIU MIU WOMENS TALES`, `CRITICS WEEK - EVENTI SPECIALI` and `SIC@SIC` join the Parallel Sections group; the four near-identical per-strand computeds collapse into one `PARALLEL_SECTIONS` table.
- The Schedule tab needed no code change — `showSchedulePending` already derives from `schedule.length`, so the "official schedule pending" placeholder disappears now that the endpoint returns rows.

Also fixed while auditing: one Notti Veneziane row carried another film's `source_url` (so it was showing the wrong screening times), and one Fuori Concorso row had no `source_url` at all.

Part of #253. Closes #480.

## Test plan
- [x] SFC syntax + template compile validated in all 4 repos (`@vue/compiler-sfc`)
- [x] Parsed screenings spot-checked against the official pages across all three source sites — dates, times, venues, am/pm conversion and press-slot exclusion all match
- [x] Post-insert validation: 0 duplicates, 0 malformed timestamps, 0 rows without a venue, 0 orphans, screening counts for every other festival unchanged
- [x] Category mapping simulated against live data: all 17 categories resolve to either the Official Selection order or a parallel section, nothing falls through to `OTHER`
- [x] Manual check (pending local review): `/festival/venice-2026` Schedule tab lists 11 days of showtimes, and the Selection tab shows the three new parallel sections

One known gap, upstream: *On the Beat* (Venice Classics) has no screening table on its official page yet, so it is the only title without showtimes.

**Not merging** — held open for local dev-server review, same as Batches 2 and 3.
