### PR TITLE
fix(hero): give the episode tracking pill real context on the homepage

### DIFF
--- a/components/Hero.vue
+++ b/components/Hero.vue
@@ -756,6 +756,7 @@ export default {
       progressPercentage: 0,
       trackedEpisodesCount: 0,
       trackedSeasonData: [],  // [{season_number, tracked, total}]
+      lastTrackedSeason: null,
     };
   },
 
@@ -1239,6 +1240,7 @@ export default {
         this.progressPercentage = 0;
         this.trackedEpisodesCount = 0;
         this.trackedSeasonData = [];
+        this.lastTrackedSeason = null;
 
         Promise.all([
             this.checkMembership(),
@@ -1256,6 +1258,7 @@ export default {
                 progressPercentage: this.progressPercentage,
                 trackedEpisodesCount: this.trackedEpisodesCount,
                 trackedSeasonData: this.trackedSeasonData,
+                lastTrackedSeason: this.lastTrackedSeason,
             });
         }).catch(() => {});
     },
@@ -1460,11 +1463,13 @@ export default {
         return;
       }
       if (this.isHomepage) {
-        this.$router.push({ path: `/tv/${this.id}`, query: { tab: 'episodes' } });
+        const query = { tab: 'episodes' };
+        if (this.lastTrackedSeason) query.season = String(this.lastTrackedSeason);
+        this.$router.push({ path: `/tv/${this.id}`, query });
         return;
       }
       // TV shows: navigate to the Episodes tab
-      this.$bus.$emit('navigate-to-episodes');
+      this.$bus.$emit('navigate-to-episodes', this.lastTrackedSeason);
     },
 
     openModal() {
@@ -1740,6 +1745,7 @@ export default {
             const arr = Array.isArray(rows) ? rows : (rows.items || []);
             const eps = arr.filter(i => i.media_type === 'episode' && Number(i.season_number) > 0);
             this.trackedEpisodesCount = eps.length;
+            this.lastTrackedSeason = eps.length ? Number(eps[0].season_number) : null;
 
             // Build per-season breakdown
             const seasonMap = {};

--- a/components/Hero.vue
+++ b/components/Hero.vue
@@ -526,6 +526,7 @@ import { getHeroEnrichment, getNoirEnrichment } from '~/utils/api';
 import NoirModal from '~/components/NoirModal.vue';
 
 const AUTO_ADVANCE_DURATION_MS = 15000;
+const SEASON_LABEL_LIMIT = 3;
 
 // Festival membership per tmdb_id, shared across every Hero instance for the
 // session. Badges don't change mid-visit, so cycling the homepage carousel
@@ -846,15 +847,24 @@ export default {
           if (s.allComplete) {
              return `Season ${s.season_number} completed`;
           }
-          return `${s.tracked} of ${s.total || '?'} episodes tracked (S${s.season_number})`;
+          if (s.caughtUp) {
+             return `Caught up on Season ${s.season_number}`;
+          }
+          if (!s.total) {
+             return `${s.tracked} episode${s.tracked !== 1 ? 's' : ''} tracked (S${s.season_number})`;
+          }
+          return `${s.tracked} of ${s.total} episodes tracked (S${s.season_number})`;
        }
        // Multiple seasons
        const completedSeasons = seasons.filter(s => s.allComplete);
        if (completedSeasons.length === seasons.length) {
           return `${completedSeasons.length} seasons completed`;
        }
-       const seasonLabels = seasons.map(s => `S${s.season_number}: ${s.tracked}`).join(', ');
-       return `${this.trackedEpisodesCount} episodes tracked (${seasonLabels})`;
+       const shown = seasons.slice(0, SEASON_LABEL_LIMIT);
+       const remaining = seasons.length - shown.length;
+       const seasonLabels = shown.map(s => `S${s.season_number}: ${s.tracked}`).join(', ');
+       const suffix = remaining > 0 ? `${seasonLabels} +${remaining} more` : seasonLabels;
+       return `${this.trackedEpisodesCount} episodes tracked (${suffix})`;
     },
     articlesCapsuleLabel() {
       const count = this.relatedArticles.length;
@@ -1418,14 +1428,43 @@ export default {
         this.$bus.$emit('show-create-list-modal', this.heroItem);
     },
 
+    seasonEpisodeCounts(seasonNumber, trackedCount) {
+      const empty = { aired: null, declared: null };
+      const seasons = this.heroItem && this.heroItem.seasons;
+      if (!Array.isArray(seasons)) return empty;
+
+      const season = seasons.find(x => Number(x.season_number) === seasonNumber);
+      const declared = season ? Number(season.episode_count) : NaN;
+      if (!Number.isFinite(declared) || declared <= 0) return empty;
+
+      const last = this.heroItem && this.heroItem.last_episode_to_air;
+      const lastSeason = last ? Number(last.season_number) : NaN;
+
+      let aired = declared;
+      if (Number.isFinite(lastSeason)) {
+        if (seasonNumber > lastSeason) {
+          aired = 0;
+        } else if (seasonNumber === lastSeason) {
+          const lastEpisode = Number(last.episode_number);
+          aired = Number.isFinite(lastEpisode) ? Math.min(declared, lastEpisode) : declared;
+        }
+      }
+
+      return { aired: Math.max(aired, trackedCount), declared };
+    },
+
     handleTrackingPillClick() {
       if (this.type === 'movie') {
         // Movies: open the rate modal (which includes progress tracking)
         this.hasUserRating ? this.showRatingDetails() : this.openRatingModal();
-      } else {
-        // TV shows: navigate to the Episodes tab
-        this.$bus.$emit('navigate-to-episodes');
+        return;
       }
+      if (this.isHomepage) {
+        this.$router.push({ path: `/tv/${this.id}`, query: { tab: 'episodes' } });
+        return;
+      }
+      // TV shows: navigate to the Episodes tab
+      this.$bus.$emit('navigate-to-episodes');
     },
 
     openModal() {
@@ -1694,29 +1733,28 @@ export default {
           }
         } else {
           // For TV show, get total tracked episodes for this show
-          const resp = await fetch(`/api/progress/${encodeURIComponent(this.userEmail)}?_t=${Date.now()}`);
+          const resp = await fetch(`/api/progress/${encodeURIComponent(this.userEmail)}?tv_id=${this.id}&_t=${Date.now()}`);
           if (resp.ok) {
             const rows = await resp.json();
             // The API returns rows[] directly (array)
             const arr = Array.isArray(rows) ? rows : (rows.items || []);
-            const eps = arr.filter(i => i.media_type === 'episode' && String(i.tv_id) === String(this.id));
+            const eps = arr.filter(i => i.media_type === 'episode' && Number(i.season_number) > 0);
             this.trackedEpisodesCount = eps.length;
 
             // Build per-season breakdown
             const seasonMap = {};
             for (const ep of eps) {
-              const sn = ep.season_number || 0;
+              const sn = Number(ep.season_number);
               if (!seasonMap[sn]) seasonMap[sn] = { season_number: sn, tracked: 0, complete: 0 };
               seasonMap[sn].tracked++;
               if (Number(ep.progress_percentage) >= 100) seasonMap[sn].complete++;
             }
-            // Try to get total episodes per season from the heroItem
-            const totalSeasons = this.heroItem?.number_of_seasons || 0;
             const seasonDetails = Object.values(seasonMap).sort((a, b) => a.season_number - b.season_number);
             for (const s of seasonDetails) {
-               const seasonObj = (this.heroItem?.seasons || []).find(x => x.season_number === s.season_number);
-               s.total = seasonObj ? seasonObj.episode_count : null;
-               s.allComplete = s.complete === s.total && s.total > 0;
+               const counts = this.seasonEpisodeCounts(s.season_number, s.tracked);
+               s.total = counts.aired;
+               s.allComplete = counts.declared > 0 && s.complete >= counts.declared;
+               s.caughtUp = !s.allComplete && counts.aired > 0 && s.complete >= counts.aired;
             }
             this.trackedSeasonData = seasonDetails;
           }

--- a/components/MediaNav.vue
+++ b/components/MediaNav.vue
@@ -35,18 +35,27 @@ export default {
       this.active = index;
       this.$emit('clicked', item.replace(/\s+/g, '-').toLowerCase());
     },
+
+    syncActiveFromLabel () {
+      if (!this.activeLabel) return;
+      const index = this.menu.findIndex(item => item.replace(/\s+/g, '-').toLowerCase() === this.activeLabel);
+      if (index !== -1) {
+        this.active = index;
+      }
+    },
   },
 
   watch: {
     activeLabel: {
-      handler(newVal) {
-        if (!newVal) return;
-        const index = this.menu.findIndex(item => item.replace(/\s+/g, '-').toLowerCase() === newVal);
-        if (index !== -1) {
-          this.active = index;
-        }
+      handler() {
+        this.syncActiveFromLabel();
       },
       immediate: true,
+    },
+    menu: {
+      handler() {
+        this.syncActiveFromLabel();
+      },
     },
   },
 };

--- a/components/global/UserNav.vue
+++ b/components/global/UserNav.vue
@@ -359,7 +359,7 @@ export default {
           fetch(`${followsUrl}/company-follows/list?user_email=${encodeURIComponent(userEmail)}`),
           fetch(`${followsUrl}/user-follows/list?user_email=${encodeURIComponent(userEmail)}`),
           fetch(`${followsUrl}/profile-by-email?user_email=${encodeURIComponent(userEmail)}`),
-          fetch(`/api/progress/${encodeURIComponent(userEmail)}?_t=${Date.now()}`).catch(() => null)
+          fetch(`/api/progress/${encodeURIComponent(userEmail)}?count=1&_t=${Date.now()}`).catch(() => null)
         ]);
 
         if (ratingsRes.ok) {
@@ -411,16 +411,8 @@ export default {
 
         if (progressRes && progressRes.ok) {
           const progData = await progressRes.json();
-          if (Array.isArray(progData)) {
-            const uniqueMedia = new Set();
-            for (const item of progData) {
-              if (item.media_type === 'episode') {
-                uniqueMedia.add(`tv_${item.tv_id}`);
-              } else {
-                uniqueMedia.add(`movie_${item.media_id}`);
-              }
-            }
-            this.progressCount = uniqueMedia.size;
+          if (progData && typeof progData.count === 'number') {
+            this.progressCount = progData.count;
           }
         }
       } catch (e) {
@@ -432,19 +424,11 @@ export default {
       const userEmail = localStorage.getItem('email');
       if (!userEmail) return;
       try {
-        const resp = await fetch(`/api/progress/${encodeURIComponent(userEmail)}?_t=${Date.now()}`);
+        const resp = await fetch(`/api/progress/${encodeURIComponent(userEmail)}?count=1&_t=${Date.now()}`);
         if (resp && resp.ok) {
           const progData = await resp.json();
-          if (Array.isArray(progData)) {
-            const uniqueMedia = new Set();
-            for (const item of progData) {
-              if (item.media_type === 'episode') {
-                uniqueMedia.add(`tv_${item.tv_id}`);
-              } else {
-                uniqueMedia.add(`movie_${item.media_id}`);
-              }
-            }
-            this.progressCount = uniqueMedia.size;
+          if (progData && typeof progData.count === 'number') {
+            this.progressCount = progData.count;
           }
         }
       } catch (e) {

--- a/components/tv/Episodes.vue
+++ b/components/tv/Episodes.vue
@@ -92,11 +92,18 @@ export default {
       type: Number,
       default: 0,
     },
+    initialSeason: {
+      type: Number,
+      default: null,
+    },
   },
 
   data () {
+    const requested = Number(this.initialSeason);
+    const isSelectable = Number.isFinite(requested) && requested >= 1 && requested <= this.numberOfSeasons;
+
     return {
-      activeSeason: this.numberOfSeasons,
+      activeSeason: isSelectable ? requested : this.numberOfSeasons,
       activeEpisodes: null,
       userEmail: '',
       episodeProgressMap: {},
@@ -136,6 +143,16 @@ export default {
       seasons.sort((a, b) => a.season > b.season ? -1 : 1);
 
       return seasons;
+    },
+  },
+
+  watch: {
+    initialSeason (value) {
+      const requested = Number(value);
+      if (!Number.isFinite(requested) || requested < 1 || requested > this.numberOfSeasons) return;
+      if (requested === this.activeSeason) return;
+      this.activeSeason = requested;
+      this.getEpisodes();
     },
   },
 

--- a/components/tv/Episodes.vue
+++ b/components/tv/Episodes.vue
@@ -162,15 +162,13 @@ export default {
     async loadAllProgress() {
       if (!this.userEmail) return;
       try {
-        const resp = await fetch(`/api/progress/${encodeURIComponent(this.userEmail)}`);
+        const tvId = this.$route.params.id;
+        const resp = await fetch(`/api/progress/${encodeURIComponent(this.userEmail)}?tv_id=${encodeURIComponent(tvId)}`);
         if (resp.ok) {
           const rows = await resp.json();
-          const tvId = String(this.$route.params.id);
           const map = {};
           for (const row of rows) {
-            if (row.media_type === 'episode' && String(row.tv_id) === tvId) {
-              map[row.media_id] = row.progress_percentage || 0;
-            }
+            map[row.media_id] = row.progress_percentage || 0;
           }
           this.episodeProgressMap = map;
         }

--- a/pages/tv/[id].vue
+++ b/pages/tv/[id].vue
@@ -252,6 +252,10 @@ watch(item, async () => {
 
 onMounted(() => {
   $bus.$on('navigate-to-episodes', navigateToEpisodes);
+  if (route.query.tab === 'episodes' && showEpisodes.value) {
+    navigateToEpisodes();
+    router.replace({ path: route.path });
+  }
 });
 
 onUnmounted(() => {

--- a/pages/tv/[id].vue
+++ b/pages/tv/[id].vue
@@ -35,7 +35,7 @@
       </template>
 
       <template v-if="activeMenu === 'episodes' && showEpisodes">
-        <Episodes :number-of-seasons="item.number_of_seasons" :total-episodes="item.number_of_episodes" />
+        <Episodes :number-of-seasons="item.number_of_seasons" :total-episodes="item.number_of_episodes" :initial-season="episodesInitialSeason" />
       </template>
 
       <template v-if="activeMenu === 'videos' && showVideos">
@@ -93,7 +93,11 @@ const showRatedItems = () => {
   ratedItemsModalVisible.value = true;
 };
 
-const navigateToEpisodes = () => {
+const navigateToEpisodes = (season) => {
+  const requested = Number(season);
+  if (Number.isFinite(requested) && requested > 0) {
+    episodesInitialSeason.value = requested;
+  }
   activeMenu.value = 'episodes';
   nextTick(() => {
     // Scroll to the episodes section (the .spacing div that wraps Episodes component)
@@ -112,6 +116,7 @@ const navClicked = (label) => {
 
 const ratedItemsModalVisible = ref(false);
 const activeMenu = ref('overview');
+const episodesInitialSeason = ref(null);
 const menu = ref([]);
 const reviews = ref(null);
 const soundtrackItems = ref([]);
@@ -253,7 +258,7 @@ watch(item, async () => {
 onMounted(() => {
   $bus.$on('navigate-to-episodes', navigateToEpisodes);
   if (route.query.tab === 'episodes' && showEpisodes.value) {
-    navigateToEpisodes();
+    navigateToEpisodes(route.query.season);
     router.replace({ path: route.path });
   }
 });

--- a/server/api/hero.get.ts
+++ b/server/api/hero.get.ts
@@ -1,5 +1,6 @@
-import { dbExecute } from '~~/server/utils/db'
+import { dbExecute, useDb } from '~~/server/utils/db'
 import { getFestivalStatusByTmdbId } from '~~/server/utils/festivals'
+import { loadTvDetailsCached, type MinimalTv } from '~~/server/utils/tvDetails'
 
 export default defineEventHandler(async (event) => {
     try {
@@ -14,21 +15,46 @@ export default defineEventHandler(async (event) => {
         }
         const selectedRows = result.rows.sort(() => 0.5 - Math.random());
 
+        const config = useRuntimeConfig();
+        const apiKey = (config.public as any)?.apiKey || '';
+        const apiLang = (config.public as any)?.apiLang || 'en-US';
+
         // Embed festival membership per item (one indexed IN query for the
         // whole carousel). The Hero renders badges straight from this during
         // SSR — zero client-side festival requests and no badge pop-in.
         // Non-fatal: the hero must never fail because of badges.
         let festivalsByTmdbId: Record<string, any> = {};
-        try {
-            festivalsByTmdbId = await getFestivalStatusByTmdbId(
-                selectedRows.map((row: any) => row.tmdb_id)
-            );
-        } catch (e) {
-            console.error('Hero festival-status enrichment failed:', e);
+        let tvDetailsByTmdbId = new Map<number, MinimalTv>();
+
+        const [festivalsResult, tvDetailsResult] = await Promise.allSettled([
+            getFestivalStatusByTmdbId(selectedRows.map((row: any) => row.tmdb_id)),
+            loadTvDetailsCached(
+                useDb(),
+                selectedRows
+                    .filter((row: any) => row.media_type === 'tv')
+                    .map((row: any) => row.tmdb_id),
+                apiKey,
+                apiLang
+            ),
+        ]);
+
+        if (festivalsResult.status === 'fulfilled') {
+            festivalsByTmdbId = festivalsResult.value;
+        } else {
+            console.error('Hero festival-status enrichment failed:', festivalsResult.reason);
+        }
+
+        if (tvDetailsResult.status === 'fulfilled') {
+            tvDetailsByTmdbId = tvDetailsResult.value;
+        } else {
+            console.error('Hero TV episode-context enrichment failed:', tvDetailsResult.reason);
         }
 
         const items = await Promise.all(selectedRows.map(async (row) => {
             const cert = row.certification;
+            const tvDetails = row.media_type === 'tv'
+                ? tvDetailsByTmdbId.get(Number(row.tmdb_id))
+                : undefined;
 
             return {
                 id: row.tmdb_id,
@@ -38,6 +64,11 @@ export default defineEventHandler(async (event) => {
                 original_title: row.title,
 
                 festivals: festivalsByTmdbId[String(row.tmdb_id)] || {},
+
+                seasons: tvDetails ? tvDetails.seasons : undefined,
+                number_of_seasons: tvDetails ? tvDetails.number_of_seasons : undefined,
+                number_of_episodes: tvDetails ? tvDetails.total_episodes : undefined,
+                last_episode_to_air: tvDetails ? tvDetails.last_episode_to_air : undefined,
 
                 poster_path: row.poster_path,
                 backdrop_path: row.backdrop_path,

--- a/server/api/progress/[userId]/hydrated.get.ts
+++ b/server/api/progress/[userId]/hydrated.get.ts
@@ -1,4 +1,5 @@
 import { useDb } from '~/server/utils/db'
+import { pickTvDetails, hasTvSeasonBreakdown, type MinimalTv } from '~/server/utils/tvDetails'
 
 const TMDB_BASE = 'https://api.themoviedb.org/3'
 const CACHE_TTL_SECONDS = 7 * 24 * 60 * 60
@@ -6,10 +7,7 @@ const CACHE_TTL_SECONDS = 7 * 24 * 60 * 60
 type DetailKey = `${'movie' | 'tv'}:${number}`
 
 type MinimalMovie = { id: number; title: string; poster_path: string | null; runtime: number | null }
-type MinimalTv = { id: number; name: string; poster_path: string | null; total_episodes: number | null }
 type MinimalEpisode = { name: string; still_path: string | null; episode_number: number; season_number: number; runtime: number | null }
-
-const TV_CACHE_VERSION = 2
 
 function pickMovie(raw: any): MinimalMovie {
     return {
@@ -18,33 +16,6 @@ function pickMovie(raw: any): MinimalMovie {
         poster_path: raw?.poster_path || null,
         runtime: typeof raw?.runtime === 'number' ? raw.runtime : null,
     }
-}
-
-function pickTv(raw: any): MinimalTv {
-    // Sum episode counts for non-special seasons (season 0 = specials).
-    // Falls back to number_of_episodes if seasons[] is unavailable.
-    let total: number | null = null
-    if (Array.isArray(raw?.seasons)) {
-        let sum = 0
-        for (const s of raw.seasons) {
-            if (typeof s?.season_number === 'number' && s.season_number > 0 && typeof s?.episode_count === 'number') {
-                sum += s.episode_count
-            }
-        }
-        total = sum > 0 ? sum : (typeof raw?.number_of_episodes === 'number' ? raw.number_of_episodes : null)
-    } else if (typeof raw?.number_of_episodes === 'number') {
-        total = raw.number_of_episodes
-    }
-    return {
-        id: raw?.id,
-        name: raw?.name || '',
-        poster_path: raw?.poster_path || null,
-        total_episodes: total,
-    }
-}
-
-function isFreshTvCache(parsed: any): parsed is MinimalTv {
-    return parsed && typeof parsed === 'object' && 'total_episodes' in parsed
 }
 
 function pickEpisode(raw: any): MinimalEpisode {
@@ -154,7 +125,7 @@ export default defineEventHandler(async (event) => {
                 for (const row of res.rows as any[]) {
                     try {
                         const data = JSON.parse(row.data as string)
-                        if (!isFreshTvCache(data)) continue // older cache entries lack total_episodes; refetch
+                        if (!hasTvSeasonBreakdown(data)) continue
                         detailsMap.set(`tv:${Number(row.item_id)}` as DetailKey, data)
                     } catch { /* ignore corrupt cache row */ }
                 }
@@ -180,7 +151,7 @@ export default defineEventHandler(async (event) => {
             try {
                 const url = `${TMDB_BASE}/${type}/${id}?api_key=${apiKey}&language=${encodeURIComponent(apiLang)}`
                 const data: any = await $fetch(url, { timeout: 8000 })
-                const minimal = type === 'movie' ? pickMovie(data) : pickTv(data)
+                const minimal = type === 'movie' ? pickMovie(data) : pickTvDetails(data)
                 return { id, type, minimal }
             } catch (e: any) {
                 console.error(`[Progress Hydrated GET] TMDB fetch failed for ${type}/${id}:`, e?.message || e)

--- a/server/api/progress/[userId]/index.get.ts
+++ b/server/api/progress/[userId]/index.get.ts
@@ -7,16 +7,47 @@ export default defineEventHandler(async (event) => {
         throw createError({ statusCode: 400, statusMessage: 'Missing user ID' })
     }
 
+    const query = getQuery(event)
+    const tvId = query.tv_id != null && query.tv_id !== '' ? Number(query.tv_id) : null
+    const countOnly = query.count === '1' || query.count === 'true'
+
+    if (tvId != null && !Number.isFinite(tvId)) {
+        throw createError({ statusCode: 400, statusMessage: 'Invalid tv_id' })
+    }
+
     const db = useDb()
 
     try {
-        const result = await db.execute({
-            sql: `SELECT media_id, media_type, progress_percentage, elapsed_minutes, total_duration_minutes, tv_id, season_number, episode_number, updated_at
-                  FROM user_progress_tracking
-                  WHERE user_id = ?
-                  ORDER BY updated_at DESC`,
-            args: [userId]
-        })
+        if (countOnly) {
+            const result = await db.execute({
+                sql: `SELECT COUNT(DISTINCT CASE
+                            WHEN media_type = 'episode' THEN 'tv_' || tv_id
+                            ELSE 'movie_' || media_id
+                        END) AS tracked_titles
+                      FROM user_progress_tracking
+                      WHERE user_id = ?`,
+                args: [userId]
+            })
+            return { count: Number((result.rows[0] as any)?.tracked_titles) || 0 }
+        }
+
+        const columns = `media_id, media_type, progress_percentage, elapsed_minutes, total_duration_minutes, tv_id, season_number, episode_number, updated_at`
+
+        const result = tvId != null
+            ? await db.execute({
+                sql: `SELECT ${columns}
+                      FROM user_progress_tracking
+                      WHERE user_id = ? AND media_type = 'episode' AND tv_id = ?
+                      ORDER BY updated_at DESC`,
+                args: [userId, tvId]
+            })
+            : await db.execute({
+                sql: `SELECT ${columns}
+                      FROM user_progress_tracking
+                      WHERE user_id = ?
+                      ORDER BY updated_at DESC`,
+                args: [userId]
+            })
 
         return result.rows
     } catch (error: any) {

--- a/server/utils/tvDetails.ts
+++ b/server/utils/tvDetails.ts
@@ -1,0 +1,136 @@
+import type { Client } from '@libsql/client'
+
+const TMDB_BASE = 'https://api.themoviedb.org/3'
+const CACHE_TTL_SECONDS = 7 * 24 * 60 * 60
+const TMDB_TIMEOUT_MS = 6000
+
+export type TvSeasonSummary = {
+    season_number: number
+    episode_count: number
+}
+
+export type TvLastAired = {
+    season_number: number
+    episode_number: number
+}
+
+export type MinimalTv = {
+    id: number
+    name: string
+    poster_path: string | null
+    total_episodes: number | null
+    number_of_seasons: number | null
+    seasons: TvSeasonSummary[]
+    last_episode_to_air: TvLastAired | null
+}
+
+export function pickTvDetails(raw: any): MinimalTv {
+    const seasons: TvSeasonSummary[] = Array.isArray(raw?.seasons)
+        ? raw.seasons
+            .filter((s: any) => typeof s?.season_number === 'number' && typeof s?.episode_count === 'number')
+            .map((s: any) => ({ season_number: s.season_number, episode_count: s.episode_count }))
+        : []
+
+    const nonSpecialSum = seasons.reduce(
+        (acc, s) => (s.season_number > 0 ? acc + s.episode_count : acc),
+        0,
+    )
+
+    const total = nonSpecialSum > 0
+        ? nonSpecialSum
+        : (typeof raw?.number_of_episodes === 'number' ? raw.number_of_episodes : null)
+
+    const last = raw?.last_episode_to_air
+    const lastAired: TvLastAired | null =
+        last && typeof last.season_number === 'number' && typeof last.episode_number === 'number'
+            ? { season_number: last.season_number, episode_number: last.episode_number }
+            : null
+
+    return {
+        id: raw?.id,
+        name: raw?.name || '',
+        poster_path: raw?.poster_path || null,
+        total_episodes: total,
+        number_of_seasons: typeof raw?.number_of_seasons === 'number' ? raw.number_of_seasons : null,
+        seasons,
+        last_episode_to_air: lastAired,
+    }
+}
+
+export function hasTvSeasonBreakdown(parsed: any): parsed is MinimalTv {
+    return !!parsed
+        && typeof parsed === 'object'
+        && 'total_episodes' in parsed
+        && Array.isArray(parsed.seasons)
+}
+
+export async function loadTvDetailsCached(
+    db: Client,
+    tvIds: Array<number | string>,
+    apiKey: string,
+    apiLang: string,
+): Promise<Map<number, MinimalTv>> {
+    const resolved = new Map<number, MinimalTv>()
+
+    const ids = Array.from(new Set(
+        tvIds.map((id) => Number(id)).filter((id) => Number.isFinite(id) && id > 0),
+    ))
+    if (!ids.length || !apiKey) return resolved
+
+    const nowSec = Math.floor(Date.now() / 1000)
+    const placeholders = ids.map(() => '?').join(',')
+
+    try {
+        const cached = await db.execute({
+            sql: `SELECT item_id, data FROM tmdb_cache
+                  WHERE item_type = 'tv' AND data_type = 'details'
+                    AND cached_at >= ? AND item_id IN (${placeholders})`,
+            args: [nowSec - CACHE_TTL_SECONDS, ...ids],
+        })
+        for (const row of cached.rows as any[]) {
+            try {
+                const parsed = JSON.parse(row.data as string)
+                if (hasTvSeasonBreakdown(parsed)) resolved.set(Number(row.item_id), parsed)
+            } catch { }
+        }
+    } catch (e: any) {
+        console.error('[TV details] cache lookup failed:', e?.message || e)
+    }
+
+    const missing = ids.filter((id) => !resolved.has(id))
+    if (!missing.length) return resolved
+
+    const fetched = await Promise.all(missing.map(async (id) => {
+        try {
+            const url = `${TMDB_BASE}/tv/${id}?api_key=${apiKey}&language=${encodeURIComponent(apiLang)}`
+            const data: any = await $fetch(url, { timeout: TMDB_TIMEOUT_MS })
+            return { id, minimal: pickTvDetails(data) }
+        } catch (e: any) {
+            console.error(`[TV details] TMDB fetch failed for tv/${id}:`, e?.message || e)
+            return null
+        }
+    }))
+
+    const writeOps: { sql: string; args: any[] }[] = []
+    for (const entry of fetched) {
+        if (!entry) continue
+        resolved.set(entry.id, entry.minimal)
+        writeOps.push({
+            sql: `INSERT INTO tmdb_cache (item_id, item_type, data_type, data, cached_at)
+                  VALUES (?, 'tv', 'details', ?, ?)
+                  ON CONFLICT(item_id, item_type, data_type)
+                  DO UPDATE SET data = excluded.data, cached_at = excluded.cached_at`,
+            args: [entry.id, JSON.stringify(entry.minimal), nowSec],
+        })
+    }
+
+    if (writeOps.length) {
+        try {
+            await db.batch(writeOps, 'write')
+        } catch (e: any) {
+            console.error('[TV details] cache write failed:', e?.message || e)
+        }
+    }
+
+    return resolved
+}


### PR DESCRIPTION
## Summary

- The tracking pill in the homepage hero rendered `1 of ? episodes tracked (S6)` for any tracked series in the carousel, and did nothing when clicked. Both symptoms came from the same gap: the hero payload carries no season data, and the pill's click emitted an event only the detail view listens for.
- Season context now resolves server-side through the shared TMDB detail cache, so the label renders real totals during SSR and the detail view runs the exact same code path.
- Counting one series' episodes no longer downloads the viewer's entire progress history.

Closes #483.

## Where the `?` came from

`trackingInfoText` falls back to `'?'` when the per-season total is unknown. That total is read from `heroItem.seasons[].episode_count`, and the homepage hero is built from a table that has no season or episode columns — so on that surface the lookup could never succeed. On a detail view the item comes from the full upstream payload, which includes `seasons[]`, which is why the same pill worked there.

The knock-on effect was larger than the placeholder: `allComplete` is derived as `complete === total && total > 0`, so with `total` null it was permanently false. `Season N completed` and `N seasons completed` were unreachable on the homepage even for a season the viewer had finished.

`server/utils/tvDetails.ts` now owns one canonical minimal TV shape — season breakdown, `last_episode_to_air`, non-special episode total — read from `tmdb_cache` with a 7-day TTL and refetched only on a miss. `/api/hero` resolves it for TV rows in parallel with the festival badges, non-fatal on both sides. The hydrated progress endpoint moved onto the same shape so the two can't invalidate each other's cache entries; the fields it consumes are byte-identical to what it produced before, verified across eight series.

Cost: ~671 bytes added per TV row (three rows in the current carousel), against ~213 KB of progress downloads removed.

## Unscoped progress reads

`loadProgress()` counted one show's episodes by fetching the viewer's whole history and filtering client-side, with a cache-buster that guaranteed it was never reused — once per series per carousel rotation. The list endpoint now takes `?tv_id=` and `?count=`, and the hero, the episodes view and the user nav read through them. Unparameterised calls still return the same array.

Measured on a live account: 355 rows / 72,614 B → 205 B for the reported series, and 17 KB in the worst case (an 86-episode show), instead of the full history growing without bound.

## Completion versus caught up

Declaring a season complete against `episode_count` is wrong in both directions — it includes unaired episodes. The pill now separates the two: the denominator is what has aired, while completion is measured against the full declared count, with a distinct state in between.

```
1 of 10 episodes tracked (S6)          season fully aired, one watched
Season 6 completed                     season fully aired, all watched
Caught up on Season 3                  5 of 10 aired, all 5 watched
3 of 5 episodes tracked (S3)           5 of 10 aired, 3 watched
12 episodes tracked (S1: 2, S2: 2, S3: 2 +3 more)
1 episode tracked (S6)                 no season metadata, degraded
```

Specials no longer count toward the totals, and the multi-season label caps its segments instead of overflowing the pill.

## Landing on the right tab and season

Two further defects surfaced during review.

The tab strip resolves its highlight by matching the active label against the menu, but the menu is built after the soundtrack and awards lookups resolve. A tab selected on mount was matched against an empty array and silently dropped — the episodes list rendered while the strip still underlined Overview. The strip now re-resolves when the menu arrives, which fixes any programmatic tab selection, not just this one.

The episodes view also defaulted to the newest season, which for a long-running series is often one that has not aired — clicking a pill that reads `(S6)` landed on a wall of unreleased placeholders. The pill now carries the season the viewer last watched, taken from the most recent progress row, and the episodes view opens there. Out-of-range or missing values fall back to the newest season.

## Test plan

- [x] Production build passes; the built hero chunk contains the resolved season context
- [x] SFC compile check on every touched component
- [x] `trackingInfoText` and `seasonEpisodeCounts` exercised from source against live upstream metadata across twelve states — reported bug, fully watched, airing/caught up, airing/behind, unaired, multi-season, label cap, degraded fallback, movie branch
- [x] Shared TV shape diffed against the previous implementation for eight series: `id`, `name`, `poster_path` and `total_episodes` identical, so the hydrated endpoint is unaffected
- [x] Scoped and count queries verified against live data, including query plans; payload reduction measured
- [x] Tab-strip highlight verified under the failing ordering (label set before the menu exists) and four other orderings
- [x] Initial-season resolution verified for in-range, out-of-range, zero, missing and non-numeric values
- [x] Confirmed live: pill reads `1 of 10 episodes tracked (S6)`, click opens the episodes tab with the strip highlighted, and a second tracked season redirects to the most recently watched one

One behaviour change worth noting: the progress counter in the user nav is now computed server-side and drops by one, because the previous client-side tally counted a malformed row — an episode entry with no series id, no season and no episode — as if it were a tracked title.
